### PR TITLE
feat(authority): add reusable transaction controls

### DIFF
--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -2130,6 +2130,18 @@
   margin: 1.5rem 0 0;
 }
 
+.dollar-profile-choice {
+  margin: 0 0 1.5rem;
+}
+
+.dollar-profile-choice.has-pegged {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dollar-pegged-panel {
+  padding: 0;
+}
+
 .dollar-asset-choice legend {
   position: absolute;
   transform: translateY(-1.45rem);

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -2618,6 +2618,91 @@
   margin-top: 1rem;
 }
 
+.position-collateral-summary {
+  margin-top: 10px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid var(--app-border);
+  background: var(--app-surface);
+  border-radius: var(--radius-lg);
+}
+
+.position-collateral-summary.is-compact {
+  padding: 1rem;
+}
+
+.position-collateral-summary > div > p:last-child,
+.position-collateral-empty {
+  margin: 0.45rem 0 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.position-collateral-summary ul {
+  display: grid;
+  gap: 10px;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.position-collateral-summary li {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+}
+
+.position-collateral-summary li > div:first-child {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.position-collateral-summary li a {
+  color: var(--accent);
+  font-size: var(--text-caption);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.position-collateral-summary li strong {
+  color: var(--app-text);
+  font-size: var(--text-base);
+  font-weight: 500;
+}
+
+.position-collateral-summary dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 1rem 0 0;
+  border: 1px solid var(--app-border);
+  background: var(--app-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.position-collateral-summary dl > div {
+  min-width: 0;
+  padding: 0.75rem;
+  background: var(--app-surface);
+}
+
+.position-collateral-summary dt {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.position-collateral-summary dd {
+  margin: 0.4rem 0 0;
+  font-size: var(--text-sm);
+  overflow-wrap: anywhere;
+}
+
 .position-card dl,
 .position-hero dl,
 .position-metrics {
@@ -4489,6 +4574,7 @@
 
   .position-card dl,
   .position-hero dl,
+  .position-collateral-summary dl,
   .position-metrics,
   .reward-grid,
   .reward-selector {

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -896,6 +896,173 @@
   color: var(--negative) !important;
 }
 
+.approval-tools {
+  display: grid;
+  gap: 1rem;
+  margin-top: 10px;
+}
+
+.approval-tools-heading,
+.approval-tools-summary,
+.approval-tools-note,
+.approval-tools-row {
+  border: 1px solid var(--app-border);
+  background: var(--app-surface);
+  border-radius: var(--radius-lg);
+}
+
+.approval-tools-heading {
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.approval-tools-heading h2 {
+  margin: 0.8rem 0;
+  font-size: var(--text-2xl);
+  font-weight: 500;
+}
+
+.approval-tools-heading > p:last-child,
+.approval-tools-note {
+  color: var(--app-text-muted);
+  font-size: var(--text-base);
+  line-height: 1.7;
+}
+
+.approval-tools-summary {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(140px, 1fr) auto;
+  gap: 1px;
+  overflow: hidden;
+  background: var(--app-border);
+}
+
+.approval-tools-summary > div {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem;
+  background: var(--app-surface);
+}
+
+.approval-tools-summary span,
+.approval-tools-token > span,
+.approval-tools-spender > span {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.approval-tools-summary strong {
+  font-size: var(--text-xl);
+  font-weight: 500;
+}
+
+.approval-tools-summary > button,
+.approval-tools-state button {
+  min-height: var(--control-height-sm);
+  padding: 0 1rem;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-raised);
+  color: var(--app-text);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.approval-tools-summary > button:hover:not(:disabled),
+.approval-tools-state button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.approval-tools-summary > button:disabled,
+.approval-tools-state button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.approval-tools-summary > button {
+  min-width: 220px;
+  border-color: var(--negative);
+  background: var(--negative-wash);
+  color: var(--negative);
+  border-radius: 0;
+}
+
+.approval-tools-note {
+  margin: 0;
+  padding: 1rem;
+}
+
+.approval-tools-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.approval-tools-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.65fr) minmax(250px, 1.35fr) minmax(180px, auto);
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+}
+
+.approval-tools-token,
+.approval-tools-spender,
+.approval-tools-state {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.approval-tools-token strong {
+  font-size: var(--text-lg);
+  font-weight: 500;
+}
+
+.approval-tools-token small,
+.approval-tools-spender small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  line-height: 1.5;
+}
+
+.approval-tools-state {
+  justify-items: end;
+}
+
+.approval-tools-state > div {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.approval-tools-state .is-revoke {
+  border-color: var(--negative);
+  color: var(--negative);
+}
+
+.approval-status {
+  padding: 0.3rem 0.55rem;
+  border: 1px solid var(--app-border-strong);
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: var(--radius-md);
+}
+
+.approval-status.is-maximum {
+  border-color: var(--positive);
+  color: var(--positive);
+}
+
+.approval-status.is-custom {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
 .wallet-surface,
 .portal-workspace {
   margin-top: 10px;
@@ -4669,6 +4836,15 @@
   .fee-allocation dl {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .approval-tools-row {
+    grid-template-columns: minmax(140px, 0.7fr) minmax(220px, 1.3fr);
+  }
+
+  .approval-tools-state {
+    grid-column: 1 / -1;
+    justify-items: start;
+  }
 }
 
 @media (max-width: 560px) {
@@ -4733,5 +4909,27 @@
 
   .claim-selector label > small {
     grid-column: 2;
+  }
+
+  .approval-tools-summary,
+  .approval-tools-row {
+    grid-template-columns: 1fr;
+  }
+
+  .approval-tools-summary > button {
+    min-height: 52px;
+  }
+
+  .approval-tools-state {
+    grid-column: auto;
+  }
+
+  .approval-tools-state > div {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .approval-tools-state button {
+    width: 100%;
   }
 }

--- a/app/(dapp)/app/tools/page.tsx
+++ b/app/(dapp)/app/tools/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { ApprovalToolsPage } from "@/components/tools/ApprovalToolsPage";
+
+export const metadata: Metadata = {
+  title: "Approval Tools | Statics Protocol",
+  description: "Review, enable, and revoke Statics application approvals.",
+};
+
+export default function ToolsPage() {
+  return <ApprovalToolsPage />;
+}

--- a/components/baskets/BasketDetailPage.tsx
+++ b/components/baskets/BasketDetailPage.tsx
@@ -48,6 +48,7 @@ import {
 import { readClientDollarDeployment, verifyDollarDeployment } from "@/lib/dollar/deployment";
 import { loadPositionCatalog } from "@/lib/positions/positions";
 import { isOnchainRevert, isWalletRejection } from "@/lib/dollar/transactions";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 const deploymentState = readClientDollarDeployment();
@@ -298,7 +299,6 @@ function BasketDetailRuntime({ basketId }: { basketId: bigint }) {
         const quoted = currentQuote.amounts[availability.approvalIndex];
         if (!constituent || quoted === undefined)
           throw new Error("The approval quote is incomplete.");
-        const maximum = maximumWithSlippage(quoted, slippageBps);
         await recordAndSend({
           kind: "approve-basket-asset",
           label: `Approve ${constituent.token.symbol}`,
@@ -306,7 +306,7 @@ function BasketDetailRuntime({ basketId }: { basketId: bigint }) {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [deploymentState.deployment.contracts.diamond, maximum],
+            args: [deploymentState.deployment.contracts.diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
       } else if (availability.kind === "execute") {
@@ -336,7 +336,7 @@ function BasketDetailRuntime({ basketId }: { basketId: bigint }) {
                 constituent.allowance < (bounds[index] ?? 0n)
             )
           ) {
-            throw new Error("The fresh quote requires another bounded underlying approval.");
+            throw new Error("The fresh quote requires another underlying approval.");
           }
         }
         // A minted basket held in the wallet earns nothing: rewards accrue

--- a/components/baskets/BasketSwapPanel.tsx
+++ b/components/baskets/BasketSwapPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useSignTypedData } from "@privy-io/react-auth";
 import { useMemo, useState } from "react";
 import {
   decodeFunctionResult,
@@ -15,7 +14,6 @@ import { usePublicClient, useWalletClient } from "wagmi";
 import {
   CanonicalPoolStatus,
   basketTokenAbi,
-  buildPermit2PermitTypedData,
   buildQuoteV4ExactInputSingleCall,
   buildV4ExactInputSingleSwap,
   permit2AllowanceAbi,
@@ -26,9 +24,6 @@ import {
 import {
   canonicalSwapPoolKey,
   isCurrentCanonicalSwapQuote,
-  permit2SwapApproval,
-  privyPermit2Request,
-  signPermit2ForWallet,
   SWAP_PERMIT_TTL_SECONDS,
   zeroForExactInput,
 } from "@/lib/baskets/swap";
@@ -45,6 +40,12 @@ import {
   verifyLiquidityDeployment,
 } from "@/lib/dollar/deployment";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import {
+  MAX_ERC20_ALLOWANCE,
+  MAX_PERMIT2_ALLOWANCE,
+  MAX_PERMIT2_EXPIRATION,
+  hasUsablePermit2Allowance,
+} from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 const deploymentState = readClientDollarDeployment();
@@ -57,7 +58,6 @@ function display(value: bigint, decimals: number): string {
 
 export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
   const walletState = useWalletState();
-  const { signTypedData: signEmbeddedTypedData } = useSignTypedData();
   const publicClient = usePublicClient();
   const walletClient = useWalletClient();
   const wallet =
@@ -246,7 +246,7 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [liquidity.contracts.permit2, freshBalance],
+            args: [liquidity.contracts.permit2, MAX_ERC20_ALLOWANCE],
           }),
           sendTransaction: ({ to, data, value }) =>
             walletClient.data!.sendTransaction({
@@ -291,32 +291,50 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
         functionName: "allowance",
         args: [wallet, inputToken.address, router],
       });
-      const permitSingle = permit2SwapApproval(
-        inputToken.address,
-        amount,
-        allowance[2],
-        router,
-        deadline
-      );
-      const typedData = buildPermit2PermitTypedData(
-        deploymentState.deployment.chainId,
-        liquidity.contracts.permit2,
-        permitSingle
-      );
-      const signature = await signPermit2ForWallet({
-        walletKind: walletState.walletKind,
-        typedData,
-        signEmbedded: async (permit) => {
-          const request = privyPermit2Request(permit, wallet);
-          const signed = await signEmbeddedTypedData(request.typedData, request.options);
-          return signed.signature as `0x${string}`;
-        },
-        signExternal: (permit) =>
-          walletClient.data!.signTypedData({
-            account: wallet,
-            ...permit,
+      if (!hasUsablePermit2Allowance(allowance[0], allowance[1], amount, Number(block.timestamp))) {
+        await executeProtocolTransaction({
+          publicClient,
+          wallet,
+          chainId: deploymentState.deployment.chainId,
+          kind: "approve-permit2",
+          label: `Authorize ${inputToken.symbol} swaps`,
+          amount: `Maximum ${inputToken.symbol}`,
+          to: liquidity.contracts.permit2,
+          data: encodeFunctionData({
+            abi: permit2AllowanceAbi,
+            functionName: "approve",
+            args: [inputToken.address, router, MAX_PERMIT2_ALLOWANCE, MAX_PERMIT2_EXPIRATION],
           }),
-      });
+          sendTransaction: ({ to, data, value }) =>
+            walletClient.data!.sendTransaction({
+              account: wallet,
+              chain: walletClient.data!.chain,
+              to,
+              data,
+              value,
+            }),
+          describeError: describeBasketError,
+          verifyConfirmation: async () => {
+            const confirmed = await publicClient.readContract({
+              address: liquidity.contracts.permit2,
+              abi: permit2AllowanceAbi,
+              functionName: "allowance",
+              args: [wallet, inputToken.address, router],
+            });
+            if (
+              !hasUsablePermit2Allowance(
+                confirmed[0],
+                confirmed[1],
+                amount,
+                Number(block.timestamp)
+              )
+            ) {
+              throw new Error("The confirmed Permit2 swap authorization is not usable.");
+            }
+          },
+        });
+        return;
+      }
       const execution = buildV4ExactInputSingleSwap({
         router,
         poolKey: currentQuote.poolKey,
@@ -324,7 +342,6 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
         amountIn: amount,
         amountOutMinimum: minimumOut,
         deadline,
-        permit: { permitSingle, signature },
       });
       const outputBefore = await publicClient.readContract({
         address: outputToken.address,

--- a/components/baskets/BasketSwapPanel.tsx
+++ b/components/baskets/BasketSwapPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useSignTypedData } from "@privy-io/react-auth";
 import { useMemo, useState } from "react";
 import {
   decodeFunctionResult,
@@ -26,6 +27,8 @@ import {
   canonicalSwapPoolKey,
   isCurrentCanonicalSwapQuote,
   permit2SwapApproval,
+  privyPermit2Request,
+  signPermit2ForWallet,
   SWAP_PERMIT_TTL_SECONDS,
   zeroForExactInput,
 } from "@/lib/baskets/swap";
@@ -54,6 +57,7 @@ function display(value: bigint, decimals: number): string {
 
 export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
   const walletState = useWalletState();
+  const { signTypedData: signEmbeddedTypedData } = useSignTypedData();
   const publicClient = usePublicClient();
   const walletClient = useWalletClient();
   const wallet =
@@ -294,13 +298,24 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
         router,
         deadline
       );
-      const signature = await walletClient.data.signTypedData({
-        account: wallet,
-        ...buildPermit2PermitTypedData(
-          deploymentState.deployment.chainId,
-          liquidity.contracts.permit2,
-          permitSingle
-        ),
+      const typedData = buildPermit2PermitTypedData(
+        deploymentState.deployment.chainId,
+        liquidity.contracts.permit2,
+        permitSingle
+      );
+      const signature = await signPermit2ForWallet({
+        walletKind: walletState.walletKind,
+        typedData,
+        signEmbedded: async (permit) => {
+          const request = privyPermit2Request(permit, wallet);
+          const signed = await signEmbeddedTypedData(request.typedData, request.options);
+          return signed.signature as `0x${string}`;
+        },
+        signExternal: (permit) =>
+          walletClient.data!.signTypedData({
+            account: wallet,
+            ...permit,
+          }),
       });
       const execution = buildV4ExactInputSingleSwap({
         router,

--- a/components/dollar/DollarPage.tsx
+++ b/components/dollar/DollarPage.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   buildDepositETHTransaction,
@@ -76,6 +77,7 @@ import { loadLoanCatalog } from "@/lib/loans/loans";
 import { loadBasketRewardSummary, totalRewardsByAsset } from "@/lib/baskets/rewards";
 import { readEvesMarketUrl } from "@/lib/site-config";
 import { overviewTiles } from "@/lib/overview";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { PeggedDollarPanel } from "@/components/portal/PeggedDollarPanel";
 
 const deploymentState = readClientDollarDeployment();
@@ -92,6 +94,18 @@ const modeLabels: Record<DollarActionMode, string> = {
 const isSupplyMode = (mode: DollarActionMode): mode is "supply" | "unsupply" =>
   mode === "supply" || mode === "unsupply";
 type DollarProfileChoice = DollarCollateralChoice | "USDG";
+
+export function DollarProfileContent({
+  profile,
+  volatile,
+  pegged,
+}: {
+  profile: DollarProfileChoice;
+  volatile: ReactNode;
+  pegged: ReactNode;
+}) {
+  return profile === "USDG" ? pegged : volatile;
+}
 
 export function DollarProfilePills({
   value,
@@ -769,23 +783,23 @@ function DollarActionPanel({
       } else if (actionAvailability.kind === "approve-weth") {
         await recordAndSend({
           kind: "approve-weth",
-          label: "Approve exact WETH",
+          label: "Enable WETH deposits",
           to: deployment.contracts.weth,
           data: encodeFunctionData({
             abi: wethAbi,
             functionName: "approve",
-            args: [deployment.contracts.gateway, amount],
+            args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
           }),
         });
       } else if (actionAvailability.kind === "approve-dollar") {
         await recordAndSend({
           kind: "approve-dollar",
-          label: "Approve exact Dollar",
+          label: "Enable Dollar recombination",
           to: deployment.contracts.dollar,
           data: encodeFunctionData({
             abi: staticsDollarTokenAbi,
             functionName: "approve",
-            args: [deployment.contracts.gateway, amount],
+            args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
           }),
         });
       } else if (actionAvailability.kind === "approve-dollar-periphery") {
@@ -794,12 +808,12 @@ function DollarActionPanel({
         }
         await recordAndSend({
           kind: "approve-dollar",
-          label: "Approve exact Dollar",
+          label: "Enable Dollar redemptions",
           to: deployment.contracts.dollar,
           data: encodeFunctionData({
             abi: staticsDollarTokenAbi,
             functionName: "approve",
-            args: [snapshot.data.periphery, amount],
+            args: [snapshot.data.periphery, MAX_ERC20_ALLOWANCE],
           }),
         });
       } else if (actionAvailability.kind === "execute" && currentQuote?.mode === "redeem") {
@@ -1103,67 +1117,76 @@ function DollarActionPanel({
               setAsset(choice);
             }}
           />
-          {peggedSelected && <PeggedDollarPanel embedded onPendingChange={setPeggedPending} />}
-          <div className="dollar-tabs" aria-label="Dollar action" hidden={peggedSelected}>
-            {(["deposit", "recombine", "redeem", "supply", "unsupply"] as const).map((choice) => (
-              <button
-                key={choice}
-                type="button"
-                className={mode === choice ? "active" : undefined}
-                onClick={() => {
-                  setMode(choice);
-                  setActionError(null);
-                }}
-                disabled={anyPending}
-              >
-                {modeLabels[choice]}
-              </button>
-            ))}
-          </div>
-          <div className="dollar-field" hidden={peggedSelected}>
-            <label htmlFor="dollar-amount">{amountUnit} amount</label>
-            <div>
-              <input
-                id="dollar-amount"
-                value={amountInput}
-                onChange={(event) => {
-                  setAmountInput(event.target.value);
-                  setActionError(null);
-                }}
-                inputMode="decimal"
-                placeholder="0.00"
-                disabled={anyPending}
-              />
-              <button
-                type="button"
-                onClick={() => {
-                  setAmountInput(formatUnits(balance, 18));
-                  setActionError(null);
-                }}
-                disabled={anyPending || (mode === "deposit" && asset === "ETH")}
-              >
-                {mode === "deposit" && asset === "ETH" ? "Keep gas" : "Max"}
-              </button>
-            </div>
-            <small>
-              Available {displayAmount(balance)} {amountUnit}
-              {mode === "redeem" &&
-                ` · ${displayAmount(state.redeemableLiquidity)} Dollar redeemable right now`}
-              {isSupplyMode(mode) &&
-                ` · ${displayAmount(supply.effectiveShares)} currently supplied`}
-            </small>
-          </div>
-          <div className="dollar-quote" hidden={peggedSelected}>
-            <span>{isSupplyMode(mode) ? "Your Risk shares" : previewLabel}</span>
-            <strong>{supplyOutput ?? output}</strong>
-            {preview && (
-              <small>
-                {quoteState === "ready"
-                  ? "Current input verified. Bounds include 0.50% execution tolerance."
-                  : "Refreshing for the current input; submission remains disabled."}
-              </small>
-            )}
-          </div>
+          <DollarProfileContent
+            profile={peggedSelected ? "USDG" : asset}
+            pegged={<PeggedDollarPanel embedded onPendingChange={setPeggedPending} />}
+            volatile={
+              <>
+                <div className="dollar-tabs" aria-label="Dollar action">
+                  {(["deposit", "recombine", "redeem", "supply", "unsupply"] as const).map(
+                    (choice) => (
+                      <button
+                        key={choice}
+                        type="button"
+                        className={mode === choice ? "active" : undefined}
+                        onClick={() => {
+                          setMode(choice);
+                          setActionError(null);
+                        }}
+                        disabled={anyPending}
+                      >
+                        {modeLabels[choice]}
+                      </button>
+                    )
+                  )}
+                </div>
+                <div className="dollar-field">
+                  <label htmlFor="dollar-amount">{amountUnit} amount</label>
+                  <div>
+                    <input
+                      id="dollar-amount"
+                      value={amountInput}
+                      onChange={(event) => {
+                        setAmountInput(event.target.value);
+                        setActionError(null);
+                      }}
+                      inputMode="decimal"
+                      placeholder="0.00"
+                      disabled={anyPending}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setAmountInput(formatUnits(balance, 18));
+                        setActionError(null);
+                      }}
+                      disabled={anyPending || (mode === "deposit" && asset === "ETH")}
+                    >
+                      {mode === "deposit" && asset === "ETH" ? "Keep gas" : "Max"}
+                    </button>
+                  </div>
+                  <small>
+                    Available {displayAmount(balance)} {amountUnit}
+                    {mode === "redeem" &&
+                      ` · ${displayAmount(state.redeemableLiquidity)} Dollar redeemable right now`}
+                    {isSupplyMode(mode) &&
+                      ` · ${displayAmount(supply.effectiveShares)} currently supplied`}
+                  </small>
+                </div>
+                <div className="dollar-quote">
+                  <span>{isSupplyMode(mode) ? "Your Risk shares" : previewLabel}</span>
+                  <strong>{supplyOutput ?? output}</strong>
+                  {preview && (
+                    <small>
+                      {quoteState === "ready"
+                        ? "Current input verified. Bounds include 0.50% execution tolerance."
+                        : "Refreshing for the current input; submission remains disabled."}
+                    </small>
+                  )}
+                </div>
+              </>
+            }
+          />
           {!peggedSelected && redeemShortfall !== null && (
             <p className="dollar-warning" role="status">
               Only {displayAmount(redeemShortfall)} of the {displayAmount(quote.data!.amount)}{" "}
@@ -1229,15 +1252,16 @@ function DollarActionPanel({
               {actionError}
             </p>
           )}
-          <button
-            className="dollar-submit"
-            type="button"
-            onClick={() => void executeNextAction()}
-            disabled={anyPending || !actionAvailability.executable}
-            hidden={peggedSelected}
-          >
-            {pendingAction === "primary" ? "Waiting for confirmation…" : actionAvailability.label}
-          </button>
+          {!peggedSelected && (
+            <button
+              className="dollar-submit"
+              type="button"
+              onClick={() => void executeNextAction()}
+              disabled={anyPending || !actionAvailability.executable}
+            >
+              {pendingAction === "primary" ? "Waiting for confirmation…" : actionAvailability.label}
+            </button>
+          )}
         </div>
 
         {peggedSelected && (
@@ -1273,79 +1297,81 @@ function DollarActionPanel({
             </p>
           </aside>
         )}
-        <aside className="dollar-protocol-card" hidden={peggedSelected}>
-          <p className="dapp-section-label" aria-live="polite">
-            WETH profile{snapshot.isFetching ? " · refreshing" : ""}
-          </p>
-          <dl>
-            <div>
-              <dt>Health</dt>
-              <dd>
-                {!state.solvency.oracleAvailable
-                  ? "Oracle unavailable"
-                  : state.solvency.healthy
-                    ? "Healthy"
-                    : "Impaired"}
-              </dd>
-            </div>
-            <div>
-              <dt>Price feed</dt>
-              <dd>${displayAmount(state.priceWad)}</dd>
-            </div>
-            <div>
-              <dt>Collateral ratio</dt>
-              <dd>{Number(state.profile.collateralRatioBps) / 100}%</dd>
-            </div>
-            <div>
-              <dt>Debt</dt>
-              <dd>{displayAmount(state.profile.seniorOutstanding)} Dollar</dd>
-            </div>
-            <div>
-              <dt>Borrow limit</dt>
-              <dd>{displayAmount(state.profile.debtCeiling)} Dollar</dd>
-            </div>
-            <div>
-              <dt>Profile mode</dt>
-              <dd>{profileModeLabel(state.profile.mode)}</dd>
-            </div>
-            <div>
-              <dt>Series state</dt>
-              <dd>{seriesStatusLabel(state.series.status)}</dd>
-            </div>
-            <div>
-              <dt>Paused mask</dt>
-              <dd>{state.pausedOperations.toString()}</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>{globalHealthLabel(state.globalHealth[0])}</dd>
-            </div>
-            <div>
-              <dt>Gateway</dt>
-              <dd title={deployment.contracts.gateway}>
-                {shortAddress(deployment.contracts.gateway)}
-              </dd>
-            </div>
-          </dl>
-          {state.riskApproved && (
-            <button type="button" onClick={() => void revokeRisk()} disabled={anyPending}>
-              {pendingAction === "revoke" ? "Revoking…" : "Revoke Risk operator"}
-            </button>
-          )}
-          <p>
-            Receiver is fixed to {shortAddress(wallet)}. Quotes are refreshed and simulated before
-            the wallet receives a signing request.
-          </p>
-          {evesMarketUrl ? (
-            <a href={evesMarketUrl} target="_blank" rel="noreferrer">
-              Continue to Eves Market ↗
-            </a>
-          ) : (
-            <span className="dollar-disabled-link" aria-disabled="true">
-              Eves Market link unavailable
-            </span>
-          )}
-        </aside>
+        {!peggedSelected && (
+          <aside className="dollar-protocol-card">
+            <p className="dapp-section-label" aria-live="polite">
+              WETH profile{snapshot.isFetching ? " · refreshing" : ""}
+            </p>
+            <dl>
+              <div>
+                <dt>Health</dt>
+                <dd>
+                  {!state.solvency.oracleAvailable
+                    ? "Oracle unavailable"
+                    : state.solvency.healthy
+                      ? "Healthy"
+                      : "Impaired"}
+                </dd>
+              </div>
+              <div>
+                <dt>Price feed</dt>
+                <dd>${displayAmount(state.priceWad)}</dd>
+              </div>
+              <div>
+                <dt>Collateral ratio</dt>
+                <dd>{Number(state.profile.collateralRatioBps) / 100}%</dd>
+              </div>
+              <div>
+                <dt>Debt</dt>
+                <dd>{displayAmount(state.profile.seniorOutstanding)} Dollar</dd>
+              </div>
+              <div>
+                <dt>Borrow limit</dt>
+                <dd>{displayAmount(state.profile.debtCeiling)} Dollar</dd>
+              </div>
+              <div>
+                <dt>Profile mode</dt>
+                <dd>{profileModeLabel(state.profile.mode)}</dd>
+              </div>
+              <div>
+                <dt>Series state</dt>
+                <dd>{seriesStatusLabel(state.series.status)}</dd>
+              </div>
+              <div>
+                <dt>Paused mask</dt>
+                <dd>{state.pausedOperations.toString()}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{globalHealthLabel(state.globalHealth[0])}</dd>
+              </div>
+              <div>
+                <dt>Gateway</dt>
+                <dd title={deployment.contracts.gateway}>
+                  {shortAddress(deployment.contracts.gateway)}
+                </dd>
+              </div>
+            </dl>
+            {state.riskApproved && (
+              <button type="button" onClick={() => void revokeRisk()} disabled={anyPending}>
+                {pendingAction === "revoke" ? "Revoking…" : "Revoke Risk operator"}
+              </button>
+            )}
+            <p>
+              Receiver is fixed to {shortAddress(wallet)}. Quotes are refreshed and simulated before
+              the wallet receives a signing request.
+            </p>
+            {evesMarketUrl ? (
+              <a href={evesMarketUrl} target="_blank" rel="noreferrer">
+                Continue to Eves Market ↗
+              </a>
+            ) : (
+              <span className="dollar-disabled-link" aria-disabled="true">
+                Eves Market link unavailable
+              </span>
+            )}
+          </aside>
+        )}
       </section>
     </>
   );

--- a/components/dollar/DollarPage.tsx
+++ b/components/dollar/DollarPage.tsx
@@ -76,6 +76,7 @@ import { loadLoanCatalog } from "@/lib/loans/loans";
 import { loadBasketRewardSummary, totalRewardsByAsset } from "@/lib/baskets/rewards";
 import { readEvesMarketUrl } from "@/lib/site-config";
 import { overviewTiles } from "@/lib/overview";
+import { PeggedDollarPanel } from "@/components/portal/PeggedDollarPanel";
 
 const deploymentState = readClientDollarDeployment();
 
@@ -90,6 +91,42 @@ const modeLabels: Record<DollarActionMode, string> = {
 /** Supply and withdraw move Risk shares; the other three move Dollar or ETH. */
 const isSupplyMode = (mode: DollarActionMode): mode is "supply" | "unsupply" =>
   mode === "supply" || mode === "unsupply";
+type DollarProfileChoice = DollarCollateralChoice | "USDG";
+
+export function DollarProfilePills({
+  value,
+  peggedAvailable,
+  disabled,
+  onChange,
+}: {
+  value: DollarProfileChoice;
+  peggedAvailable: boolean;
+  disabled: boolean;
+  onChange: (choice: DollarProfileChoice) => void;
+}) {
+  const choices: readonly DollarProfileChoice[] = peggedAvailable
+    ? ["ETH", "WETH", "USDG"]
+    : ["ETH", "WETH"];
+  return (
+    <fieldset
+      className={`dollar-asset-choice dollar-profile-choice${peggedAvailable ? " has-pegged" : ""}`}
+    >
+      <legend>Collateral profile</legend>
+      {choices.map((choice) => (
+        <button
+          key={choice}
+          type="button"
+          className={value === choice ? "active" : undefined}
+          aria-pressed={value === choice}
+          onClick={() => onChange(choice)}
+          disabled={disabled}
+        >
+          {choice}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
 const evesMarketUrl = readEvesMarketUrl(process.env.NEXT_PUBLIC_EVES_MARKET_URL);
 
 function shortAddress(address: Address): string {
@@ -478,6 +515,8 @@ function DollarActionPanel({
   const snapshot = useDollarSnapshot(deployment, wallet);
   const [mode, setMode] = useState<DollarActionMode>("deposit");
   const [asset, setAsset] = useState<DollarCollateralChoice>("ETH");
+  const [peggedSelected, setPeggedSelected] = useState(false);
+  const [peggedPending, setPeggedPending] = useState(false);
   const [amountInput, setAmountInput] = useState("");
   const [pendingAction, setPendingAction] = useState<"primary" | "revoke" | "claim" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -1024,7 +1063,7 @@ function DollarActionPanel({
             quote.data.mode === "deposit" ? asset : "Dollar"
           }`
         : "Onchain preview";
-  const anyPending = pendingAction !== null;
+  const anyPending = pendingAction !== null || peggedPending;
 
   return (
     <>
@@ -1049,7 +1088,23 @@ function DollarActionPanel({
 
       <section className="dollar-workspace">
         <div className="dollar-action-card">
-          <div className="dollar-tabs" aria-label="Dollar action">
+          <DollarProfilePills
+            value={peggedSelected ? "USDG" : asset}
+            peggedAvailable={Boolean(deployment.pegged)}
+            disabled={anyPending}
+            onChange={(choice) => {
+              setAmountInput("");
+              setActionError(null);
+              if (choice === "USDG") {
+                setPeggedSelected(true);
+                return;
+              }
+              setPeggedSelected(false);
+              setAsset(choice);
+            }}
+          />
+          {peggedSelected && <PeggedDollarPanel embedded onPendingChange={setPeggedPending} />}
+          <div className="dollar-tabs" aria-label="Dollar action" hidden={peggedSelected}>
             {(["deposit", "recombine", "redeem", "supply", "unsupply"] as const).map((choice) => (
               <button
                 key={choice}
@@ -1065,7 +1120,7 @@ function DollarActionPanel({
               </button>
             ))}
           </div>
-          <div className="dollar-field">
+          <div className="dollar-field" hidden={peggedSelected}>
             <label htmlFor="dollar-amount">{amountUnit} amount</label>
             <div>
               <input
@@ -1098,24 +1153,7 @@ function DollarActionPanel({
                 ` · ${displayAmount(supply.effectiveShares)} currently supplied`}
             </small>
           </div>
-          <fieldset className="dollar-asset-choice" hidden={isSupplyMode(mode)}>
-            <legend>{mode === "deposit" ? "Deposit asset" : "Receive asset"}</legend>
-            {(["ETH", "WETH"] as const).map((choice) => (
-              <button
-                key={choice}
-                type="button"
-                className={asset === choice ? "active" : undefined}
-                onClick={() => {
-                  setAsset(choice);
-                  setActionError(null);
-                }}
-                disabled={anyPending}
-              >
-                {choice}
-              </button>
-            ))}
-          </fieldset>
-          <div className="dollar-quote">
+          <div className="dollar-quote" hidden={peggedSelected}>
             <span>{isSupplyMode(mode) ? "Your Risk shares" : previewLabel}</span>
             <strong>{supplyOutput ?? output}</strong>
             {preview && (
@@ -1126,14 +1164,14 @@ function DollarActionPanel({
               </small>
             )}
           </div>
-          {redeemShortfall !== null && (
+          {!peggedSelected && redeemShortfall !== null && (
             <p className="dollar-warning" role="status">
               Only {displayAmount(redeemShortfall)} of the {displayAmount(quote.data!.amount)}{" "}
               Dollar you entered can be redeemed right now -- that is all the Risk shares currently
               opted in. The rest stays in your wallet.
             </p>
           )}
-          {mode === "supply" && (
+          {!peggedSelected && mode === "supply" && (
             <p className="dollar-note">
               Supplying lets Dollar holders redeem without holding Risk shares of their own. Your
               shares become redeemable the moment this confirms, and you earn only where a
@@ -1141,49 +1179,52 @@ function DollarActionPanel({
               shares stay withdrawable.
             </p>
           )}
-          {mode === "unsupply" && (
+          {!peggedSelected && mode === "unsupply" && (
             <p className="dollar-note">
               Withdrawing returns unconsumed Risk shares to this wallet. Shares a redemption already
               consumed are gone as shares -- they became proceeds, which you collect by claiming.
             </p>
           )}
-          {isSupplyMode(mode) && hasClaimableProceeds(supply) && supply.positionId !== null && (
-            <div className="dollar-claim-row">
-              <div>
-                <span>Proceeds to claim</span>
-                <strong>
-                  {[
-                    [supply.claimableCollateral, asset] as const,
-                    [supply.claimableStaticsDollar, "Dollar"] as const,
-                    [supply.claimableStatics, "STATICS"] as const,
-                  ]
-                    .filter(([value]) => value > 0n)
-                    .map(([value, label]) => `${displayAmount(value)} ${label}`)
-                    .join(" · ")}
-                </strong>
+          {!peggedSelected &&
+            isSupplyMode(mode) &&
+            hasClaimableProceeds(supply) &&
+            supply.positionId !== null && (
+              <div className="dollar-claim-row">
+                <div>
+                  <span>Proceeds to claim</span>
+                  <strong>
+                    {[
+                      [supply.claimableCollateral, asset] as const,
+                      [supply.claimableStaticsDollar, "Dollar"] as const,
+                      [supply.claimableStatics, "STATICS"] as const,
+                    ]
+                      .filter(([value]) => value > 0n)
+                      .map(([value, label]) => `${displayAmount(value)} ${label}`)
+                      .join(" · ")}
+                  </strong>
+                </div>
+                <button type="button" disabled={anyPending} onClick={() => void claimProceeds()}>
+                  {pendingAction === "claim" ? "Waiting for confirmation…" : "Claim"}
+                </button>
               </div>
-              <button type="button" disabled={anyPending} onClick={() => void claimProceeds()}>
-                {pendingAction === "claim" ? "Waiting for confirmation…" : "Claim"}
-              </button>
-            </div>
-          )}
-          {mode === "redeem" && (
+            )}
+          {!peggedSelected && mode === "redeem" && (
             <p className="dollar-note">
               Redeeming spends Risk shares somebody else opted in, so you do not need to hold any.
               Recombine instead if you hold both and want the full collateral.
             </p>
           )}
-          {mode === "recombine" && !state.riskApproved && (
+          {!peggedSelected && mode === "recombine" && !state.riskApproved && (
             <p className="dollar-warning">
               ERC-1155 approval covers every Risk series, not only series{" "}
               {state.seriesId.toString()}. The gateway is fixed by the verified deployment and
               approval can be revoked below.
             </p>
           )}
-          {actionAvailability.reason && (
+          {!peggedSelected && actionAvailability.reason && (
             <p className="dollar-action-reason">{actionAvailability.reason}</p>
           )}
-          {actionError && (
+          {!peggedSelected && actionError && (
             <p className="dapp-inline-error" role="alert">
               {actionError}
             </p>
@@ -1193,12 +1234,46 @@ function DollarActionPanel({
             type="button"
             onClick={() => void executeNextAction()}
             disabled={anyPending || !actionAvailability.executable}
+            hidden={peggedSelected}
           >
             {pendingAction === "primary" ? "Waiting for confirmation…" : actionAvailability.label}
           </button>
         </div>
 
-        <aside className="dollar-protocol-card">
+        {peggedSelected && (
+          <aside className="dollar-protocol-card">
+            <p className="dapp-section-label">USDG profile</p>
+            <dl>
+              <div>
+                <dt>Profile</dt>
+                <dd>#{deployment.pegged?.profileId.toString()}</dd>
+              </div>
+              <div>
+                <dt>Collateral</dt>
+                <dd>USDG</dd>
+              </div>
+              <div>
+                <dt>Dollar received</dt>
+                <dd>USDstx</dd>
+              </div>
+              <div>
+                <dt>Risk shares</dt>
+                <dd>None</dd>
+              </div>
+              <div>
+                <dt>Gateway</dt>
+                <dd title={deployment.contracts.gateway}>
+                  {shortAddress(deployment.contracts.gateway)}
+                </dd>
+              </div>
+            </dl>
+            <p>
+              USDG enters the pegged profile directly. It mints Statics Dollar without creating an
+              ethLEV position.
+            </p>
+          </aside>
+        )}
+        <aside className="dollar-protocol-card" hidden={peggedSelected}>
           <p className="dapp-section-label" aria-live="polite">
             WETH profile{snapshot.isFetching ? " · refreshing" : ""}
           </p>

--- a/components/liquidity/LiquidityPage.tsx
+++ b/components/liquidity/LiquidityPage.tsx
@@ -19,7 +19,6 @@ import {
   BasketStatus,
   basketTokenAbi,
   buildActivateLiquidityPositionCall,
-  buildApproveV4PositionCall,
   buildBorrowAndProvideLiquidityCall,
   buildClaimLiquidityRewardsCall,
   buildIncreaseStakedLiquidityCall,
@@ -49,6 +48,12 @@ import {
 } from "@/lib/liquidity/liquidity";
 import { describePositionError, unlockedCollateral } from "@/lib/positions/positions";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import {
+  MAX_ERC20_ALLOWANCE,
+  MAX_PERMIT2_ALLOWANCE,
+  MAX_PERMIT2_EXPIRATION,
+  operatorApprovalAbi,
+} from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 const deploymentState = readClientDollarDeployment();
@@ -262,7 +267,7 @@ function LiquidityRuntime() {
           encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [contracts.permit2, required],
+            args: [contracts.permit2, MAX_ERC20_ALLOWANCE],
           }),
           {
             verifyConfirmation: async () => {
@@ -292,7 +297,12 @@ function LiquidityRuntime() {
           `Authorize ${token.symbol} for PositionManager`,
           `${amount(required, token.decimals)} ${token.symbol}`,
           contracts.permit2,
-          buildPermit2ApproveCall(token.address, contracts.positionManager, required, now + 3_600),
+          buildPermit2ApproveCall(
+            token.address,
+            contracts.positionManager,
+            MAX_PERMIT2_ALLOWANCE,
+            MAX_PERMIT2_EXPIRATION
+          ),
           {
             verifyConfirmation: async () => {
               const confirmed = await publicClient.readContract({
@@ -623,27 +633,30 @@ function LiquidityRuntime() {
         throw new Error("The selected liquidity position is not owned by this wallet.");
       const approved = await publicClient.readContract({
         address: positionManager,
-        abi: v4PositionManagerReadAbi,
-        functionName: "getApproved",
-        args: [position.tokenId],
+        abi: operatorApprovalAbi,
+        functionName: "isApprovedForAll",
+        args: [wallet, diamond],
       });
-      if (getAddress(approved) !== diamond) {
+      if (!approved) {
         await send(
           "approve-lp-nft",
-          `Approve Liquidity position #${position.tokenId}`,
-          `Liquidity position #${position.tokenId}`,
+          "Enable Statics liquidity position management",
+          "All wallet-owned liquidity positions",
           positionManager,
-          buildApproveV4PositionCall(diamond, position.tokenId),
+          encodeFunctionData({
+            abi: operatorApprovalAbi,
+            functionName: "setApprovalForAll",
+            args: [diamond, true],
+          }),
           {
             verifyConfirmation: async () => {
               const confirmed = await publicClient.readContract({
                 address: positionManager,
-                abi: v4PositionManagerReadAbi,
-                functionName: "getApproved",
-                args: [position.tokenId],
+                abi: operatorApprovalAbi,
+                functionName: "isApprovedForAll",
+                args: [wallet, diamond],
               });
-              if (getAddress(confirmed) !== diamond)
-                throw new Error("The liquidity position approval was not confirmed.");
+              if (!confirmed) throw new Error("The liquidity operator approval was not confirmed.");
             },
           }
         );
@@ -883,7 +896,7 @@ function LiquidityRuntime() {
             encodeFunctionData({
               abi: basketTokenAbi,
               functionName: "approve",
-              args: [diamond, required],
+              args: [diamond, MAX_ERC20_ALLOWANCE],
             }),
             {
               verifyConfirmation: async () => {

--- a/components/loans/LoansPage.tsx
+++ b/components/loans/LoansPage.tsx
@@ -51,6 +51,7 @@ import {
   ConfirmationVerificationError,
   executeProtocolTransaction,
 } from "@/lib/protocol/transactions";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 const deploymentState = readClientDollarDeployment();
@@ -441,7 +442,7 @@ function LoansRuntime() {
           const data = encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [deploymentState.deployment.contracts.diamond, amount],
+            args: [deploymentState.deployment.contracts.diamond, MAX_ERC20_ALLOWANCE],
           });
           await executeProtocolTransaction({
             publicClient,
@@ -471,8 +472,8 @@ function LoansRuntime() {
                 functionName: "allowance",
                 args: [wallet, deploymentState.deployment.contracts.diamond],
               });
-              if (allowance !== amount) {
-                throw new Error("The confirmed token allowance is not the exact requested amount.");
+              if (allowance < amount) {
+                throw new Error("The confirmed token allowance is below the required amount.");
               }
             },
           });

--- a/components/portal/PeggedDollarPanel.tsx
+++ b/components/portal/PeggedDollarPanel.tsx
@@ -87,7 +87,13 @@ async function walletClients(wallet: ReturnType<typeof useWalletState>) {
   };
 }
 
-export function PeggedDollarPanel() {
+export function PeggedDollarPanel({
+  embedded = false,
+  onPendingChange,
+}: {
+  embedded?: boolean;
+  onPendingChange?: (pending: boolean) => void;
+}) {
   const wallet = useWalletState();
   const configured = configuredDeploymentState;
   const deployment = configured.status === "configured" ? configured.deployment : null;
@@ -105,6 +111,16 @@ export function PeggedDollarPanel() {
   } catch {
     amount = 0n;
   }
+
+  const updatePending = useCallback(
+    (next: boolean) => {
+      setPending(next);
+      onPendingChange?.(next);
+    },
+    [onPendingChange]
+  );
+
+  useEffect(() => () => onPendingChange?.(false), [onPendingChange]);
 
   const readSnapshot = useCallback(async () => {
     if (!deployment?.pegged || !wallet.address || wallet.chainId !== deployment.chainId)
@@ -275,20 +291,20 @@ export function PeggedDollarPanel() {
 
   const nextAction = async () => {
     if (!deployment?.pegged || !quote || !snapshot || pending) return;
-    setPending(true);
+    updatePending(true);
     setError(null);
     try {
       setReviewing(true);
     } catch (cause) {
       setError(describeDollarError(cause));
     } finally {
-      setPending(false);
+      updatePending(false);
     }
   };
 
   const confirm = async () => {
     if (!deployment?.pegged || !quote || !snapshot || pending) return;
-    setPending(true);
+    updatePending(true);
     setError(null);
     try {
       const fresh = await readQuote();
@@ -372,7 +388,7 @@ export function PeggedDollarPanel() {
     } catch (cause) {
       setError(describeDollarError(cause));
     } finally {
-      setPending(false);
+      updatePending(false);
     }
   };
 
@@ -406,11 +422,13 @@ export function PeggedDollarPanel() {
                 : balanceInsufficient
                   ? `Insufficient ${direction === "mint" ? "USDG" : "USDstx"}`
                   : direction === "mint"
-                    ? "Review mint"
+                    ? embedded
+                      ? "Review deposit"
+                      : "Review mint"
                     : "Review redemption";
 
   return (
-    <div className="portal-panel" role="tabpanel">
+    <div className={`portal-panel${embedded ? " dollar-pegged-panel" : ""}`} role="tabpanel">
       <div className="portal-direction-tabs" aria-label="Statics Dollar direction">
         {(["mint", "redeem"] as const).map((item) => (
           <button
@@ -425,7 +443,7 @@ export function PeggedDollarPanel() {
             }}
             disabled={pending}
           >
-            {item === "mint" ? "Mint" : "Redeem"}
+            {item === "mint" ? (embedded ? "Deposit" : "Mint") : "Redeem"}
           </button>
         ))}
       </div>
@@ -511,10 +529,14 @@ export function PeggedDollarPanel() {
         >
           {pending
             ? direction === "mint"
-              ? "Minting…"
+              ? embedded
+                ? "Depositing…"
+                : "Minting…"
               : "Redeeming…"
             : direction === "mint"
-              ? "Confirm mint"
+              ? embedded
+                ? "Confirm deposit"
+                : "Confirm mint"
               : "Confirm redemption"}
         </button>
       ) : (

--- a/components/portal/PeggedDollarPanel.tsx
+++ b/components/portal/PeggedDollarPanel.tsx
@@ -12,10 +12,13 @@ import {
 import {
   basketTokenAbi,
   buildErc20PermitTypedData,
+  buildMintPeggedCall,
   buildMintPeggedWithPermitCall,
+  buildRedeemPeggedCall,
   buildRedeemPeggedWithPermitCall,
   staticsAbi,
 } from "@statics-protocol/sdk";
+import { useSignTypedData } from "@privy-io/react-auth";
 
 import { readClientDollarDeployment, verifyDollarDeployment } from "@/lib/dollar/deployment";
 import {
@@ -31,8 +34,11 @@ import {
   decodePermitSignature,
   exactPeggedMintPermitValue,
   permitDeadline,
+  privyPermitRequest,
+  signPermitForWallet,
 } from "@/lib/dollar/permit";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 type Direction = "mint" | "redeem";
@@ -54,6 +60,8 @@ type PeggedQuote =
 type Snapshot = {
   collateralBalance: bigint;
   dollarBalance: bigint;
+  collateralAllowance: bigint;
+  dollarAllowance: bigint;
 };
 
 function deploymentState() {
@@ -95,6 +103,7 @@ export function PeggedDollarPanel({
   onPendingChange?: (pending: boolean) => void;
 }) {
   const wallet = useWalletState();
+  const { signTypedData: signEmbeddedTypedData } = useSignTypedData();
   const configured = configuredDeploymentState;
   const deployment = configured.status === "configured" ? configured.deployment : null;
   const [direction, setDirection] = useState<Direction>("mint");
@@ -127,21 +136,34 @@ export function PeggedDollarPanel({
       return null;
     const { account, publicClient } = await walletClients(wallet);
     await verifyDollarDeployment(publicClient, deployment);
-    const [collateralBalance, dollarBalance] = await Promise.all([
-      publicClient.readContract({
-        address: deployment.pegged.collateral,
-        abi: basketTokenAbi,
-        functionName: "balanceOf",
-        args: [account],
-      }),
-      publicClient.readContract({
-        address: deployment.contracts.dollar,
-        abi: basketTokenAbi,
-        functionName: "balanceOf",
-        args: [account],
-      }),
-    ]);
-    const next = { collateralBalance, dollarBalance };
+    const [collateralBalance, dollarBalance, collateralAllowance, dollarAllowance] =
+      await Promise.all([
+        publicClient.readContract({
+          address: deployment.pegged.collateral,
+          abi: basketTokenAbi,
+          functionName: "balanceOf",
+          args: [account],
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.dollar,
+          abi: basketTokenAbi,
+          functionName: "balanceOf",
+          args: [account],
+        }),
+        publicClient.readContract({
+          address: deployment.pegged.collateral,
+          abi: basketTokenAbi,
+          functionName: "allowance",
+          args: [account, deployment.contracts.gateway],
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.dollar,
+          abi: basketTokenAbi,
+          functionName: "allowance",
+          args: [account, deployment.contracts.gateway],
+        }),
+      ]);
+    const next = { collateralBalance, dollarBalance, collateralAllowance, dollarAllowance };
     setSnapshot(next);
     return next;
   }, [deployment, wallet]);
@@ -273,18 +295,29 @@ export function PeggedDollarPanel({
       publicClient.getBlock(),
     ]);
     const deadline = permitDeadline(block.timestamp);
-    const signature = await walletClient.signTypedData({
-      account,
-      ...buildErc20PermitTypedData({
-        tokenName,
-        chainId: deployment.chainId,
-        token,
-        owner: account,
-        spender: deployment.contracts.gateway,
-        value,
-        nonce,
-        deadline,
-      }),
+    const typedData = buildErc20PermitTypedData({
+      tokenName,
+      chainId: deployment.chainId,
+      token,
+      owner: account,
+      spender: deployment.contracts.gateway,
+      value,
+      nonce,
+      deadline,
+    });
+    const signature = await signPermitForWallet({
+      walletKind: wallet.walletKind,
+      typedData,
+      signEmbedded: async (permit) => {
+        const request = privyPermitRequest(permit, account);
+        const signed = await signEmbeddedTypedData(request.typedData, request.options);
+        return signed.signature as `0x${string}`;
+      },
+      signExternal: (permit) =>
+        walletClient.signTypedData({
+          account,
+          ...permit,
+        }),
     });
     return decodePermitSignature(deadline, signature);
   };
@@ -308,30 +341,33 @@ export function PeggedDollarPanel({
     setError(null);
     try {
       const fresh = await readQuote();
-      const before = snapshot;
+      const before = (await readSnapshot()) ?? snapshot;
       if (quote.direction === "mint" && fresh.direction === "mint") {
         const maximum = maximumWithTolerance(quote.totalCollateralIn);
-        let permitValue: bigint;
         try {
-          permitValue = exactPeggedMintPermitValue(fresh.totalCollateralIn, maximum);
+          exactPeggedMintPermitValue(fresh.totalCollateralIn, maximum);
         } catch (cause) {
           setQuote(fresh);
           setReviewing(false);
           throw cause;
         }
-        const permit = await signPermit(deployment.pegged.collateral, permitValue);
+        const receiver = getAddress(wallet.address!);
+        const data =
+          before.collateralAllowance >= fresh.totalCollateralIn
+            ? buildMintPeggedCall(deployment.pegged.profileId, quote.amount, maximum, receiver)
+            : buildMintPeggedWithPermitCall(
+                deployment.pegged.profileId,
+                quote.amount,
+                maximum,
+                receiver,
+                await signPermit(deployment.pegged.collateral, MAX_ERC20_ALLOWANCE)
+              );
         await send(
           "mint-pegged",
           "Mint Statics Dollar with USDG",
           display(quote.amount, 18, "USDstx"),
           deployment.contracts.gateway,
-          buildMintPeggedWithPermitCall(
-            deployment.pegged.profileId,
-            quote.amount,
-            maximum,
-            getAddress(wallet.address!),
-            permit
-          ),
+          data,
           {
             validateSimulation: (result) => void validatePeggedMintSimulation(result),
             verifyConfirmation: async () => {
@@ -351,19 +387,23 @@ export function PeggedDollarPanel({
           setReviewing(false);
           throw new Error("The USDG output moved below the reviewed minimum.");
         }
-        const permit = await signPermit(deployment.contracts.dollar, quote.amount);
+        const receiver = getAddress(wallet.address!);
+        const data =
+          before.dollarAllowance >= quote.amount
+            ? buildRedeemPeggedCall(deployment.pegged.profileId, quote.amount, minimum, receiver)
+            : buildRedeemPeggedWithPermitCall(
+                deployment.pegged.profileId,
+                quote.amount,
+                minimum,
+                receiver,
+                await signPermit(deployment.contracts.dollar, MAX_ERC20_ALLOWANCE)
+              );
         await send(
           "redeem-pegged",
           "Redeem Statics Dollar for USDG",
           display(quote.amount, 18, "USDstx"),
           deployment.contracts.gateway,
-          buildRedeemPeggedWithPermitCall(
-            deployment.pegged.profileId,
-            quote.amount,
-            minimum,
-            getAddress(wallet.address!),
-            permit
-          ),
+          data,
           {
             validateSimulation: (result) => void validatePeggedRedemptionSimulation(result),
             verifyConfirmation: async () => {

--- a/components/positions/PositionCollateralSummary.tsx
+++ b/components/positions/PositionCollateralSummary.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { formatUnits } from "viem";
+
+import type { PositionCollateral } from "@/lib/positions/positions";
+
+function displayAmount(value: bigint, decimals: number): string {
+  const [whole, fraction = ""] = formatUnits(value, decimals).split(".");
+  const shortFraction = fraction.slice(0, 4).replace(/0+$/, "");
+  return shortFraction ? `${whole}.${shortFraction}` : whole;
+}
+
+export function PositionCollateralSummary({
+  collateral,
+  currentBlock,
+  compact = false,
+}: {
+  collateral: readonly PositionCollateral[];
+  currentBlock: bigint;
+  compact?: boolean;
+}) {
+  return (
+    <section
+      className={`position-collateral-summary${compact ? " is-compact" : ""}`}
+      aria-label="BasketTokens held by this position"
+    >
+      <div>
+        <p className="dapp-section-label">BasketTokens held by this position</p>
+        {!compact && (
+          <p>
+            These BasketTokens belong to this PositionNFT. The Diamond holds them in custody while
+            they earn basket fees and support loans.
+          </p>
+        )}
+      </div>
+      {collateral.length === 0 ? (
+        <p className="position-collateral-empty">No BasketTokens are deposited.</p>
+      ) : (
+        <ul>
+          {collateral.map((holding) => {
+            const decimals = holding.basket.token.decimals;
+            const available = holding.depositedShares - holding.lockedShares;
+            const coolingDown = currentBlock < holding.withdrawableAfterBlock;
+            return (
+              <li key={holding.basket.basketId.toString()}>
+                <div>
+                  <Link href={`/app/baskets/${holding.basket.basketId.toString()}`}>
+                    {holding.basket.symbol}
+                  </Link>
+                  <strong>
+                    {displayAmount(holding.depositedShares, decimals)} {holding.basket.symbol}
+                  </strong>
+                </div>
+                <dl>
+                  <div>
+                    <dt>Deposited</dt>
+                    <dd>{displayAmount(holding.depositedShares, decimals)}</dd>
+                  </div>
+                  <div>
+                    <dt>Available to withdraw</dt>
+                    <dd>
+                      {coolingDown
+                        ? "Next block"
+                        : `${displayAmount(available, decimals)} ${holding.basket.symbol}`}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Securing loans</dt>
+                    <dd>
+                      {displayAmount(holding.lockedShares, decimals)} {holding.basket.symbol}
+                    </dd>
+                  </div>
+                </dl>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/positions/PositionDetailPage.tsx
+++ b/components/positions/PositionDetailPage.tsx
@@ -49,6 +49,7 @@ import {
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import { useWalletState } from "@/providers/wallet-context";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
+import { PositionCollateralSummary } from "@/components/positions/PositionCollateralSummary";
 import { PositionDetailPreview } from "@/components/preview/DappPreview";
 import { dappPreviewEnabled } from "@/lib/dapp-preview";
 
@@ -608,6 +609,11 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
         Dollar, and liquidity obligation. This release intentionally does not provide a transfer
         button.
       </p>
+
+      <PositionCollateralSummary
+        collateral={position.collateral}
+        currentBlock={catalog.data.currentBlock}
+      />
 
       <div className="position-detail-grid">
         <section className="position-panel">

--- a/components/positions/PositionDetailPage.tsx
+++ b/components/positions/PositionDetailPage.tsx
@@ -47,6 +47,7 @@ import {
   validateCustomRewardAsset,
 } from "@/lib/positions/positions";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
 import { PositionCollateralSummary } from "@/components/positions/PositionCollateralSummary";
@@ -324,7 +325,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [diamond, collateralAmount],
+            args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
         return;
@@ -375,7 +376,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [diamond, maximum],
+            args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
         return;
@@ -495,7 +496,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [diamond, stakeAmount],
+            args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
         return;

--- a/components/positions/PositionListPage.tsx
+++ b/components/positions/PositionListPage.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { buildCreatePositionCall, staticsAbi } from "@statics-protocol/sdk";
 
 import { SurfaceEmptyState } from "@/components/common/EmptyState";
+import { PositionCollateralSummary } from "@/components/positions/PositionCollateralSummary";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
 import { PositionListPreview } from "@/components/preview/DappPreview";
 import { deriveSurfaceState, isSurfaceReady } from "@/lib/surface-state";
@@ -207,10 +208,15 @@ function PositionListRuntime() {
                 chainId={deploymentState.deployment.chainId}
                 label="Owner"
               />
+              <PositionCollateralSummary
+                collateral={position.collateral}
+                currentBlock={catalog.data.currentBlock}
+                compact
+              />
               <dl>
                 <div>
-                  <dt>Basket collateral</dt>
-                  <dd>{position.collateral.length} baskets</dd>
+                  <dt>Basket legs</dt>
+                  <dd>{position.collateral.length}</dd>
                 </div>
                 <div>
                   <dt>Global stake</dt>

--- a/components/preview/DappPreview.tsx
+++ b/components/preview/DappPreview.tsx
@@ -90,8 +90,8 @@ export function DollarOverviewPreview() {
 }
 
 export function DollarPagePreview() {
-  const [mode, setMode] = useState<"deposit" | "recombine">("deposit");
-  const [asset, setAsset] = useState<"ETH" | "WETH">("ETH");
+  const [mode, setMode] = useState<"deposit" | "recombine" | "redeem">("deposit");
+  const [asset, setAsset] = useState<"ETH" | "WETH" | "USDG">("ETH");
   return (
     <>
       <PreviewBanner surface="Dollar" />
@@ -111,22 +111,36 @@ export function DollarPagePreview() {
             >
               Deposit
             </button>
-            <button
-              type="button"
-              className={mode === "recombine" ? "active" : undefined}
-              onClick={() => setMode("recombine")}
-            >
-              Recombine
-            </button>
+            {asset === "USDG" ? (
+              <button
+                type="button"
+                className={mode === "redeem" ? "active" : undefined}
+                onClick={() => setMode("redeem")}
+              >
+                Redeem
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={mode === "recombine" ? "active" : undefined}
+                onClick={() => setMode("recombine")}
+              >
+                Recombine
+              </button>
+            )}
           </div>
-          <fieldset className="dollar-asset-choice">
-            <legend>Collateral output</legend>
-            {(["ETH", "WETH"] as const).map((choice) => (
+          <fieldset className="dollar-asset-choice dollar-profile-choice has-pegged">
+            <legend>Collateral profile</legend>
+            {(["ETH", "WETH", "USDG"] as const).map((choice) => (
               <button
                 type="button"
                 key={choice}
                 className={asset === choice ? "active" : undefined}
-                onClick={() => setAsset(choice)}
+                aria-pressed={asset === choice}
+                onClick={() => {
+                  setAsset(choice);
+                  setMode("deposit");
+                }}
               >
                 {choice}
               </button>
@@ -134,7 +148,11 @@ export function DollarPagePreview() {
           </fieldset>
           <div className="dollar-field">
             <label htmlFor="preview-dollar-amount">
-              {mode === "deposit" ? `${asset} collateral` : "Dollar amount"}
+              {mode === "deposit"
+                ? asset === "USDG"
+                  ? "Statics Dollar to receive"
+                  : `${asset} collateral`
+                : "Dollar amount"}
             </label>
             <div>
               <input id="preview-dollar-amount" value="" placeholder={unavailable} readOnly />
@@ -151,7 +169,9 @@ export function DollarPagePreview() {
             <strong>{unavailable}</strong>
             <small>{unavailable}</small>
           </div>
-          <PreviewAction>{mode === "deposit" ? "Deposit" : "Recombine"}</PreviewAction>
+          <PreviewAction>
+            {mode === "deposit" ? "Deposit" : mode === "redeem" ? "Redeem" : "Recombine"}
+          </PreviewAction>
         </div>
         <aside className="dollar-protocol-card">
           <p className="dapp-section-label">Protocol state</p>

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -36,6 +36,7 @@ import {
   loadPositionCatalog,
 } from "@/lib/positions/positions";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { useWalletState } from "@/providers/wallet-context";
 
 const deploymentState = readClientDollarDeployment();
@@ -221,7 +222,7 @@ function RewardsRuntime() {
           data: encodeFunctionData({
             abi: basketTokenAbi,
             functionName: "approve",
-            args: [diamond, amount],
+            args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
       } else {

--- a/components/tools/ApprovalToolsPage.tsx
+++ b/components/tools/ApprovalToolsPage.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { getAddress } from "viem";
+import { usePublicClient, useWalletClient } from "wagmi";
+import { useState } from "react";
+
+import { EmptyState } from "@/components/common/EmptyState";
+import { AddressDisplay } from "@/components/protocol/AddressDisplay";
+import { dappPreviewEnabled } from "@/lib/dapp-preview";
+import {
+  readClientDollarDeployment,
+  verifyDollarDeployment,
+  verifyLiquidityDeployment,
+} from "@/lib/dollar/deployment";
+import {
+  buildApprovalUpdate,
+  loadApprovalInventory,
+  readApprovalState,
+  type ApprovalRecord,
+} from "@/lib/protocol/approval-inventory";
+import { approvalStatusLabel } from "@/lib/protocol/approvals";
+import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { useWalletState } from "@/providers/wallet-context";
+
+const deploymentState = readClientDollarDeployment();
+
+function approvalKindLabel(kind: ApprovalRecord["kind"]): string {
+  if (kind === "permit2") return "Permit2 allowance";
+  if (kind === "erc721-token") return "Legacy NFT approval";
+  if (kind === "operator") return "Operator approval";
+  return "Token allowance";
+}
+
+function describeApprovalError(cause: unknown): string {
+  return cause instanceof Error ? cause.message : "The approval update failed.";
+}
+
+export function ApprovalToolsPage() {
+  const wallet = useWalletState();
+  if (dappPreviewEnabled || wallet.status === "unconfigured") {
+    return (
+      <section className="approval-tools">
+        <div className="approval-tools-heading">
+          <p className="dapp-section-label">Account tools</p>
+          <h2>App approvals</h2>
+          <p>
+            Connect the DApp to review and manage token, Permit2, and operator approvals for the
+            verified Statics deployment.
+          </p>
+        </div>
+      </section>
+    );
+  }
+  return <ApprovalToolsRuntime />;
+}
+
+function ApprovalToolsRuntime() {
+  const walletState = useWalletState();
+  const publicClient = usePublicClient();
+  const walletClient = useWalletClient();
+  const wallet =
+    walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [bulkProgress, setBulkProgress] = useState<Readonly<{
+    current: number;
+    total: number;
+  }> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const approvals = useQuery({
+    queryKey: [
+      "approval-tools",
+      deploymentState.status === "configured"
+        ? deploymentState.deployment.protocolCommit
+        : "unconfigured",
+      wallet,
+    ],
+    enabled:
+      deploymentState.status === "configured" &&
+      Boolean(publicClient) &&
+      Boolean(wallet) &&
+      walletState.status === "ready" &&
+      walletState.isTargetChain,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      if (!publicClient || !wallet || deploymentState.status !== "configured") {
+        throw new Error("No verified Statics deployment is configured.");
+      }
+      await verifyDollarDeployment(publicClient, deploymentState.deployment);
+      if (deploymentState.deployment.liquidity) {
+        await verifyLiquidityDeployment(publicClient, deploymentState.deployment);
+      }
+      return loadApprovalInventory(publicClient, deploymentState.deployment, wallet);
+    },
+  });
+
+  if (
+    walletState.status === "signed-out" ||
+    walletState.status === "error" ||
+    walletState.status === "wallet-missing"
+  ) {
+    return (
+      <EmptyState
+        title="Connect your wallet to manage approvals"
+        description="Approval authority belongs to a specific wallet, so Statics must know which account to inspect."
+        action={{
+          label:
+            walletState.status === "wallet-missing" ? "Create embedded wallet" : "Connect wallet",
+          onClick:
+            walletState.status === "wallet-missing"
+              ? () => void walletState.createWallet()
+              : walletState.login,
+        }}
+      />
+    );
+  }
+  if (walletState.status !== "ready") {
+    return (
+      <EmptyState
+        title="Wallet loading"
+        description="Statics is waiting for the active wallet before reading approvals."
+      />
+    );
+  }
+  if (!walletState.isTargetChain) {
+    return (
+      <EmptyState
+        title="Switch to Robinhood Chain Testnet"
+        description="The Tools page only manages approvals for the verified Statics deployment."
+        action={{ label: "Switch network", onClick: () => void walletState.switchNetwork() }}
+      />
+    );
+  }
+  if (deploymentState.status !== "configured") {
+    return (
+      <EmptyState
+        title="Tools unavailable"
+        description="No verified Statics deployment is configured."
+      />
+    );
+  }
+
+  const records = approvals.data ?? [];
+  const currentTimestamp = Math.floor(approvals.dataUpdatedAt / 1_000);
+  const active = records.filter(
+    (approval) =>
+      approvalStatusLabel(
+        approval.kind,
+        approval.allowance,
+        approval.expiration,
+        currentTimestamp
+      ) !== "Revoked"
+  );
+  const busy = pendingKey !== null;
+
+  const updateApproval = async (approval: ApprovalRecord, enabled: boolean) => {
+    if (!publicClient || !walletClient.data || !wallet) {
+      throw new Error("The connected wallet is unavailable.");
+    }
+    const transaction = buildApprovalUpdate(approval, enabled);
+    await executeProtocolTransaction({
+      publicClient,
+      wallet,
+      chainId: deploymentState.deployment.chainId,
+      kind: enabled ? "set-app-approval" : "revoke-app-approval",
+      label: `${enabled ? "Set maximum" : "Revoke"} ${approval.tokenSymbol} approval`,
+      amount: `${approvalKindLabel(approval.kind)} for ${approval.spenderLabel}`,
+      to: transaction.target,
+      data: transaction.data,
+      sendTransaction: ({ to, data, value }) =>
+        walletClient.data!.sendTransaction({
+          account: wallet,
+          chain: walletClient.data!.chain,
+          to,
+          data,
+          value,
+        }),
+      describeError: describeApprovalError,
+      verifyConfirmation: async () => {
+        const confirmed = await readApprovalState(publicClient, wallet, approval);
+        const status = approvalStatusLabel(
+          approval.kind,
+          confirmed.allowance,
+          confirmed.expiration
+        );
+        if (enabled ? status !== "Maximum" : status !== "Revoked") {
+          throw new Error("The confirmed approval does not match the requested state.");
+        }
+      },
+    });
+  };
+
+  const updateOne = async (approval: ApprovalRecord, enabled: boolean) => {
+    if (busy) return;
+    setPendingKey(approval.key);
+    setError(null);
+    try {
+      await updateApproval(approval, enabled);
+      await approvals.refetch();
+    } catch (cause) {
+      setError(describeApprovalError(cause));
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  const revokeAll = async () => {
+    if (busy || active.length === 0) return;
+    setPendingKey("all");
+    setError(null);
+    try {
+      for (let index = 0; index < active.length; index += 1) {
+        setBulkProgress({ current: index + 1, total: active.length });
+        await updateApproval(active[index]!, false);
+      }
+      await approvals.refetch();
+    } catch (cause) {
+      setError(
+        `${describeApprovalError(cause)} Confirmed revocations remain effective; refresh and retry the rest.`
+      );
+      await approvals.refetch();
+    } finally {
+      setBulkProgress(null);
+      setPendingKey(null);
+    }
+  };
+
+  return (
+    <section className="approval-tools" aria-labelledby="approval-tools-title">
+      <div className="approval-tools-heading">
+        <p className="dapp-section-label">Account tools</p>
+        <h2 id="approval-tools-title">App approvals</h2>
+        <p>
+          Statics uses maximum approvals so routine deposits, minting, repayment, staking, swaps,
+          and liquidity management do not ask for the same authority repeatedly. Revoke any
+          authority here at any time.
+        </p>
+      </div>
+
+      <div className="approval-tools-summary">
+        <div>
+          <span>Known authorities</span>
+          <strong>{records.length}</strong>
+        </div>
+        <div>
+          <span>Currently active</span>
+          <strong>{active.length}</strong>
+        </div>
+        <button
+          type="button"
+          onClick={() => void revokeAll()}
+          disabled={busy || active.length === 0}
+        >
+          {bulkProgress
+            ? `Revoking ${bulkProgress.current} of ${bulkProgress.total}…`
+            : "Revoke all app approvals"}
+        </button>
+      </div>
+
+      <p className="approval-tools-note">
+        “Revoke all” submits one explicit wallet transaction per active authority. It stops if a
+        transaction is rejected or fails; approvals already confirmed remain revoked.
+      </p>
+
+      {approvals.isPending && <p className="approval-tools-note">Reading current approvals…</p>}
+      {approvals.error && (
+        <p className="dapp-inline-error" role="alert">
+          {describeApprovalError(approvals.error)}
+        </p>
+      )}
+      {error && (
+        <p className="dapp-inline-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="approval-tools-list">
+        {records.map((approval) => {
+          const status = approvalStatusLabel(
+            approval.kind,
+            approval.allowance,
+            approval.expiration,
+            currentTimestamp
+          );
+          const rowPending = pendingKey === approval.key;
+          return (
+            <article key={approval.key} className="approval-tools-row">
+              <div className="approval-tools-token">
+                <span>{approvalKindLabel(approval.kind)}</span>
+                <strong>{approval.tokenSymbol}</strong>
+                <small>{approval.tokenName}</small>
+              </div>
+              <div className="approval-tools-spender">
+                <span>{approval.spenderLabel}</span>
+                <AddressDisplay
+                  address={approval.spender}
+                  chainId={deploymentState.deployment.chainId}
+                  label="Spender"
+                />
+                <small>{approval.purposes.join(" · ")}</small>
+              </div>
+              <div className="approval-tools-state">
+                <span className={`approval-status is-${status.toLowerCase()}`}>{status}</span>
+                <div>
+                  {status !== "Maximum" && (
+                    <button
+                      type="button"
+                      onClick={() => void updateOne(approval, true)}
+                      disabled={busy}
+                    >
+                      {rowPending ? "Confirming…" : "Set maximum"}
+                    </button>
+                  )}
+                  {status !== "Revoked" && (
+                    <button
+                      className="is-revoke"
+                      type="button"
+                      onClick={() => void updateOne(approval, false)}
+                      disabled={busy}
+                    >
+                      {rowPending ? "Confirming…" : "Revoke"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/docs/statics-approval-surfaces.md
+++ b/docs/statics-approval-surfaces.md
@@ -1,0 +1,44 @@
+# Statics approval surfaces
+
+This map covers approvals created by the Statics application on its configured
+Robinhood deployment. The Tools page derives the same token and spender set
+from the verified deployment and live basket catalog.
+
+| User flow                                     | Asset authority                       | Approved spender | Reusable policy                                                   |
+| --------------------------------------------- | ------------------------------------- | ---------------- | ----------------------------------------------------------------- |
+| Mint a basket                                 | Each basket underlying                | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Deposit BasketTokens                          | BasketToken                           | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Mint into a position                          | Each basket underlying                | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Repay or extend a basket loan                 | Each principal asset                  | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Stake STATICS                                 | STATICS                               | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Increase staked v4 liquidity                  | Pool currencies                       | StaticsDiamond   | Maximum ERC-20 allowance                                          |
+| Deposit WETH to Dollar                        | WETH                                  | Dollar Gateway   | Maximum ERC-20 allowance                                          |
+| Recombine Dollar and Risk                     | USDstx                                | Dollar Gateway   | Maximum ERC-20 allowance                                          |
+| Mint pegged Dollar                            | USDG                                  | Dollar Gateway   | Maximum ERC-20 permit on first use, existing allowance thereafter |
+| Redeem pegged Dollar                          | USDstx                                | Dollar Gateway   | Maximum ERC-20 permit on first use, existing allowance thereafter |
+| Redeem Dollar through supplied Risk liquidity | USDstx                                | Dollar Periphery | Maximum ERC-20 allowance                                          |
+| Recombine Risk shares                         | ethLEV                                | Dollar Gateway   | ERC-1155 operator approval                                        |
+| Supply consumable Risk shares                 | ethLEV                                | Dollar Periphery | ERC-1155 operator approval                                        |
+| Canonical basket swap                         | Pool input token                      | Permit2          | Maximum ERC-20 allowance                                          |
+| Canonical basket swap                         | Permit2 allowance for input token     | Universal Router | Maximum Permit2 allowance and expiration                          |
+| Create v4 liquidity                           | Pool currencies                       | Permit2          | Maximum ERC-20 allowance                                          |
+| Create v4 liquidity                           | Permit2 allowance for pool currencies | PositionManager  | Maximum Permit2 allowance and expiration                          |
+| Stake a v4 liquidity position                 | v4 position NFT                       | StaticsDiamond   | ERC-721 operator approval                                         |
+
+The inventory also discovers wallet-owned v4 positions that still carry the
+older per-token approval and exposes each one for revocation.
+
+## Tools boundary
+
+`/app/tools` manages only authorities whose token and spender are derived from
+the verified Statics deployment, the live basket catalog, and the pinned
+Robinhood Uniswap v4 contracts.
+
+Across bridge approvals and general portal-swap approvals can be created on
+arbitrary origin networks for third-party venue contracts. They remain managed
+by those venue flows and wallet/explorer tooling; the Robinhood Statics Tools
+page does not claim to enumerate or revoke them.
+
+“Revoke all” submits one explicit wallet transaction for every active authority
+and stops on the first rejected or failed transaction. Already-confirmed
+revocations remain effective.

--- a/lib/baskets/swap.ts
+++ b/lib/baskets/swap.ts
@@ -1,6 +1,7 @@
-import { getAddress, type Address } from "viem";
+import { getAddress, type Address, type Hex } from "viem";
 
 import type { Permit2PermitSingle, V4PoolKey } from "@statics-protocol/sdk";
+import type { WalletKind } from "@/providers/wallet-context";
 
 export const SWAP_PERMIT_TTL_SECONDS = 20n * 60n;
 
@@ -67,4 +68,70 @@ export function permit2SwapApproval(
     spender: router,
     sigDeadline: deadline,
   };
+}
+
+export function privyPermit2Request<
+  T extends {
+    readonly types: {
+      readonly PermitDetails: readonly {
+        readonly name: string;
+        readonly type: string;
+      }[];
+      readonly PermitSingle: readonly {
+        readonly name: string;
+        readonly type: string;
+      }[];
+    };
+    readonly message: {
+      readonly details: {
+        readonly amount: bigint;
+        readonly expiration: number;
+        readonly nonce: number;
+      };
+      readonly sigDeadline: bigint;
+    };
+  },
+>(typedData: T, address: Address) {
+  return {
+    typedData: {
+      ...typedData,
+      types: {
+        ...typedData.types,
+        PermitDetails: [...typedData.types.PermitDetails],
+        PermitSingle: [...typedData.types.PermitSingle],
+      },
+      message: {
+        ...typedData.message,
+        details: {
+          ...typedData.message.details,
+          amount: typedData.message.details.amount.toString(),
+          expiration: typedData.message.details.expiration.toString(),
+          nonce: typedData.message.details.nonce.toString(),
+        },
+        sigDeadline: typedData.message.sigDeadline.toString(),
+      },
+    },
+    options: {
+      address,
+      uiOptions: {
+        showWalletUIs: false as const,
+      },
+    },
+  };
+}
+
+export async function signPermit2ForWallet<T>({
+  walletKind,
+  typedData,
+  signEmbedded,
+  signExternal,
+}: {
+  walletKind: WalletKind;
+  typedData: T;
+  signEmbedded: (typedData: T) => Promise<Hex>;
+  signExternal: (typedData: T) => Promise<Hex>;
+}): Promise<Hex> {
+  if (walletKind === "embedded") return signEmbedded(typedData);
+  if (walletKind === "external") return signExternal(typedData);
+  throw new Error("The connected wallet type is unavailable.");
 }

--- a/lib/baskets/swap.ts
+++ b/lib/baskets/swap.ts
@@ -1,7 +1,6 @@
-import { getAddress, type Address, type Hex } from "viem";
+import { getAddress, type Address } from "viem";
 
-import type { Permit2PermitSingle, V4PoolKey } from "@statics-protocol/sdk";
-import type { WalletKind } from "@/providers/wallet-context";
+import type { V4PoolKey } from "@statics-protocol/sdk";
 
 export const SWAP_PERMIT_TTL_SECONDS = 20n * 60n;
 
@@ -48,90 +47,4 @@ export function zeroForExactInput(poolKey: V4PoolKey, inputToken: Address): bool
   if (poolKey.currency0.toLowerCase() === input) return true;
   if (poolKey.currency1.toLowerCase() === input) return false;
   throw new Error("The selected token is not in this canonical pool.");
-}
-
-export function permit2SwapApproval(
-  token: Address,
-  amount: bigint,
-  nonce: number,
-  router: Address,
-  deadline: bigint
-): Permit2PermitSingle {
-  if (deadline > BigInt(0xffff_ffff_ffff)) throw new Error("Permit2 deadline exceeds uint48.");
-  return {
-    details: {
-      token,
-      amount,
-      expiration: Number(deadline),
-      nonce,
-    },
-    spender: router,
-    sigDeadline: deadline,
-  };
-}
-
-export function privyPermit2Request<
-  T extends {
-    readonly types: {
-      readonly PermitDetails: readonly {
-        readonly name: string;
-        readonly type: string;
-      }[];
-      readonly PermitSingle: readonly {
-        readonly name: string;
-        readonly type: string;
-      }[];
-    };
-    readonly message: {
-      readonly details: {
-        readonly amount: bigint;
-        readonly expiration: number;
-        readonly nonce: number;
-      };
-      readonly sigDeadline: bigint;
-    };
-  },
->(typedData: T, address: Address) {
-  return {
-    typedData: {
-      ...typedData,
-      types: {
-        ...typedData.types,
-        PermitDetails: [...typedData.types.PermitDetails],
-        PermitSingle: [...typedData.types.PermitSingle],
-      },
-      message: {
-        ...typedData.message,
-        details: {
-          ...typedData.message.details,
-          amount: typedData.message.details.amount.toString(),
-          expiration: typedData.message.details.expiration.toString(),
-          nonce: typedData.message.details.nonce.toString(),
-        },
-        sigDeadline: typedData.message.sigDeadline.toString(),
-      },
-    },
-    options: {
-      address,
-      uiOptions: {
-        showWalletUIs: false as const,
-      },
-    },
-  };
-}
-
-export async function signPermit2ForWallet<T>({
-  walletKind,
-  typedData,
-  signEmbedded,
-  signExternal,
-}: {
-  walletKind: WalletKind;
-  typedData: T;
-  signEmbedded: (typedData: T) => Promise<Hex>;
-  signExternal: (typedData: T) => Promise<Hex>;
-}): Promise<Hex> {
-  if (walletKind === "embedded") return signEmbedded(typedData);
-  if (walletKind === "external") return signExternal(typedData);
-  throw new Error("The connected wallet type is unavailable.");
 }

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -100,6 +100,12 @@ const routePresentations = {
     title: "Settings",
     description: "Your account, network, and wallet details, plus how to export your keys.",
   },
+  tools: {
+    label: "Tools",
+    status: "Tools",
+    title: "Approval tools",
+    description: "Review and revoke the permissions this wallet has granted to Statics.",
+  },
 } as const satisfies Record<string, DappRoutePresentation>;
 
 export function getDappRoutePresentation(pathname: string): DappRoutePresentation {
@@ -114,5 +120,6 @@ export function getDappRoutePresentation(pathname: string): DappRoutePresentatio
   if (pathname.startsWith("/app/liquidity")) return routePresentations.liquidity;
   if (pathname.startsWith("/app/activity")) return routePresentations.activity;
   if (pathname.startsWith("/app/settings")) return routePresentations.settings;
+  if (pathname.startsWith("/app/tools")) return routePresentations.tools;
   return routePresentations.overview;
 }

--- a/lib/dollar/action-state.ts
+++ b/lib/dollar/action-state.ts
@@ -206,10 +206,10 @@ export function deriveDollarActionAvailability({
     );
   }
 
-  if (mode === "deposit" && asset === "WETH" && snapshot.wethAllowance !== amount) {
+  if (mode === "deposit" && asset === "WETH" && snapshot.wethAllowance < amount) {
     return {
       kind: "approve-weth",
-      label: "Approve exact WETH",
+      label: "Enable WETH deposits",
       reason: null,
       executable: true,
     };
@@ -219,15 +219,15 @@ export function deriveDollarActionAvailability({
   if (mode === "redeem" && snapshot.peripheryDollarAllowance < amount) {
     return {
       kind: "approve-dollar-periphery",
-      label: "Approve exact Dollar",
+      label: "Enable Dollar redemptions",
       reason: null,
       executable: true,
     };
   }
-  if (mode === "recombine" && snapshot.dollarAllowance !== amount) {
+  if (mode === "recombine" && snapshot.dollarAllowance < amount) {
     return {
       kind: "approve-dollar",
-      label: "Approve exact Dollar",
+      label: "Enable Dollar recombination",
       reason: null,
       executable: true,
     };

--- a/lib/dollar/activity.ts
+++ b/lib/dollar/activity.ts
@@ -67,6 +67,8 @@ export type DollarActivityKind =
   | "unstake-lp-nft"
   | "borrow-liquidity"
   | "approve-loan-asset"
+  | "set-app-approval"
+  | "revoke-app-approval"
   | "borrow-loan"
   | "repay-loan"
   | "extend-loan"

--- a/lib/dollar/permit.ts
+++ b/lib/dollar/permit.ts
@@ -1,6 +1,7 @@
 import { parseSignature, type Hex } from "viem";
 
 import type { PermitSignature } from "@statics-protocol/sdk";
+import type { WalletKind } from "@/providers/wallet-context";
 
 export const PERMIT_TTL_SECONDS = 20n * 60n;
 
@@ -16,6 +17,60 @@ export function exactPeggedMintPermitValue(
     throw new Error("The required USDG moved above the reviewed maximum.");
   }
   return freshCollateralIn;
+}
+
+export function privyPermitRequest<
+  T extends {
+    readonly types: {
+      readonly Permit: readonly {
+        readonly name: string;
+        readonly type: string;
+      }[];
+    };
+    readonly message: {
+      readonly value: bigint;
+      readonly nonce: bigint;
+      readonly deadline: bigint;
+    };
+  },
+>(typedData: T, address: `0x${string}`) {
+  return {
+    typedData: {
+      ...typedData,
+      types: {
+        ...typedData.types,
+        Permit: [...typedData.types.Permit],
+      },
+      message: {
+        ...typedData.message,
+        value: typedData.message.value.toString(),
+        nonce: typedData.message.nonce.toString(),
+        deadline: typedData.message.deadline.toString(),
+      },
+    },
+    options: {
+      address,
+      uiOptions: {
+        showWalletUIs: false as const,
+      },
+    },
+  };
+}
+
+export async function signPermitForWallet<T>({
+  walletKind,
+  typedData,
+  signEmbedded,
+  signExternal,
+}: {
+  walletKind: WalletKind;
+  typedData: T;
+  signEmbedded: (typedData: T) => Promise<Hex>;
+  signExternal: (typedData: T) => Promise<Hex>;
+}): Promise<Hex> {
+  if (walletKind === "embedded") return signEmbedded(typedData);
+  if (walletKind === "external") return signExternal(typedData);
+  throw new Error("The connected wallet type is unavailable.");
 }
 
 export function decodePermitSignature(deadline: bigint, signature: Hex): PermitSignature {

--- a/lib/loans/loans.ts
+++ b/lib/loans/loans.ts
@@ -129,7 +129,7 @@ function normalizeLoan(
     debtShares: snapshot.debtShares,
     penaltyShares: snapshot.penaltyShares,
     maturity: BigInt(snapshot.maturity),
-    assets: snapshot.assets.map(getAddress),
+    assets: snapshot.assets.map((asset) => getAddress(asset)),
     principals: snapshot.principals,
   };
 }
@@ -320,7 +320,7 @@ export async function loadBorrowQuote(
     collateralShares: result.collateralShares,
     debtShares: result.debtShares,
     penaltyShares: result.penaltyShares,
-    assets: result.assets.map(getAddress),
+    assets: result.assets.map((asset) => getAddress(asset)),
     principals: result.principals,
   };
 }
@@ -339,7 +339,7 @@ export async function loadExtensionQuote(
   if (assets.length !== requiredFees.length) {
     throw new Error("The current extension quote returned an invalid fee vector.");
   }
-  return { loanId, assets: assets.map(getAddress), requiredFees };
+  return { loanId, assets: assets.map((asset) => getAddress(asset)), requiredFees };
 }
 
 export function validateExtensionGrossAmounts(

--- a/lib/protocol/approval-inventory.ts
+++ b/lib/protocol/approval-inventory.ts
@@ -1,0 +1,422 @@
+import {
+  encodeFunctionData,
+  getAddress,
+  zeroAddress,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+
+import {
+  basketTokenAbi,
+  permit2AllowanceAbi,
+  staticsAbi,
+  staticsDollarCoreAbi,
+  staticsDollarRiskTokenAbi,
+  v4PositionManagerReadAbi,
+} from "@statics-protocol/sdk";
+
+import { loadBasketCatalog, loadTokenMetadata } from "@/lib/baskets/baskets";
+import type { DollarDeployment } from "@/lib/dollar/deployment";
+import {
+  MAX_ERC20_ALLOWANCE,
+  MAX_PERMIT2_ALLOWANCE,
+  MAX_PERMIT2_EXPIRATION,
+  operatorApprovalAbi,
+} from "@/lib/protocol/approvals";
+
+export type ApprovalKind = "erc20" | "permit2" | "operator" | "erc721-token";
+
+export type ApprovalRecord = Readonly<{
+  key: string;
+  kind: ApprovalKind;
+  authorityContract: Address;
+  token: Address;
+  tokenSymbol: string;
+  tokenName: string;
+  spender: Address;
+  spenderLabel: string;
+  purposes: readonly string[];
+  allowance: bigint;
+  expiration?: number;
+  tokenId?: bigint;
+}>;
+
+type ApprovalDefinition = Omit<ApprovalRecord, "allowance" | "expiration">;
+
+function approvalKey(
+  kind: ApprovalKind,
+  authorityContract: Address,
+  token: Address,
+  spender: Address,
+  tokenId?: bigint
+) {
+  return [
+    ...[kind, authorityContract, token, spender].map((value) => value.toLowerCase()),
+    tokenId?.toString() ?? "",
+  ].join(":");
+}
+
+function addDefinition(
+  definitions: Map<string, ApprovalDefinition>,
+  definition: Omit<ApprovalDefinition, "key" | "purposes"> & { purpose: string }
+) {
+  const key = approvalKey(
+    definition.kind,
+    definition.authorityContract,
+    definition.token,
+    definition.spender,
+    definition.tokenId
+  );
+  const current = definitions.get(key);
+  definitions.set(key, {
+    key,
+    kind: definition.kind,
+    authorityContract: definition.authorityContract,
+    token: definition.token,
+    tokenSymbol: definition.tokenSymbol,
+    tokenName: definition.tokenName,
+    spender: definition.spender,
+    spenderLabel: definition.spenderLabel,
+    tokenId: definition.tokenId,
+    purposes: current
+      ? [...new Set([...current.purposes, definition.purpose])]
+      : [definition.purpose],
+  });
+}
+
+export async function loadApprovalInventory(
+  publicClient: PublicClient,
+  deployment: DollarDeployment,
+  wallet: Address
+): Promise<readonly ApprovalRecord[]> {
+  const catalog = await loadBasketCatalog(publicClient, deployment, null);
+  const [stakingTokenAddress, periphery] = await Promise.all([
+    publicClient.readContract({
+      address: deployment.contracts.diamond,
+      abi: staticsAbi,
+      functionName: "stakingToken",
+    }),
+    publicClient.readContract({
+      address: deployment.contracts.core,
+      abi: staticsDollarCoreAbi,
+      functionName: "periphery",
+    }),
+  ]);
+  const stakingToken = await loadTokenMetadata(publicClient, getAddress(stakingTokenAddress));
+  const ecosystemTokens = new Map<
+    Address,
+    Readonly<{ address: Address; symbol: string; name: string }>
+  >();
+  for (const basket of catalog.baskets) {
+    ecosystemTokens.set(basket.token.address, basket.token);
+    for (const constituent of basket.constituents) {
+      ecosystemTokens.set(constituent.token.address, constituent.token);
+    }
+  }
+  const [weth, dollar, peggedCollateral, riskName, riskSymbol] = await Promise.all([
+    loadTokenMetadata(publicClient, deployment.contracts.weth, {
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    }),
+    loadTokenMetadata(publicClient, deployment.contracts.dollar, {
+      name: "Statics Dollar",
+      symbol: "USDstx",
+    }),
+    deployment.pegged
+      ? loadTokenMetadata(publicClient, deployment.pegged.collateral, {
+          name: "Global Dollar",
+          symbol: "USDG",
+        })
+      : Promise.resolve(null),
+    publicClient
+      .readContract({
+        address: deployment.contracts.risk,
+        abi: staticsDollarRiskTokenAbi,
+        functionName: "name",
+      })
+      .catch(() => "Statics Risk Shares"),
+    publicClient
+      .readContract({
+        address: deployment.contracts.risk,
+        abi: staticsDollarRiskTokenAbi,
+        functionName: "symbol",
+      })
+      .catch(() => "ethLEV"),
+  ]);
+
+  const definitions = new Map<string, ApprovalDefinition>();
+  const addErc20 = (
+    token: Readonly<{ address: Address; symbol: string; name: string }>,
+    spender: Address,
+    spenderLabel: string,
+    purpose: string
+  ) =>
+    addDefinition(definitions, {
+      kind: "erc20",
+      authorityContract: token.address,
+      token: token.address,
+      tokenSymbol: token.symbol,
+      tokenName: token.name,
+      spender,
+      spenderLabel,
+      purpose,
+    });
+
+  for (const token of ecosystemTokens.values()) {
+    addErc20(
+      token,
+      deployment.contracts.diamond,
+      "StaticsDiamond",
+      "Baskets, positions, and loans"
+    );
+  }
+  addErc20(stakingToken, deployment.contracts.diamond, "StaticsDiamond", "STATICS staking");
+  addErc20(weth, deployment.contracts.gateway, "Dollar Gateway", "WETH Dollar deposits");
+  addErc20(dollar, deployment.contracts.gateway, "Dollar Gateway", "Dollar recombination");
+  if (peggedCollateral) {
+    addErc20(
+      peggedCollateral,
+      deployment.contracts.gateway,
+      "Dollar Gateway",
+      "USDG Dollar minting"
+    );
+  }
+  if (getAddress(periphery) !== zeroAddress) {
+    addErc20(dollar, getAddress(periphery), "Dollar Periphery", "Dollar-only redemption");
+  }
+
+  if (deployment.liquidity) {
+    const permit2 = deployment.liquidity.contracts.permit2;
+    for (const token of ecosystemTokens.values()) {
+      addErc20(token, permit2, "Permit2", "Canonical swaps and new liquidity");
+      addDefinition(definitions, {
+        kind: "permit2",
+        authorityContract: permit2,
+        token: token.address,
+        tokenSymbol: token.symbol,
+        tokenName: token.name,
+        spender: deployment.liquidity.contracts.positionManager,
+        spenderLabel: "Uniswap v4 PositionManager",
+        purpose: "Create v4 liquidity positions",
+      });
+      if (deployment.liquidity.contracts.universalRouter) {
+        addDefinition(definitions, {
+          kind: "permit2",
+          authorityContract: permit2,
+          token: token.address,
+          tokenSymbol: token.symbol,
+          tokenName: token.name,
+          spender: deployment.liquidity.contracts.universalRouter,
+          spenderLabel: "Uniswap Universal Router",
+          purpose: "Canonical swaps",
+        });
+      }
+    }
+    addDefinition(definitions, {
+      kind: "operator",
+      authorityContract: deployment.liquidity.contracts.positionManager,
+      token: deployment.liquidity.contracts.positionManager,
+      tokenSymbol: "V4 LP",
+      tokenName: "Uniswap v4 liquidity positions",
+      spender: deployment.contracts.diamond,
+      spenderLabel: "StaticsDiamond",
+      purpose: "Stake wallet-owned liquidity positions",
+    });
+    const receivedPositions = await publicClient.getContractEvents({
+      address: deployment.liquidity.contracts.positionManager,
+      abi: v4PositionManagerReadAbi,
+      eventName: "Transfer",
+      args: { to: wallet },
+      fromBlock: deployment.deploymentStartBlock,
+      toBlock: "latest",
+      strict: true,
+    });
+    const tokenIds = [
+      ...new Set(receivedPositions.map((event) => event.args.tokenId.toString())),
+    ].map(BigInt);
+    for (const tokenId of tokenIds) {
+      const owner = await publicClient
+        .readContract({
+          address: deployment.liquidity.contracts.positionManager,
+          abi: v4PositionManagerReadAbi,
+          functionName: "ownerOf",
+          args: [tokenId],
+        })
+        .catch(() => null);
+      if (!owner || getAddress(owner) !== wallet) continue;
+      addDefinition(definitions, {
+        kind: "erc721-token",
+        authorityContract: deployment.liquidity.contracts.positionManager,
+        token: deployment.liquidity.contracts.positionManager,
+        tokenSymbol: `V4 LP #${tokenId.toString()}`,
+        tokenName: "Uniswap v4 liquidity position",
+        spender: deployment.contracts.diamond,
+        spenderLabel: "StaticsDiamond",
+        purpose: "Legacy individual liquidity-position approval",
+        tokenId,
+      });
+    }
+  }
+
+  addDefinition(definitions, {
+    kind: "operator",
+    authorityContract: deployment.contracts.risk,
+    token: deployment.contracts.risk,
+    tokenSymbol: riskSymbol,
+    tokenName: riskName,
+    spender: deployment.contracts.gateway,
+    spenderLabel: "Dollar Gateway",
+    purpose: "Risk-share recombination",
+  });
+  if (getAddress(periphery) !== zeroAddress) {
+    addDefinition(definitions, {
+      kind: "operator",
+      authorityContract: deployment.contracts.risk,
+      token: deployment.contracts.risk,
+      tokenSymbol: riskSymbol,
+      tokenName: riskName,
+      spender: getAddress(periphery),
+      spenderLabel: "Dollar Periphery",
+      purpose: "Consumable Risk-share supply",
+    });
+  }
+
+  const records = await Promise.all(
+    [...definitions.values()].map(async (definition): Promise<ApprovalRecord> => {
+      if (definition.kind === "erc20") {
+        const allowance = await publicClient.readContract({
+          address: definition.authorityContract,
+          abi: basketTokenAbi,
+          functionName: "allowance",
+          args: [wallet, definition.spender],
+        });
+        return { ...definition, allowance };
+      }
+      if (definition.kind === "permit2") {
+        const [allowance, expiration] = await publicClient.readContract({
+          address: definition.authorityContract,
+          abi: permit2AllowanceAbi,
+          functionName: "allowance",
+          args: [wallet, definition.token, definition.spender],
+        });
+        return { ...definition, allowance, expiration };
+      }
+      if (definition.kind === "erc721-token") {
+        const approved = await publicClient.readContract({
+          address: definition.authorityContract,
+          abi: v4PositionManagerReadAbi,
+          functionName: "getApproved",
+          args: [definition.tokenId!],
+        });
+        return {
+          ...definition,
+          allowance: getAddress(approved) === definition.spender ? 1n : 0n,
+        };
+      }
+      const approved = await publicClient.readContract({
+        address: definition.authorityContract,
+        abi: operatorApprovalAbi,
+        functionName: "isApprovedForAll",
+        args: [wallet, definition.spender],
+      });
+      return { ...definition, allowance: approved ? 1n : 0n };
+    })
+  );
+  return records
+    .filter((record) => record.kind !== "erc721-token" || record.allowance === 1n)
+    .sort((left, right) => {
+      const symbol = left.tokenSymbol.localeCompare(right.tokenSymbol);
+      return symbol || left.spenderLabel.localeCompare(right.spenderLabel);
+    });
+}
+
+export function buildApprovalUpdate(
+  approval: ApprovalRecord,
+  enabled: boolean
+): Readonly<{ target: Address; data: Hex }> {
+  if (approval.kind === "erc20") {
+    return {
+      target: approval.authorityContract,
+      data: encodeFunctionData({
+        abi: basketTokenAbi,
+        functionName: "approve",
+        args: [approval.spender, enabled ? MAX_ERC20_ALLOWANCE : 0n],
+      }),
+    };
+  }
+  if (approval.kind === "permit2") {
+    return {
+      target: approval.authorityContract,
+      data: encodeFunctionData({
+        abi: permit2AllowanceAbi,
+        functionName: "approve",
+        args: [
+          approval.token,
+          approval.spender,
+          enabled ? MAX_PERMIT2_ALLOWANCE : 0n,
+          enabled ? MAX_PERMIT2_EXPIRATION : 0,
+        ],
+      }),
+    };
+  }
+  if (approval.kind === "erc721-token") {
+    return {
+      target: approval.authorityContract,
+      data: encodeFunctionData({
+        abi: v4PositionManagerReadAbi,
+        functionName: "approve",
+        args: [enabled ? approval.spender : zeroAddress, approval.tokenId!],
+      }),
+    };
+  }
+  return {
+    target: approval.authorityContract,
+    data: encodeFunctionData({
+      abi: operatorApprovalAbi,
+      functionName: "setApprovalForAll",
+      args: [approval.spender, enabled],
+    }),
+  };
+}
+
+export async function readApprovalState(
+  publicClient: PublicClient,
+  wallet: Address,
+  approval: ApprovalRecord
+): Promise<Readonly<{ allowance: bigint; expiration?: number }>> {
+  if (approval.kind === "erc20") {
+    const allowance = await publicClient.readContract({
+      address: approval.authorityContract,
+      abi: basketTokenAbi,
+      functionName: "allowance",
+      args: [wallet, approval.spender],
+    });
+    return { allowance };
+  }
+  if (approval.kind === "permit2") {
+    const [allowance, expiration] = await publicClient.readContract({
+      address: approval.authorityContract,
+      abi: permit2AllowanceAbi,
+      functionName: "allowance",
+      args: [wallet, approval.token, approval.spender],
+    });
+    return { allowance, expiration };
+  }
+  if (approval.kind === "erc721-token") {
+    const approved = await publicClient.readContract({
+      address: approval.authorityContract,
+      abi: v4PositionManagerReadAbi,
+      functionName: "getApproved",
+      args: [approval.tokenId!],
+    });
+    return { allowance: getAddress(approved) === approval.spender ? 1n : 0n };
+  }
+  const approved = await publicClient.readContract({
+    address: approval.authorityContract,
+    abi: operatorApprovalAbi,
+    functionName: "isApprovedForAll",
+    args: [wallet, approval.spender],
+  });
+  return { allowance: approved ? 1n : 0n };
+}

--- a/lib/protocol/approvals.ts
+++ b/lib/protocol/approvals.ts
@@ -1,0 +1,46 @@
+import { maxUint48, maxUint160, maxUint256, parseAbi } from "viem";
+
+export const MAX_ERC20_ALLOWANCE = maxUint256;
+export const MAX_PERMIT2_ALLOWANCE = maxUint160;
+export const MAX_PERMIT2_EXPIRATION = Number(maxUint48);
+export const operatorApprovalAbi = parseAbi([
+  "function isApprovedForAll(address owner,address operator) view returns (bool)",
+  "function setApprovalForAll(address operator,bool approved)",
+]);
+
+export function hasUsablePermit2Allowance(
+  allowance: bigint,
+  expiration: number,
+  required: bigint,
+  currentTimestamp: number
+): boolean {
+  return allowance >= required && expiration > currentTimestamp;
+}
+
+export function approvalStatusLabel(
+  kind: "erc20" | "permit2" | "operator" | "erc721-token",
+  allowance: bigint,
+  expiration?: number,
+  currentTimestamp?: number
+): "Maximum" | "Custom" | "Revoked" {
+  if (
+    allowance === 0n ||
+    ((kind === "operator" || kind === "erc721-token") && allowance !== 1n) ||
+    (kind === "permit2" &&
+      expiration !== undefined &&
+      currentTimestamp !== undefined &&
+      expiration <= currentTimestamp)
+  ) {
+    return "Revoked";
+  }
+  if (
+    (kind === "erc20" && allowance === MAX_ERC20_ALLOWANCE) ||
+    (kind === "permit2" &&
+      allowance === MAX_PERMIT2_ALLOWANCE &&
+      expiration === MAX_PERMIT2_EXPIRATION) ||
+    ((kind === "operator" || kind === "erc721-token") && allowance === 1n)
+  ) {
+    return "Maximum";
+  }
+  return "Custom";
+}

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -137,6 +137,7 @@ export const appNavigationGroups: readonly AppNavigationGroup[] = [
       { label: "Wallet", enabled: true, href: "/app/wallet", tabLabel: "Wallet" },
       { label: "Activity", enabled: true, href: "/app/activity" },
       { label: "Settings", enabled: true, href: "/app/settings" },
+      { label: "Tools", enabled: true, href: "/app/tools" },
     ],
   },
 ];

--- a/test/baskets/swap.test.ts
+++ b/test/baskets/swap.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Address } from "viem";
-import { buildPermit2PermitTypedData } from "@statics-protocol/sdk";
 
 import {
   canonicalSwapPoolKey,
   isCurrentCanonicalSwapQuote,
-  permit2SwapApproval,
-  privyPermit2Request,
-  signPermit2ForWallet,
   zeroForExactInput,
 } from "@/lib/baskets/swap";
 
@@ -29,14 +25,6 @@ describe("canonical basket swaps", () => {
     expect(zeroForExactInput(poolKey, token1)).toBe(false);
   });
 
-  it("builds an exact bounded Permit2 authorization", () => {
-    expect(permit2SwapApproval(token0, 25n, 7, token1, 1_000n)).toEqual({
-      details: { token: token0, amount: 25n, expiration: 1_000, nonce: 7 },
-      spender: token1,
-      sigDeadline: 1_000n,
-    });
-  });
-
   it("rejects a cached quote after the pool or direction changes", () => {
     const quote = {
       amount: 25n,
@@ -48,79 +36,5 @@ describe("canonical basket swaps", () => {
     expect(isCurrentCanonicalSwapQuote(quote, 25n, token1, "asset-in")).toBe(false);
     expect(isCurrentCanonicalSwapQuote(quote, 25n, token0, "basket-in")).toBe(false);
     expect(isCurrentCanonicalSwapQuote(quote, 26n, token0, "asset-in")).toBe(false);
-  });
-
-  it("serializes nested Permit2 values for Privy embedded signing", () => {
-    const typedData = buildPermit2PermitTypedData(
-      46_630,
-      token1,
-      permit2SwapApproval(token0, 25n, 7, token1, 1_000n)
-    );
-    const request = privyPermit2Request(typedData, token0);
-
-    expect(() => JSON.stringify(request)).not.toThrow();
-    expect(request.typedData.message).toEqual({
-      details: {
-        token: token0,
-        amount: "25",
-        expiration: "1000",
-        nonce: "7",
-      },
-      spender: token1,
-      sigDeadline: "1000",
-    });
-    expect(request.options).toEqual({
-      address: token0,
-      uiOptions: { showWalletUIs: false },
-    });
-  });
-
-  it("uses Privy only for embedded Permit2 signatures", async () => {
-    const calls: string[] = [];
-    const signature = await signPermit2ForWallet({
-      walletKind: "embedded",
-      typedData: "permit",
-      signEmbedded: async () => {
-        calls.push("embedded");
-        return "0x01";
-      },
-      signExternal: async () => {
-        calls.push("external");
-        return "0x02";
-      },
-    });
-
-    expect(signature).toBe("0x01");
-    expect(calls).toEqual(["embedded"]);
-  });
-
-  it("keeps external Permit2 signatures on the wallet client", async () => {
-    const calls: string[] = [];
-    const signature = await signPermit2ForWallet({
-      walletKind: "external",
-      typedData: "permit",
-      signEmbedded: async () => {
-        calls.push("embedded");
-        return "0x01";
-      },
-      signExternal: async () => {
-        calls.push("external");
-        return "0x02";
-      },
-    });
-
-    expect(signature).toBe("0x02");
-    expect(calls).toEqual(["external"]);
-  });
-
-  it("rejects Permit2 signing without a connected wallet type", async () => {
-    await expect(
-      signPermit2ForWallet({
-        walletKind: null,
-        typedData: "permit",
-        signEmbedded: async () => "0x01",
-        signExternal: async () => "0x02",
-      })
-    ).rejects.toThrow("The connected wallet type is unavailable.");
   });
 });

--- a/test/baskets/swap.test.ts
+++ b/test/baskets/swap.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Address } from "viem";
+import { buildPermit2PermitTypedData } from "@statics-protocol/sdk";
 
 import {
   canonicalSwapPoolKey,
   isCurrentCanonicalSwapQuote,
   permit2SwapApproval,
+  privyPermit2Request,
+  signPermit2ForWallet,
   zeroForExactInput,
 } from "@/lib/baskets/swap";
 
@@ -45,5 +48,79 @@ describe("canonical basket swaps", () => {
     expect(isCurrentCanonicalSwapQuote(quote, 25n, token1, "asset-in")).toBe(false);
     expect(isCurrentCanonicalSwapQuote(quote, 25n, token0, "basket-in")).toBe(false);
     expect(isCurrentCanonicalSwapQuote(quote, 26n, token0, "asset-in")).toBe(false);
+  });
+
+  it("serializes nested Permit2 values for Privy embedded signing", () => {
+    const typedData = buildPermit2PermitTypedData(
+      46_630,
+      token1,
+      permit2SwapApproval(token0, 25n, 7, token1, 1_000n)
+    );
+    const request = privyPermit2Request(typedData, token0);
+
+    expect(() => JSON.stringify(request)).not.toThrow();
+    expect(request.typedData.message).toEqual({
+      details: {
+        token: token0,
+        amount: "25",
+        expiration: "1000",
+        nonce: "7",
+      },
+      spender: token1,
+      sigDeadline: "1000",
+    });
+    expect(request.options).toEqual({
+      address: token0,
+      uiOptions: { showWalletUIs: false },
+    });
+  });
+
+  it("uses Privy only for embedded Permit2 signatures", async () => {
+    const calls: string[] = [];
+    const signature = await signPermit2ForWallet({
+      walletKind: "embedded",
+      typedData: "permit",
+      signEmbedded: async () => {
+        calls.push("embedded");
+        return "0x01";
+      },
+      signExternal: async () => {
+        calls.push("external");
+        return "0x02";
+      },
+    });
+
+    expect(signature).toBe("0x01");
+    expect(calls).toEqual(["embedded"]);
+  });
+
+  it("keeps external Permit2 signatures on the wallet client", async () => {
+    const calls: string[] = [];
+    const signature = await signPermit2ForWallet({
+      walletKind: "external",
+      typedData: "permit",
+      signEmbedded: async () => {
+        calls.push("embedded");
+        return "0x01";
+      },
+      signExternal: async () => {
+        calls.push("external");
+        return "0x02";
+      },
+    });
+
+    expect(signature).toBe("0x02");
+    expect(calls).toEqual(["external"]);
+  });
+
+  it("rejects Permit2 signing without a connected wallet type", async () => {
+    await expect(
+      signPermit2ForWallet({
+        walletKind: null,
+        typedData: "permit",
+        signEmbedded: async () => "0x01",
+        signExternal: async () => "0x02",
+      })
+    ).rejects.toThrow("The connected wallet type is unavailable.");
   });
 });

--- a/test/components/dollar-page.test.tsx
+++ b/test/components/dollar-page.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { DollarOverview, DollarPage } from "@/components/dollar/DollarPage";
+import { DollarOverview, DollarPage, DollarProfilePills } from "@/components/dollar/DollarPage";
 
 describe("Dollar surfaces without a deployment", () => {
   it("allows local action selection without enabling transactions", () => {
@@ -9,9 +9,11 @@ describe("Dollar surfaces without a deployment", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Recombine" }));
     fireEvent.click(screen.getByRole("button", { name: "WETH" }));
+    fireEvent.click(screen.getByRole("button", { name: "USDG" }));
+    expect(screen.getByRole("button", { name: "Redeem" })).toBeInTheDocument();
     expect(
       screen
-        .getAllByRole("button", { name: "Recombine" })
+        .getAllByRole("button", { name: "Deposit" })
         .filter((button) => button.hasAttribute("disabled"))
     ).toHaveLength(1);
   });
@@ -22,5 +24,18 @@ describe("Dollar surfaces without a deployment", () => {
       "href",
       "/app/positions"
     );
+  });
+
+  it("offers USDG as the third collateral profile", () => {
+    const onChange = vi.fn();
+    render(<DollarProfilePills value="ETH" peggedAvailable disabled={false} onChange={onChange} />);
+
+    expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
+      "ETH",
+      "WETH",
+      "USDG",
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "USDG" }));
+    expect(onChange).toHaveBeenCalledWith("USDG");
   });
 });

--- a/test/components/dollar-page.test.tsx
+++ b/test/components/dollar-page.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { DollarOverview, DollarPage, DollarProfilePills } from "@/components/dollar/DollarPage";
+import {
+  DollarOverview,
+  DollarPage,
+  DollarProfileContent,
+  DollarProfilePills,
+} from "@/components/dollar/DollarPage";
 
 describe("Dollar surfaces without a deployment", () => {
   it("allows local action selection without enabling transactions", () => {
@@ -37,5 +42,29 @@ describe("Dollar surfaces without a deployment", () => {
     ]);
     fireEvent.click(screen.getByRole("button", { name: "USDG" }));
     expect(onChange).toHaveBeenCalledWith("USDG");
+  });
+
+  it("renders only the controls for the selected collateral profile", () => {
+    const { rerender } = render(
+      <DollarProfileContent
+        profile="USDG"
+        volatile={<button type="button">Deposit WETH</button>}
+        pegged={<button type="button">Deposit USDG</button>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Deposit USDG" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Deposit WETH" })).not.toBeInTheDocument();
+
+    rerender(
+      <DollarProfileContent
+        profile="WETH"
+        volatile={<button type="button">Deposit WETH</button>}
+        pegged={<button type="button">Deposit USDG</button>}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Deposit WETH" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Deposit USDG" })).not.toBeInTheDocument();
   });
 });

--- a/test/components/pegged-dollar-panel.test.tsx
+++ b/test/components/pegged-dollar-panel.test.tsx
@@ -36,4 +36,17 @@ describe("pegged Dollar wallet states", () => {
 
     expect(screen.getByRole("button", { name: "Wallet loading…" })).toBeDisabled();
   });
+
+  it("uses deposit language when embedded on the Dollar page", () => {
+    const onPendingChange = vi.fn();
+    const { unmount } = render(
+      <WalletContext.Provider value={{ ...defaultWalletState, status: "loading" }}>
+        <PeggedDollarPanel embedded onPendingChange={onPendingChange} />
+      </WalletContext.Provider>
+    );
+
+    expect(screen.getByRole("button", { name: "Deposit" })).toHaveAttribute("aria-pressed", "true");
+    unmount();
+    expect(onPendingChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/test/components/pegged-dollar-panel.test.tsx
+++ b/test/components/pegged-dollar-panel.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@privy-io/react-auth", () => ({
+  useSignTypedData: () => ({ signTypedData: vi.fn() }),
+}));
+
 import { PeggedDollarPanel } from "@/components/portal/PeggedDollarPanel";
 import { WalletContext, defaultWalletState } from "@/providers/wallet-context";
 

--- a/test/components/position-collateral-summary.test.tsx
+++ b/test/components/position-collateral-summary.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PositionCollateralSummary } from "@/components/positions/PositionCollateralSummary";
+import type { PositionCollateral } from "@/lib/positions/positions";
+
+const collateral = [
+  {
+    basket: {
+      basketId: 0n,
+      symbol: "TPA1",
+      token: { decimals: 18 },
+    },
+    depositedShares: 200n * 10n ** 18n,
+    lockedShares: 25n * 10n ** 18n,
+    withdrawableAfterBlock: 100n,
+  },
+] as unknown as readonly PositionCollateral[];
+
+describe("position collateral summary", () => {
+  it("shows deposited, available, and loan-locked BasketTokens", () => {
+    render(<PositionCollateralSummary collateral={collateral} currentBlock={101n} />);
+
+    expect(screen.getByText("200 TPA1")).toBeInTheDocument();
+    expect(screen.getByText("175 TPA1")).toBeInTheDocument();
+    expect(screen.getByText("25 TPA1")).toBeInTheDocument();
+    expect(screen.getByText(/belong to this PositionNFT/i)).toBeInTheDocument();
+  });
+
+  it("shows the next-block withdrawal gate without hiding ownership", () => {
+    render(<PositionCollateralSummary collateral={collateral} currentBlock={99n} compact />);
+
+    expect(screen.getByText("200 TPA1")).toBeInTheDocument();
+    expect(screen.getByText("Next block")).toBeInTheDocument();
+  });
+});

--- a/test/dollar/action-state.test.ts
+++ b/test/dollar/action-state.test.ts
@@ -102,17 +102,23 @@ describe("Dollar action availability", () => {
     ).toMatchObject({ kind: "blocked", reason: expect.stringContaining("debt ceiling") });
   });
 
-  it("presents exact WETH approval and then the deposit as separate next actions", () => {
+  it("accepts reusable WETH approval and then presents the deposit", () => {
     expect(
       derive({
         asset: "WETH",
         snapshot: { ...healthySnapshot, wethAllowance: 0n },
       })
-    ).toMatchObject({ kind: "approve-weth", label: "Approve exact WETH", executable: true });
+    ).toMatchObject({ kind: "approve-weth", label: "Enable WETH deposits", executable: true });
     expect(derive({ asset: "WETH" })).toMatchObject({
       kind: "execute",
       label: "Deposit WETH",
     });
+    expect(
+      derive({
+        asset: "WETH",
+        snapshot: { ...healthySnapshot, wethAllowance: amount + 1n },
+      })
+    ).toMatchObject({ kind: "execute", label: "Deposit WETH" });
   });
 
   it("uses recombination-specific recovery and balance rules", () => {

--- a/test/dollar/permit.test.ts
+++ b/test/dollar/permit.test.ts
@@ -1,11 +1,13 @@
 import { serializeSignature } from "viem";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   PERMIT_TTL_SECONDS,
   decodePermitSignature,
   exactPeggedMintPermitValue,
   permitDeadline,
+  privyPermitRequest,
+  signPermitForWallet,
 } from "@/lib/dollar/permit";
 
 describe("Dollar permit helpers", () => {
@@ -32,5 +34,81 @@ describe("Dollar permit helpers", () => {
     expect(() => exactPeggedMintPermitValue(106n, 105n)).toThrow(
       "The required USDG moved above the reviewed maximum."
     );
+  });
+
+  it("uses Privy's signer directly for embedded-wallet permits", async () => {
+    const embedded = vi.fn().mockResolvedValue("0x11" as const);
+    const external = vi.fn().mockResolvedValue("0x22" as const);
+
+    await expect(
+      signPermitForWallet({
+        walletKind: "embedded",
+        typedData: { primaryType: "Permit" },
+        signEmbedded: embedded,
+        signExternal: external,
+      })
+    ).resolves.toBe("0x11");
+    expect(embedded).toHaveBeenCalledOnce();
+    expect(external).not.toHaveBeenCalled();
+  });
+
+  it("builds Privy's headless intermediate permit request", () => {
+    const typedData = {
+      domain: {
+        name: "Mock USDG",
+        version: "1",
+        chainId: 46_630,
+        verifyingContract: "0x0000000000000000000000000000000000000001",
+      },
+      types: {
+        Permit: [
+          { name: "owner", type: "address" },
+          { name: "spender", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+        ],
+      },
+      primaryType: "Permit",
+      message: {
+        owner: "0x0000000000000000000000000000000000000002",
+        spender: "0x0000000000000000000000000000000000000003",
+        value: 123n,
+        nonce: 4n,
+        deadline: 567n,
+      },
+    } as const;
+
+    const request = privyPermitRequest(typedData, "0x0000000000000000000000000000000000000002");
+
+    expect(request.typedData.message).toMatchObject({
+      value: "123",
+      nonce: "4",
+      deadline: "567",
+    });
+    expect(request.options).toEqual({
+      address: "0x0000000000000000000000000000000000000002",
+      uiOptions: {
+        showWalletUIs: false,
+      },
+    });
+    expect(() => JSON.stringify(request)).not.toThrow();
+    expect(typedData.message.value).toBe(123n);
+  });
+
+  it("keeps external-wallet permits on their provider signer", async () => {
+    const embedded = vi.fn().mockResolvedValue("0x11" as const);
+    const external = vi.fn().mockResolvedValue("0x22" as const);
+
+    await expect(
+      signPermitForWallet({
+        walletKind: "external",
+        typedData: { primaryType: "Permit" },
+        signEmbedded: embedded,
+        signExternal: external,
+      })
+    ).resolves.toBe("0x22");
+    expect(external).toHaveBeenCalledOnce();
+    expect(embedded).not.toHaveBeenCalled();
   });
 });

--- a/test/e2e/foundation.spec.ts
+++ b/test/e2e/foundation.spec.ts
@@ -149,6 +149,9 @@ test.describe("Dollar DApp foundation", () => {
     await navigateDapp(page, "/app/activity");
     await expect(page).toHaveURL(/\/app\/activity$/);
 
+    await navigateDapp(page, "/app/tools");
+    await expect(page).toHaveURL(/\/app\/tools$/);
+
     await navigateDapp(page, "/app/settings");
     await expect(page).toHaveURL(/\/app\/settings$/);
   });
@@ -225,6 +228,7 @@ test.describe("Dollar DApp foundation", () => {
       "/app/loans",
       "/app/rewards",
       "/app/liquidity",
+      "/app/tools",
     ]) {
       await page.goto(route);
       const overflow = await page

--- a/test/foundation/dapp-navigation.test.ts
+++ b/test/foundation/dapp-navigation.test.ts
@@ -23,6 +23,7 @@ describe("DApp route presentation", () => {
     ["/app/liquidity", "Liquidity", "Provide liquidity"],
     ["/app/activity", "Activity", "Your activity"],
     ["/app/settings", "Settings", "Settings"],
+    ["/app/tools", "Tools", "Approval tools"],
   ])("selects %s presentation", (pathname, label, title) => {
     expect(getDappRoutePresentation(pathname)).toMatchObject({ label, title });
   });

--- a/test/foundation/route-copy.test.ts
+++ b/test/foundation/route-copy.test.ts
@@ -92,7 +92,7 @@ describe("dapp navigation grouping", () => {
     // Regrouping must not silently drop or duplicate a destination.
     const hrefs = appNavigationGroups.flatMap((group) => group.items.map((item) => item.href));
     expect(new Set(hrefs).size).toBe(hrefs.length);
-    expect(hrefs).toHaveLength(10);
+    expect(hrefs).toHaveLength(11);
   });
 
   it("keeps the flattened list in step with the groups", () => {
@@ -127,6 +127,7 @@ describe("sidebar completeness", () => {
       "Wallet",
       "Activity",
       "Settings",
+      "Tools",
     ]);
   });
 
@@ -136,6 +137,7 @@ describe("sidebar completeness", () => {
       "/app/wallet",
       "/app/activity",
       "/app/settings",
+      "/app/tools",
     ]);
   });
 });

--- a/test/loans/loans.test.ts
+++ b/test/loans/loans.test.ts
@@ -9,6 +9,8 @@ import {
   hasExtensionExcess,
   isCurrentBorrowQuote,
   isCurrentExtensionQuote,
+  loadBorrowQuote,
+  loadExtensionQuote,
   loadLoanCatalog,
   loanTimeline,
   validateExtensionGrossAmounts,
@@ -28,6 +30,7 @@ const wallet = "0x0000000000000000000000000000000000000001" as Address;
 const diamond = "0x0000000000000000000000000000000000000002" as Address;
 const basketToken = "0x0000000000000000000000000000000000000003" as Address;
 const asset = "0x0000000000000000000000000000000000000004" as Address;
+const secondAsset = "0x1FBE1a0e43594b3455993B5dE5Fd0A7A266298d0" as Address;
 
 const basket = {
   basketId: 0n,
@@ -57,6 +60,19 @@ const basket = {
       vaultBalance: 100_000_000n,
       walletBalance: 20_000_000n,
       allowance: 10_000_000n,
+    },
+    {
+      token: {
+        address: secondAsset,
+        name: "Second Asset",
+        symbol: "TWO",
+        decimals: 18,
+        metadataAvailable: true,
+      },
+      bundleAmount: 1n,
+      vaultBalance: 100n,
+      walletBalance: 20n,
+      allowance: 10n,
     },
   ],
   mintFeeTiers: [],
@@ -214,8 +230,8 @@ describe("loan lifecycle state", () => {
             collateralShares: 90n,
             feeShares: 1n,
             maturity: loanId === 1n ? 6_000n : 1_000n,
-            assets: [asset],
-            principals: [75n],
+            assets: [asset, secondAsset],
+            principals: [75n, 65n],
           };
         }
         if (functionName === "ownerOf") {
@@ -239,10 +255,47 @@ describe("loan lifecycle state", () => {
     );
 
     expect(catalog.ownedLoans.map((loan) => loan.loanId)).toEqual([1n]);
+    expect(catalog.ownedLoans[0]?.assets.map((loanAsset) => loanAsset.token.address)).toEqual([
+      asset,
+      secondAsset,
+    ]);
     expect(catalog.publicRecoverableLoans.map((loan) => loan.loanId)).toEqual([3n]);
     expect(readContract).not.toHaveBeenCalledWith(
       expect.objectContaining({ functionName: "loan", args: [2n] })
     );
+  });
+
+  it("preserves canonical addresses across multi-asset borrow and extension quotes", async () => {
+    const publicClient = {
+      readContract: vi.fn(async ({ functionName }: { functionName: string }) => {
+        if (functionName === "quoteBorrow") {
+          return {
+            feeShares: 1n,
+            collateralShares: 99n,
+            debtShares: 90n,
+            penaltyShares: 5n,
+            assets: [asset, secondAsset],
+            principals: [45n, 45n],
+          };
+        }
+        if (functionName === "quoteExtension") {
+          return [
+            [asset, secondAsset],
+            [2n, 3n],
+          ] as const;
+        }
+        throw new Error(`Unexpected read ${functionName}`);
+      }),
+    } as unknown as PublicClient;
+
+    await expect(loadBorrowQuote(publicClient, deployment, 0n, 100n)).resolves.toMatchObject({
+      assets: [asset, secondAsset],
+    });
+    await expect(loadExtensionQuote(publicClient, deployment, 1n)).resolves.toEqual({
+      loanId: 1n,
+      assets: [asset, secondAsset],
+      requiredFees: [2n, 3n],
+    });
   });
 
   it("fails closed when an active loan read fails for a reason other than closure", async () => {

--- a/test/protocol/approvals.test.ts
+++ b/test/protocol/approvals.test.ts
@@ -1,0 +1,135 @@
+import { decodeFunctionData, getAddress, zeroAddress } from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  basketTokenAbi,
+  permit2AllowanceAbi,
+  v4PositionManagerReadAbi,
+} from "@statics-protocol/sdk";
+
+import { buildApprovalUpdate, type ApprovalRecord } from "@/lib/protocol/approval-inventory";
+import {
+  MAX_ERC20_ALLOWANCE,
+  MAX_PERMIT2_ALLOWANCE,
+  MAX_PERMIT2_EXPIRATION,
+  approvalStatusLabel,
+  hasUsablePermit2Allowance,
+  operatorApprovalAbi,
+} from "@/lib/protocol/approvals";
+
+const token = getAddress("0x0000000000000000000000000000000000000001");
+const spender = getAddress("0x0000000000000000000000000000000000000002");
+const permit2 = getAddress("0x0000000000000000000000000000000000000003");
+
+function record(overrides: Partial<ApprovalRecord> = {}): ApprovalRecord {
+  return {
+    key: "approval",
+    kind: "erc20",
+    authorityContract: token,
+    token,
+    tokenName: "Token",
+    tokenSymbol: "TKN",
+    spender,
+    spenderLabel: "StaticsDiamond",
+    purposes: ["Basket minting"],
+    allowance: 0n,
+    ...overrides,
+  };
+}
+
+describe("application approval policy", () => {
+  it("recognizes maximum, custom, and revoked authority", () => {
+    expect(approvalStatusLabel("erc20", 0n)).toBe("Revoked");
+    expect(approvalStatusLabel("erc20", 5n)).toBe("Custom");
+    expect(approvalStatusLabel("erc20", MAX_ERC20_ALLOWANCE)).toBe("Maximum");
+    expect(approvalStatusLabel("permit2", MAX_PERMIT2_ALLOWANCE, MAX_PERMIT2_EXPIRATION)).toBe(
+      "Maximum"
+    );
+    expect(approvalStatusLabel("permit2", 5n, 999, 1_000)).toBe("Revoked");
+    expect(approvalStatusLabel("operator", 1n)).toBe("Maximum");
+  });
+
+  it("requires both sufficient Permit2 amount and an unexpired authorization", () => {
+    expect(hasUsablePermit2Allowance(10n, 1_001, 10n, 1_000)).toBe(true);
+    expect(hasUsablePermit2Allowance(9n, 1_001, 10n, 1_000)).toBe(false);
+    expect(hasUsablePermit2Allowance(10n, 1_000, 10n, 1_000)).toBe(false);
+  });
+
+  it("builds maximum and zero ERC20 allowance updates", () => {
+    const maximum = decodeFunctionData({
+      abi: basketTokenAbi,
+      data: buildApprovalUpdate(record(), true).data,
+    });
+    const revoked = decodeFunctionData({
+      abi: basketTokenAbi,
+      data: buildApprovalUpdate(record(), false).data,
+    });
+
+    expect(maximum).toMatchObject({
+      functionName: "approve",
+      args: [spender, MAX_ERC20_ALLOWANCE],
+    });
+    expect(revoked).toMatchObject({ functionName: "approve", args: [spender, 0n] });
+  });
+
+  it("builds maximum and zero Permit2 allowance updates", () => {
+    const approval = record({
+      kind: "permit2",
+      authorityContract: permit2,
+      expiration: 0,
+    });
+    const maximum = decodeFunctionData({
+      abi: permit2AllowanceAbi,
+      data: buildApprovalUpdate(approval, true).data,
+    });
+    const revoked = decodeFunctionData({
+      abi: permit2AllowanceAbi,
+      data: buildApprovalUpdate(approval, false).data,
+    });
+
+    expect(maximum).toMatchObject({
+      functionName: "approve",
+      args: [token, spender, MAX_PERMIT2_ALLOWANCE, MAX_PERMIT2_EXPIRATION],
+    });
+    expect(revoked).toMatchObject({
+      functionName: "approve",
+      args: [token, spender, 0n, 0],
+    });
+  });
+
+  it("builds broad operator enable and revoke updates", () => {
+    const approval = record({ kind: "operator" });
+    const maximum = decodeFunctionData({
+      abi: operatorApprovalAbi,
+      data: buildApprovalUpdate(approval, true).data,
+    });
+    const revoked = decodeFunctionData({
+      abi: operatorApprovalAbi,
+      data: buildApprovalUpdate(approval, false).data,
+    });
+
+    expect(maximum).toMatchObject({
+      functionName: "setApprovalForAll",
+      args: [spender, true],
+    });
+    expect(revoked).toMatchObject({
+      functionName: "setApprovalForAll",
+      args: [spender, false],
+    });
+  });
+
+  it("revokes legacy per-position v4 approvals", () => {
+    const approval = record({ kind: "erc721-token", tokenId: 42n });
+    const maximum = decodeFunctionData({
+      abi: v4PositionManagerReadAbi,
+      data: buildApprovalUpdate(approval, true).data,
+    });
+    const revoked = decodeFunctionData({
+      abi: v4PositionManagerReadAbi,
+      data: buildApprovalUpdate(approval, false).data,
+    });
+
+    expect(maximum).toMatchObject({ functionName: "approve", args: [spender, 42n] });
+    expect(revoked).toMatchObject({ functionName: "approve", args: [zeroAddress, 42n] });
+  });
+});


### PR DESCRIPTION
## Summary

- expose the USDG profile and clarify deposited basket holdings
- preserve multi-asset addresses and embedded-wallet Permit2 signing
- add reusable approval and authority controls for protocol actions

## Stack

5 of 8. Merge after #4. This boundary is not intended to be a standalone production release.

## Validation

The complete stacked head at e42473e passes `npm run verify`; this historical boundary was not rerun separately.