### PR TITLE
Fix transaction balance reconciliation

### DIFF
--- a/components/baskets/BasketDetailPage.tsx
+++ b/components/baskets/BasketDetailPage.tsx
@@ -442,8 +442,8 @@ function BasketDetailRuntime({
                 ? `Redeem ${basket.symbol} from position`
                 : `Redeem ${basket.symbol}`
               : collateralFunction
-                ? `Buy and deposit ${basket.symbol}`
-                : `Buy ${basket.symbol}`,
+                ? `Mint and deposit ${basket.symbol}`
+                : `Mint ${basket.symbol}`,
           to: deploymentState.deployment.contracts.diamond,
           data,
           value:

--- a/components/baskets/BasketSwapPanel.tsx
+++ b/components/baskets/BasketSwapPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { decodeFunctionResult, encodeFunctionData, formatUnits, getAddress } from "viem";
@@ -36,6 +36,7 @@ import {
   verifyLiquidityDeployment,
 } from "@/lib/dollar/deployment";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { protocolQueryKeys } from "@/lib/protocol/query-keys";
 import {
   MAX_PERMIT2_ALLOWANCE,
   MAX_PERMIT2_EXPIRATION,
@@ -59,6 +60,7 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
   const walletState = useWalletState();
   const publicClient = usePublicClient();
   const walletClient = useWalletClient();
+  const queryClient = useQueryClient();
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
   const [assetIndex, setAssetIndex] = useState(0);
@@ -390,7 +392,17 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
         },
       });
       setAmountInput("");
-      await quote.refetch();
+      await Promise.all([
+        quote.refetch(),
+        queryClient.refetchQueries({
+          queryKey: protocolQueryKeys.basketCatalog(
+            deploymentState.deployment.protocolCommit,
+            wallet
+          ),
+          exact: true,
+          type: "active",
+        }),
+      ]);
     } catch (cause) {
       setError(describeBasketError(cause));
     } finally {

--- a/components/dollar/DollarPage.tsx
+++ b/components/dollar/DollarPage.tsx
@@ -915,7 +915,14 @@ function DollarActionPanel({
         });
         setAmountInput("");
       }
-      await snapshot.refetch();
+      await Promise.all([
+        snapshot.refetch(),
+        ...(supplySeriesId !== undefined &&
+        Boolean(supplyPeriphery) &&
+        supplyPeriphery !== zeroAddress
+          ? [supplyState.refetch()]
+          : []),
+      ]);
     } catch (error) {
       setActionError(describeDollarError(error));
     } finally {

--- a/components/wallet/WalletNftList.tsx
+++ b/components/wallet/WalletNftList.tsx
@@ -32,7 +32,7 @@ export function WalletNftList({
       <div className="ui-empty">
         <h3 className="ui-empty-title">No NFTs yet</h3>
         <p className="ui-empty-description">
-          Positions and liquidity positions appear here. Buy a basket or supply liquidity and the
+          Positions and liquidity positions appear here. Mint a basket or supply liquidity and the
           NFT that represents it shows up in your wallet.
         </p>
       </div>

--- a/components/wallet/WalletNftPanel.tsx
+++ b/components/wallet/WalletNftPanel.tsx
@@ -148,7 +148,7 @@ export function WalletNftPanel({
           empty={{
             title: "No NFTs yet",
             description:
-              "Positions and liquidity positions appear here. Buy a basket or supply liquidity and the NFT that represents it shows up in your wallet.",
+              "Positions and liquidity positions appear here. Mint a basket or supply liquidity and the NFT that represents it shows up in your wallet.",
             action: { label: "Browse baskets", href: "/app/baskets" },
           }}
         />

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -38,10 +38,7 @@ import { TokenLogo } from "@/components/wallet/TokenLogo";
 import { useWalletTokens } from "@/hooks/useWalletTokens";
 import { getFundingNetwork } from "@/lib/funding-networks";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
-import {
-  scheduleProtocolReconciliation,
-  subscribeToProtocolTransactions,
-} from "@/lib/protocol/reconciliation";
+import { subscribeToProtocolReconciliation } from "@/lib/protocol/reconciliation";
 import { searchTokenList } from "@/lib/token-list";
 import { getNativeTokenLogoURI } from "@/lib/token-icons";
 import type { WalletToken } from "@/lib/wallet-tokens";
@@ -209,22 +206,14 @@ export function WalletPage() {
   });
 
   useEffect(() => {
-    const cancellations = new Set<() => void>();
-    const unsubscribe = subscribeToProtocolTransactions((confirmed) => {
-      if (
-        !wallet.address ||
-        confirmed.chainId !== wallet.fundingChainId ||
-        confirmed.wallet.toLowerCase() !== wallet.address.toLowerCase()
-      ) {
-        return;
-      }
-      const cancel = scheduleProtocolReconciliation(() => refreshBalancesRef.current());
-      cancellations.add(cancel);
-    });
-    return () => {
-      unsubscribe();
-      cancellations.forEach((cancel) => cancel());
-    };
+    const walletAddress = wallet.address?.toLowerCase();
+    return subscribeToProtocolReconciliation(
+      () => refreshBalancesRef.current(),
+      (confirmed) =>
+        walletAddress !== undefined &&
+        confirmed.chainId === wallet.fundingChainId &&
+        confirmed.wallet.toLowerCase() === walletAddress
+    );
   }, [wallet.address, wallet.fundingChainId]);
 
   useEffect(() => {

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -38,6 +38,10 @@ import { TokenLogo } from "@/components/wallet/TokenLogo";
 import { useWalletTokens } from "@/hooks/useWalletTokens";
 import { getFundingNetwork } from "@/lib/funding-networks";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import {
+  scheduleProtocolReconciliation,
+  subscribeToProtocolTransactions,
+} from "@/lib/protocol/reconciliation";
 import { searchTokenList } from "@/lib/token-list";
 import { getNativeTokenLogoURI } from "@/lib/token-icons";
 import type { WalletToken } from "@/lib/wallet-tokens";
@@ -198,6 +202,30 @@ export function WalletPage() {
       if (currentRefresh === refreshId.current) setRefreshing(false);
     }
   };
+
+  const refreshBalancesRef = useRef(refreshBalances);
+  useEffect(() => {
+    refreshBalancesRef.current = refreshBalances;
+  });
+
+  useEffect(() => {
+    const cancellations = new Set<() => void>();
+    const unsubscribe = subscribeToProtocolTransactions((confirmed) => {
+      if (
+        !wallet.address ||
+        confirmed.chainId !== wallet.fundingChainId ||
+        confirmed.wallet.toLowerCase() !== wallet.address.toLowerCase()
+      ) {
+        return;
+      }
+      const cancel = scheduleProtocolReconciliation(() => refreshBalancesRef.current());
+      cancellations.add(cancel);
+    });
+    return () => {
+      unsubscribe();
+      cancellations.forEach((cancel) => cancel());
+    };
+  }, [wallet.address, wallet.fundingChainId]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -57,7 +57,7 @@ const routePresentations = {
     status: "Baskets",
     title: "Baskets",
     description:
-      "Buy or sell a fixed bundle of assets as one unit. You will see exactly what a basket holds before you buy.",
+      "Mint or redeem a fixed bundle of assets as one unit. You will see exactly what a basket holds before you mint.",
   },
   positions: {
     label: "Positions",

--- a/lib/protocol/reconciliation.ts
+++ b/lib/protocol/reconciliation.ts
@@ -103,3 +103,25 @@ export function scheduleProtocolReconciliation(
   );
   return () => timers.forEach((timer) => globalThis.clearTimeout(timer));
 }
+
+/**
+ * Keep only the newest reconciliation schedule. Its reads include every state
+ * transition through the newest confirmed block, so retaining older schedules
+ * adds RPC work without preserving information.
+ */
+export function subscribeToProtocolReconciliation(
+  refresh: () => void | Promise<unknown>,
+  matches: (detail: ProtocolTransactionConfirmedDetail) => boolean = () => true,
+  delays: readonly number[] = QUERY_RECONCILIATION_DELAYS_MS
+): () => void {
+  let cancelReconciliation: (() => void) | null = null;
+  const unsubscribe = subscribeToProtocolTransactions((detail) => {
+    if (!matches(detail)) return;
+    cancelReconciliation?.();
+    cancelReconciliation = scheduleProtocolReconciliation(refresh, delays);
+  });
+  return () => {
+    unsubscribe();
+    cancelReconciliation?.();
+  };
+}

--- a/lib/protocol/reconciliation.ts
+++ b/lib/protocol/reconciliation.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import type { Address, PublicClient } from "viem";
+
+const RPC_CATCH_UP_DELAYS_MS = [0, 250, 750, 1_500, 3_000] as const;
+const QUERY_RECONCILIATION_DELAYS_MS = [0, 1_500, 4_000, 8_000] as const;
+
+export const PROTOCOL_TRANSACTION_CONFIRMED_EVENT = "statics:protocol-transaction-confirmed";
+
+export type ProtocolTransactionConfirmedDetail = Readonly<{
+  wallet: Address;
+  chainId: number;
+  blockNumber: bigint;
+}>;
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds));
+}
+
+/**
+ * A receipt can arrive before the RPC node used for reads serves that block.
+ * Wait briefly for `eth_blockNumber` to catch up before callers refresh state.
+ * Returning false keeps a confirmed transaction confirmed; scheduled query
+ * reconciliation below continues trying without pretending the write failed.
+ */
+export async function waitForRpcBlock(
+  publicClient: PublicClient,
+  blockNumber: bigint,
+  delays: readonly number[] = RPC_CATCH_UP_DELAYS_MS
+): Promise<boolean> {
+  for (const wait of delays) {
+    if (wait > 0) await delay(wait);
+    try {
+      const current = await publicClient.getBlockNumber({ cacheTime: 0 });
+      if (current >= blockNumber) return true;
+    } catch {
+      // A later attempt may land on a healthy RPC backend.
+    }
+  }
+  return false;
+}
+
+/**
+ * Confirmation verification is read-only and safe to repeat. A single stale
+ * read must not turn a successful transaction into a false verification error.
+ */
+export async function retryConfirmationVerification(
+  verify: () => Promise<void>,
+  delays: readonly number[] = RPC_CATCH_UP_DELAYS_MS
+): Promise<void> {
+  let lastError: unknown = new Error("Confirmed state could not be verified.");
+  for (const wait of delays) {
+    if (wait > 0) await delay(wait);
+    try {
+      await verify();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+export function announceProtocolTransactionConfirmed(
+  detail: ProtocolTransactionConfirmedDetail
+): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<ProtocolTransactionConfirmedDetail>(PROTOCOL_TRANSACTION_CONFIRMED_EVENT, {
+      detail,
+    })
+  );
+}
+
+export function subscribeToProtocolTransactions(
+  listener: (detail: ProtocolTransactionConfirmedDetail) => void
+): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  const handle = (event: Event) => {
+    listener((event as CustomEvent<ProtocolTransactionConfirmedDetail>).detail);
+  };
+  window.addEventListener(PROTOCOL_TRANSACTION_CONFIRMED_EVENT, handle);
+  return () => window.removeEventListener(PROTOCOL_TRANSACTION_CONFIRMED_EVENT, handle);
+}
+
+/**
+ * Refresh active state immediately, then retry at bounded intervals. This is
+ * deliberately transaction-triggered instead of permanent polling so normal
+ * browsing does not multiply RPC traffic.
+ */
+export function scheduleProtocolReconciliation(
+  refresh: () => void | Promise<unknown>,
+  delays: readonly number[] = QUERY_RECONCILIATION_DELAYS_MS
+): () => void {
+  const timers = delays.map((wait) =>
+    globalThis.setTimeout(() => {
+      try {
+        void Promise.resolve(refresh()).catch(() => undefined);
+      } catch {
+        // A later scheduled refresh can still reconcile the confirmed write.
+      }
+    }, wait)
+  );
+  return () => timers.forEach((timer) => globalThis.clearTimeout(timer));
+}

--- a/lib/protocol/transactions.ts
+++ b/lib/protocol/transactions.ts
@@ -10,6 +10,11 @@ import {
   type ProtocolReplacementReason,
 } from "@/lib/dollar/activity";
 import { isOnchainRevert, isWalletRejection } from "@/lib/dollar/transactions";
+import {
+  announceProtocolTransactionConfirmed,
+  retryConfirmationVerification,
+  waitForRpcBlock,
+} from "@/lib/protocol/reconciliation";
 
 export type ProtocolTransactionRequest = Readonly<{
   publicClient: PublicClient;
@@ -101,9 +106,18 @@ export async function executeProtocolTransaction(
       throw new Error(message);
     }
 
+    if (typeof receipt.blockNumber === "bigint") {
+      await waitForRpcBlock(request.publicClient, receipt.blockNumber);
+      announceProtocolTransactionConfirmed({
+        wallet: request.wallet,
+        chainId: request.chainId,
+        blockNumber: receipt.blockNumber,
+      });
+    }
+
     if (request.verifyConfirmation) {
       try {
-        await request.verifyConfirmation(receipt);
+        await retryConfirmationVerification(() => request.verifyConfirmation!(receipt));
       } catch (error) {
         const verificationError = new ConfirmationVerificationError(
           "The transaction confirmed, but refreshed protocol state could not be verified. Refresh before another action.",

--- a/lib/vocabulary.ts
+++ b/lib/vocabulary.ts
@@ -41,7 +41,7 @@ export const glossary = {
   },
   basket: {
     label: "Basket",
-    plain: "A fixed bundle of assets you can buy or sell as a single unit.",
+    plain: "A fixed bundle of assets you can mint or redeem as a single unit.",
     protocol: "Static basket",
   },
   underlying: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -94,7 +94,7 @@
       "label": "Baskets",
       "status": "Baskets",
       "title": "Baskets",
-      "description": "Buy or sell a fixed bundle of assets as one unit. You will see exactly what a basket holds before you buy."
+      "description": "Mint or redeem a fixed bundle of assets as one unit. You will see exactly what a basket holds before you mint."
     },
     "positions": {
       "label": "Positions",
@@ -200,7 +200,7 @@
     "discovered": "{count} discovered",
     "stale": "Basket data is temporarily unavailable. Showing the last received state.",
     "emptyTitle": "No baskets yet",
-    "emptyDescription": "A basket is a fixed bundle of assets you can buy or sell as one unit. New launches are currently steward-controlled.",
+    "emptyDescription": "A basket is a fixed bundle of assets you can mint or redeem as one unit. New launches are currently steward-controlled.",
     "viewPolicy": "View launch policy",
     "underlyings": "Underlyings",
     "totalSupply": "Total supply",
@@ -449,7 +449,7 @@
     "itsAssets": "its assets",
     "basketSubject": "basket rewards",
     "noBaskets": "No baskets deposited yet",
-    "noBasketsDescription": "Buy a basket with depositing switched on, and it starts earning a share of the trading fees on the assets it holds.",
+    "noBasketsDescription": "Mint a basket with depositing switched on, and it starts earning a share of the trading fees on the assets it holds.",
     "browseBaskets": "Browse baskets",
     "startEarning": "Start earning",
     "createAndStakeTitle": "Stake Statics",
@@ -596,7 +596,7 @@
     "wethOracle": "WETH oracle",
     "openDollar": "Open Dollar",
     "nothingHere": "Nothing here yet",
-    "nothingHereDescription": "Buy a basket and it starts earning more of the assets it holds. Or get Statics Dollar and stake it to earn in whichever assets you choose.",
+    "nothingHereDescription": "Mint a basket and it starts earning more of the assets it holds. Or get Statics Dollar and stake it to earn in whichever assets you choose.",
     "browseBaskets": "Browse baskets",
     "getDollar": "Get Statics Dollar",
     "earnedByBaskets": "Earned by your baskets",
@@ -777,7 +777,7 @@
     "basket": {
       "label": "Basket",
       "plural": "Baskets",
-      "plain": "A fixed bundle of assets you can buy or sell as a single unit."
+      "plain": "A fixed bundle of assets you can mint or redeem as a single unit."
     },
     "underlying": {
       "label": "Underlying",

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -18,7 +18,7 @@ import {
   useWallets as useSolanaWallets,
 } from "@privy-io/react-auth/solana";
 import { createConfig, WagmiProvider } from "@privy-io/wagmi";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
 
@@ -29,6 +29,10 @@ import {
 } from "@/lib/wallet-config";
 import { fundingNetworks, getFundingNetwork, isFundingChainId } from "@/lib/funding-networks";
 import { selectStaticsWallet } from "@/lib/wallet/selection";
+import {
+  scheduleProtocolReconciliation,
+  subscribeToProtocolTransactions,
+} from "@/lib/protocol/reconciliation";
 import { WalletContext, defaultWalletState, type WalletState } from "./wallet-context";
 import {
   defaultSolanaWalletState,
@@ -284,11 +288,32 @@ function UnconfiguredWalletBridge({ children }: { children: React.ReactNode }) {
   );
 }
 
+function ProtocolQueryReconciler() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const cancellations = new Set<() => void>();
+    const unsubscribe = subscribeToProtocolTransactions(() => {
+      const cancel = scheduleProtocolReconciliation(() =>
+        queryClient.refetchQueries({ type: "active" })
+      );
+      cancellations.add(cancel);
+    });
+    return () => {
+      unsubscribe();
+      cancellations.forEach((cancel) => cancel());
+    };
+  }, [queryClient]);
+
+  return null;
+}
+
 export function DAppProviders({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>
+      <ProtocolQueryReconciler />
       {walletEnvironment.configured ? (
         <ConfiguredWalletProviders>{children}</ConfiguredWalletProviders>
       ) : (

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -29,10 +29,7 @@ import {
 } from "@/lib/wallet-config";
 import { fundingNetworks, getFundingNetwork, isFundingChainId } from "@/lib/funding-networks";
 import { selectStaticsWallet } from "@/lib/wallet/selection";
-import {
-  scheduleProtocolReconciliation,
-  subscribeToProtocolTransactions,
-} from "@/lib/protocol/reconciliation";
+import { subscribeToProtocolReconciliation } from "@/lib/protocol/reconciliation";
 import { WalletContext, defaultWalletState, type WalletState } from "./wallet-context";
 import {
   defaultSolanaWalletState,
@@ -291,19 +288,10 @@ function UnconfiguredWalletBridge({ children }: { children: React.ReactNode }) {
 function ProtocolQueryReconciler() {
   const queryClient = useQueryClient();
 
-  useEffect(() => {
-    const cancellations = new Set<() => void>();
-    const unsubscribe = subscribeToProtocolTransactions(() => {
-      const cancel = scheduleProtocolReconciliation(() =>
-        queryClient.refetchQueries({ type: "active" })
-      );
-      cancellations.add(cancel);
-    });
-    return () => {
-      unsubscribe();
-      cancellations.forEach((cancel) => cancel());
-    };
-  }, [queryClient]);
+  useEffect(
+    () => subscribeToProtocolReconciliation(() => queryClient.refetchQueries({ type: "active" })),
+    [queryClient]
+  );
 
   return null;
 }

--- a/test/dollar/supply.test.ts
+++ b/test/dollar/supply.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -79,6 +81,13 @@ describe("Risk supply Position selection", () => {
 });
 
 describe("supplying Risk Shares as redemption liquidity", () => {
+  it("refreshes supply state after another Dollar action changes the wallet balance", () => {
+    const dollarPage = fs.readFileSync("components/dollar/DollarPage.tsx", "utf8");
+
+    expect(dollarPage).toContain("snapshot.refetch(),");
+    expect(dollarPage).toContain("? [supplyState.refetch()]");
+  });
+
   it("asks for approval before it can pull shares in", () => {
     const next = deriveSupplyStep(
       100n,

--- a/test/foundation/basket-action-boundaries.test.ts
+++ b/test/foundation/basket-action-boundaries.test.ts
@@ -41,4 +41,11 @@ describe("basket action ownership", () => {
     expect(basketDetail).not.toContain("`Buy ${basket.symbol}`");
     expect(basketDetail).not.toContain("`Buy and deposit ${basket.symbol}`");
   });
+
+  it("refreshes the balance-bearing basket catalog after a swap", () => {
+    const basketSwap = read("components/baskets/BasketSwapPanel.tsx");
+
+    expect(basketSwap).toContain("protocolQueryKeys.basketCatalog(");
+    expect(basketSwap).toContain("queryClient.refetchQueries({");
+  });
 });

--- a/test/foundation/basket-action-boundaries.test.ts
+++ b/test/foundation/basket-action-boundaries.test.ts
@@ -32,4 +32,13 @@ describe("basket action ownership", () => {
     expect(positionDetail).toContain("?action=mint&positionId=");
     expect(positionDetail).toContain("?action=redeem&positionId=");
   });
+
+  it("describes basket creation as minting in transaction activity", () => {
+    const basketDetail = read("components/baskets/BasketDetailPage.tsx");
+
+    expect(basketDetail).toContain("`Mint ${basket.symbol}`");
+    expect(basketDetail).toContain("`Mint and deposit ${basket.symbol}`");
+    expect(basketDetail).not.toContain("`Buy ${basket.symbol}`");
+    expect(basketDetail).not.toContain("`Buy and deposit ${basket.symbol}`");
+  });
 });

--- a/test/foundation/no-wallet-runtime.test.ts
+++ b/test/foundation/no-wallet-runtime.test.ts
@@ -40,6 +40,7 @@ describe("wallet runtime boundary", () => {
     expect(bridge).toBeGreaterThan(wagmiProvider);
     expect(source).toContain('walletChainType: "ethereum-and-solana"');
     expect(source).toContain("defaultSolanaRpcsPlugin()");
+    expect(source).toContain("<ProtocolQueryReconciler />");
     expect(source).not.toMatch(/addSigners|delegateWallet|policyIds/);
   });
 });

--- a/test/protocol/reconciliation.test.ts
+++ b/test/protocol/reconciliation.test.ts
@@ -1,0 +1,64 @@
+import type { Address, PublicClient } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  announceProtocolTransactionConfirmed,
+  retryConfirmationVerification,
+  scheduleProtocolReconciliation,
+  subscribeToProtocolTransactions,
+  waitForRpcBlock,
+} from "@/lib/protocol/reconciliation";
+
+describe("confirmed transaction reconciliation", () => {
+  it("waits until the read RPC serves the confirmed block", async () => {
+    const getBlockNumber = vi.fn().mockResolvedValueOnce(99n).mockResolvedValueOnce(100n);
+
+    await expect(
+      waitForRpcBlock({ getBlockNumber } as unknown as PublicClient, 100n, [0, 0])
+    ).resolves.toBe(true);
+    expect(getBlockNumber).toHaveBeenCalledTimes(2);
+    expect(getBlockNumber).toHaveBeenCalledWith({ cacheTime: 0 });
+  });
+
+  it("retries a stale confirmation read before reporting failure", async () => {
+    const verify = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("stale balance"))
+      .mockResolvedValueOnce();
+
+    await expect(retryConfirmationVerification(verify, [0, 0])).resolves.toBeUndefined();
+    expect(verify).toHaveBeenCalledTimes(2);
+  });
+
+  it("announces the wallet, chain, and block that need reconciliation", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToProtocolTransactions(listener);
+    const detail = {
+      wallet: "0x0000000000000000000000000000000000000001" as Address,
+      chainId: 46_630,
+      blockNumber: 123n,
+    };
+
+    announceProtocolTransactionConfirmed(detail);
+
+    expect(listener).toHaveBeenCalledWith(detail);
+    unsubscribe();
+  });
+
+  it("runs bounded refresh passes and supports cancellation", async () => {
+    vi.useFakeTimers();
+    try {
+      const refresh = vi.fn();
+      const cancel = scheduleProtocolReconciliation(refresh, [0, 10, 20]);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(refresh).toHaveBeenCalledTimes(2);
+
+      cancel();
+      await vi.runAllTimersAsync();
+      expect(refresh).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/test/protocol/reconciliation.test.ts
+++ b/test/protocol/reconciliation.test.ts
@@ -5,6 +5,7 @@ import {
   announceProtocolTransactionConfirmed,
   retryConfirmationVerification,
   scheduleProtocolReconciliation,
+  subscribeToProtocolReconciliation,
   subscribeToProtocolTransactions,
   waitForRpcBlock,
 } from "@/lib/protocol/reconciliation";
@@ -55,6 +56,29 @@ describe("confirmed transaction reconciliation", () => {
       expect(refresh).toHaveBeenCalledTimes(2);
 
       cancel();
+      await vi.runAllTimersAsync();
+      expect(refresh).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("replaces an older transaction schedule and cancels the latest on unsubscribe", async () => {
+    vi.useFakeTimers();
+    try {
+      const refresh = vi.fn();
+      const wallet = "0x0000000000000000000000000000000000000001" as Address;
+      const unsubscribe = subscribeToProtocolReconciliation(refresh, () => true, [10, 20]);
+
+      announceProtocolTransactionConfirmed({ wallet, chainId: 46_630, blockNumber: 100n });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(refresh).toHaveBeenCalledTimes(1);
+
+      announceProtocolTransactionConfirmed({ wallet, chainId: 46_630, blockNumber: 101n });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(refresh).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
       await vi.runAllTimersAsync();
       expect(refresh).toHaveBeenCalledTimes(2);
     } finally {

--- a/test/protocol/transactions.test.ts
+++ b/test/protocol/transactions.test.ts
@@ -15,9 +15,11 @@ describe("protocol transaction execution", () => {
 
   it("simulates before signing and reports success only after a confirmed receipt", async () => {
     const call = vi.fn().mockResolvedValue({ data: "0x01" });
+    const getBlockNumber = vi.fn().mockResolvedValue(17n);
     const waitForTransactionReceipt = vi.fn().mockResolvedValue({
       status: "success",
       transactionHash: hash,
+      blockNumber: 17n,
     });
     const sendTransaction = vi.fn().mockResolvedValue(hash);
 
@@ -25,6 +27,7 @@ describe("protocol transaction execution", () => {
       executeProtocolTransaction({
         publicClient: {
           call,
+          getBlockNumber,
           waitForTransactionReceipt,
         } as unknown as PublicClient,
         wallet,
@@ -43,6 +46,7 @@ describe("protocol transaction execution", () => {
     expect(waitForTransactionReceipt).toHaveBeenCalledWith(
       expect.objectContaining({ hash, confirmations: 1 })
     );
+    expect(getBlockNumber).toHaveBeenCalledWith({ cacheTime: 0 });
     expect(readProtocolActivity(wallet, 31_337)[0]).toMatchObject({
       kind: "create-position",
       status: "confirmed",
@@ -84,8 +88,9 @@ describe("protocol transaction execution", () => {
   it("preserves a confirmed receipt when refreshed state cannot be verified", async () => {
     const verificationFailure = new Error("Loan state remained stale");
 
-    await expect(
-      executeProtocolTransaction({
+    vi.useFakeTimers();
+    try {
+      const execution = executeProtocolTransaction({
         publicClient: {
           call: vi.fn().mockResolvedValue({ data: "0x" }),
           waitForTransactionReceipt: vi.fn().mockResolvedValue({
@@ -105,8 +110,15 @@ describe("protocol transaction execution", () => {
         verifyConfirmation: async () => {
           throw verificationFailure;
         },
-      })
-    ).rejects.toThrow("confirmed, but refreshed protocol state could not be verified");
+      });
+      const rejection = expect(execution).rejects.toThrow(
+        "confirmed, but refreshed protocol state could not be verified"
+      );
+      await vi.runAllTimersAsync();
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(readProtocolActivity(wallet, 31_337)[0]).toMatchObject({
       kind: "repay-loan",


### PR DESCRIPTION
## Summary

- label basket creation accurately as Mint and Mint and deposit instead of Buy terminology
- wait for the read RPC to reach the confirmed block and retry temporarily stale confirmation checks
- reconcile active onchain queries after confirmed transactions without permanent polling
- refresh Dollar Risk supply state, Basket swap balances, and Wallet balances after writes

## Validation

- npm run lint
- npm run lint:css
- npm run format:check
- npm run typecheck
- npm test (76 files, 389 tests passed)
- focused reconciliation, transaction, Dollar supply, Basket boundary, and provider boundary tests

## Not run

- npm run test:e2e and production build were not run in this intermediate test cycle; live Robinhood testnet UI testing remains in progress.