### PR TITLE
feat(liquidity): simplify paired asset entry

### DIFF
--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -4270,6 +4270,143 @@
   color: var(--accent);
 }
 
+.liquidity-contribution {
+  display: grid;
+  gap: 1rem;
+}
+
+.basket-field > .liquidity-amount-control {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.liquidity-amount-control button {
+  min-height: 48px;
+  padding: 0 0.8rem;
+  border: 0;
+  border-left: 1px solid var(--app-border);
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--text-caption);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.liquidity-amount-control button:disabled {
+  color: var(--app-text-muted);
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.liquidity-contribution-quote {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--app-border);
+  background: var(--app-bg);
+  border-radius: var(--radius-lg);
+}
+
+.liquidity-pair-requirement {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.liquidity-pair-requirement span,
+.liquidity-quote-columns > div > span,
+.liquidity-contribution-quote > small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.liquidity-pair-requirement strong {
+  color: var(--app-text);
+  text-align: right;
+}
+
+.liquidity-quote-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  background: var(--app-border);
+  border-radius: var(--radius-md);
+}
+
+.liquidity-quote-columns > div {
+  padding: 0.85rem;
+  background: var(--app-surface);
+}
+
+.liquidity-quote-columns dl {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0.65rem 0 0;
+}
+
+.liquidity-quote-columns dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.liquidity-quote-columns dt {
+  color: var(--app-text-muted);
+}
+
+.liquidity-quote-columns dd {
+  margin: 0;
+  color: var(--app-text);
+}
+
+.liquidity-balance-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.liquidity-balance-list > div {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.8rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+}
+
+.liquidity-balance-list span,
+.liquidity-balance-list small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.liquidity-balance-list strong {
+  color: var(--app-text);
+}
+
+.liquidity-balance-list .is-sufficient {
+  border-color: color-mix(in srgb, var(--positive) 45%, var(--app-border));
+}
+
+.liquidity-balance-list .is-sufficient small {
+  color: var(--positive);
+}
+
+.liquidity-balance-list .is-insufficient {
+  border-color: color-mix(in srgb, var(--negative) 55%, var(--app-border));
+}
+
+.liquidity-balance-list .is-insufficient small {
+  color: var(--negative);
+}
+
+.liquidity-limiting-balance {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
 .liquidity-tabs {
   grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
   margin: 1rem 0;
@@ -5035,6 +5172,19 @@
   .remaining-tabs,
   .liquidity-tabs {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .liquidity-pair-requirement {
+    display: grid;
+  }
+
+  .liquidity-pair-requirement strong {
+    text-align: left;
+  }
+
+  .liquidity-quote-columns,
+  .liquidity-balance-list {
+    grid-template-columns: 1fr;
   }
 
   .creation-steps button {

--- a/components/liquidity/LiquidityPage.tsx
+++ b/components/liquidity/LiquidityPage.tsx
@@ -91,10 +91,35 @@ export function resolveLiquidityPool(
   return pools?.find((item) => item.poolId === position.poolId) ?? selected;
 }
 
-function amount(value: bigint, decimals: number): string {
-  return Number(formatUnits(value, decimals)).toLocaleString(undefined, {
-    maximumFractionDigits: 6,
-  });
+export function formatLiquidityAmount(value: bigint, decimals: number): string {
+  const [whole = "0", fraction = ""] = formatUnits(value, decimals).split(".");
+  const maximumFractionDigits = 6;
+  const paddedFraction = fraction.padEnd(maximumFractionDigits + 1, "0");
+  let roundedWhole = BigInt(whole);
+  let roundedFraction = BigInt(paddedFraction.slice(0, maximumFractionDigits) || "0");
+  const fractionScale = 10n ** BigInt(maximumFractionDigits);
+
+  if (paddedFraction[maximumFractionDigits] >= "5") {
+    roundedFraction += 1n;
+    if (roundedFraction === fractionScale) {
+      roundedWhole += 1n;
+      roundedFraction = 0n;
+    }
+  }
+
+  const wholeFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+  const formattedWhole = wholeFormatter.format(roundedWhole);
+  const formattedFraction = roundedFraction
+    .toString()
+    .padStart(maximumFractionDigits, "0")
+    .replace(/0+$/, "");
+  if (!formattedFraction) return formattedWhole;
+
+  const decimalSeparator =
+    new Intl.NumberFormat(undefined, { minimumFractionDigits: 1 })
+      .formatToParts(0.1)
+      .find((part) => part.type === "decimal")?.value ?? ".";
+  return `${formattedWhole}${decimalSeparator}${formattedFraction}`;
 }
 
 function inputAmount(value: bigint, decimals: number, locale: string): string {
@@ -167,7 +192,7 @@ export function LiquidityContributionForm({
           <div className="liquidity-pair-requirement">
             <span>Paired asset required</span>
             <strong>
-              Up to {amount(quote.maximumAmounts[otherIndex], otherToken.decimals)}{" "}
+              Up to {formatLiquidityAmount(quote.maximumAmounts[otherIndex], otherToken.decimals)}{" "}
               {otherToken.symbol}
             </strong>
           </div>
@@ -178,7 +203,7 @@ export function LiquidityContributionForm({
                 {tokens.map((token, index) => (
                   <div key={token.address}>
                     <dt>{token.symbol}</dt>
-                    <dd>{amount(quote.estimatedAmounts[index]!, token.decimals)}</dd>
+                    <dd>{formatLiquidityAmount(quote.estimatedAmounts[index]!, token.decimals)}</dd>
                   </div>
                 ))}
               </dl>
@@ -189,7 +214,7 @@ export function LiquidityContributionForm({
                 {tokens.map((token, index) => (
                   <div key={token.address}>
                     <dt>{token.symbol}</dt>
-                    <dd>{amount(quote.maximumAmounts[index]!, token.decimals)}</dd>
+                    <dd>{formatLiquidityAmount(quote.maximumAmounts[index]!, token.decimals)}</dd>
                   </div>
                 ))}
               </dl>
@@ -215,9 +240,13 @@ export function LiquidityContributionForm({
               }
             >
               <span>{token.symbol} balance</span>
-              <strong>{balances ? amount(balance, token.decimals) : "Loading…"}</strong>
+              <strong>
+                {balances ? formatLiquidityAmount(balance, token.decimals) : "Loading…"}
+              </strong>
               {insufficient ? (
-                <small>Needs {amount(required - balance, token.decimals)} more</small>
+                <small>
+                  Needs {formatLiquidityAmount(required - balance, token.decimals)} more
+                </small>
               ) : quote && balances ? (
                 <small>Sufficient</small>
               ) : null}
@@ -451,7 +480,7 @@ function LiquidityRuntime() {
         await send(
           "approve-lp-token",
           `Approve ${token.symbol} for Permit2`,
-          `${amount(required, token.decimals)} ${token.symbol}`,
+          `${formatLiquidityAmount(required, token.decimals)} ${token.symbol}`,
           token.address,
           encodeFunctionData({
             abi: basketTokenAbi,
@@ -484,7 +513,7 @@ function LiquidityRuntime() {
         await send(
           "approve-permit2",
           `Authorize ${token.symbol} for PositionManager`,
-          `${amount(required, token.decimals)} ${token.symbol}`,
+          `${formatLiquidityAmount(required, token.decimals)} ${token.symbol}`,
           contracts.permit2,
           buildPermit2ApproveCall(
             token.address,
@@ -517,7 +546,7 @@ function LiquidityRuntime() {
     await send(
       "create-lp-nft",
       `Create ${selectedPool.basketSymbol}/${selectedPool.asset.symbol} liquidity position`,
-      `${amount(quote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${amount(
+      `${formatLiquidityAmount(quote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${formatLiquidityAmount(
         quote.estimatedAmounts[1],
         tokens[1].decimals
       )} ${tokens[1].symbol}`,
@@ -863,7 +892,7 @@ function LiquidityRuntime() {
           await send(
             "approve-lp-token",
             `Approve ${token.symbol} for liquidity increase`,
-            `${amount(required, token.decimals)} ${token.symbol}`,
+            `${formatLiquidityAmount(required, token.decimals)} ${token.symbol}`,
             token.address,
             encodeFunctionData({
               abi: basketTokenAbi,
@@ -895,7 +924,7 @@ function LiquidityRuntime() {
       await send(
         "increase-lp-nft",
         `Increase Liquidity position #${position.tokenId}`,
-        `${amount(contributionQuote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${amount(
+        `${formatLiquidityAmount(contributionQuote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${formatLiquidityAmount(
           contributionQuote.estimatedAmounts[1],
           tokens[1].decimals
         )} ${tokens[1].symbol}`,
@@ -1052,7 +1081,7 @@ function LiquidityRuntime() {
       const token = tokens[balanceShortfall];
       const missing =
         contributionQuote.maximumAmounts[balanceShortfall] - balances[balanceShortfall];
-      return `Your wallet needs ${amount(missing, token.decimals)} more ${token.symbol}.`;
+      return `Your wallet needs ${formatLiquidityAmount(missing, token.decimals)} more ${token.symbol}.`;
     }
     return null;
   })();

--- a/components/liquidity/LiquidityPage.tsx
+++ b/components/liquidity/LiquidityPage.tsx
@@ -24,7 +24,6 @@ import {
   buildPermit2ApproveCall,
   buildStakeLiquidityPositionCall,
   buildUnstakeLiquidityPositionCall,
-  maximumLiquidityForAmounts,
   permit2AllowanceAbi,
   staticsAbi,
   v4PositionManagerReadAbi,
@@ -36,14 +35,20 @@ import { readClientDollarDeployment } from "@/lib/dollar/deployment";
 import {
   canonicalFullRange,
   canonicalPoolLabel,
+  liquidityWalletBalances,
   liquidityActivationWait,
   liquidityPositionActions,
   loadLiquidityCatalog,
+  maximumWalletLiquidityInput,
+  quoteWalletLiquidity,
   recommendedLiquidityAction,
   v4PoolId,
   type CanonicalPoolRecord,
+  type LiquidityTokenIndex,
   type LpPositionRecord,
+  type WalletLiquidityQuote,
 } from "@/lib/liquidity/liquidity";
+import type { TokenMetadata } from "@/lib/baskets/baskets";
 import { describePositionError } from "@/lib/positions/positions";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import {
@@ -92,6 +97,143 @@ function amount(value: bigint, decimals: number): string {
   });
 }
 
+function inputAmount(value: bigint, decimals: number, locale: string): string {
+  const formatted = formatUnits(value, decimals);
+  return locale === "es" ? formatted.replace(".", ",") : formatted;
+}
+
+export function LiquidityContributionForm({
+  tokens,
+  balances,
+  selectedIndex,
+  amountInput,
+  quote,
+  maxLimitedBy,
+  pending,
+  onAmountChange,
+  onSwitch,
+  onMax,
+}: Readonly<{
+  tokens: readonly [TokenMetadata, TokenMetadata];
+  balances: readonly [bigint, bigint] | null;
+  selectedIndex: LiquidityTokenIndex;
+  amountInput: string;
+  quote: WalletLiquidityQuote | null;
+  maxLimitedBy: LiquidityTokenIndex | null;
+  pending: boolean;
+  onAmountChange: (value: string) => void;
+  onSwitch: () => void;
+  onMax: () => void;
+}>) {
+  const selectedToken = tokens[selectedIndex];
+  const otherIndex: LiquidityTokenIndex = selectedIndex === 0 ? 1 : 0;
+  const otherToken = tokens[otherIndex];
+  return (
+    <div className="liquidity-contribution">
+      <div className="basket-field">
+        <label htmlFor="liquidity-contribution-amount">Supply up to</label>
+        <div className="liquidity-amount-control">
+          <input
+            id="liquidity-contribution-amount"
+            aria-label={`Maximum ${selectedToken.symbol}`}
+            inputMode="decimal"
+            placeholder="0.00"
+            value={amountInput}
+            disabled={pending}
+            onChange={(event) => onAmountChange(event.target.value)}
+          />
+          <button
+            type="button"
+            className="liquidity-asset-switch"
+            aria-label={`Use ${otherToken.symbol} as the input asset`}
+            disabled={pending}
+            onClick={onSwitch}
+          >
+            {selectedToken.symbol} ⇄
+          </button>
+          <button
+            type="button"
+            className="liquidity-max-button"
+            disabled={pending || !balances}
+            onClick={onMax}
+          >
+            Max
+          </button>
+        </div>
+      </div>
+
+      {quote && (
+        <section className="liquidity-contribution-quote" aria-live="polite">
+          <div className="liquidity-pair-requirement">
+            <span>Paired asset required</span>
+            <strong>
+              Up to {amount(quote.maximumAmounts[otherIndex], otherToken.decimals)}{" "}
+              {otherToken.symbol}
+            </strong>
+          </div>
+          <div className="liquidity-quote-columns">
+            <div>
+              <span>Estimated deposit</span>
+              <dl>
+                {tokens.map((token, index) => (
+                  <div key={token.address}>
+                    <dt>{token.symbol}</dt>
+                    <dd>{amount(quote.estimatedAmounts[index]!, token.decimals)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+            <div>
+              <span>Maximum spend</span>
+              <dl>
+                {tokens.map((token, index) => (
+                  <div key={token.address}>
+                    <dt>{token.symbol}</dt>
+                    <dd>{amount(quote.maximumAmounts[index]!, token.decimals)}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
+          <small>
+            Maximums include a 0.50% price-movement buffer. Unused tokens stay in or return to your
+            wallet.
+          </small>
+        </section>
+      )}
+
+      <div className="liquidity-balance-list" aria-live="polite">
+        {tokens.map((token, index) => {
+          const balance = balances?.[index] ?? 0n;
+          const required = quote?.maximumAmounts[index] ?? 0n;
+          const insufficient = Boolean(quote && balances && balance < required);
+          return (
+            <div
+              key={token.address}
+              className={
+                insufficient ? "is-insufficient" : quote && balances ? "is-sufficient" : undefined
+              }
+            >
+              <span>{token.symbol} balance</span>
+              <strong>{balances ? amount(balance, token.decimals) : "Loading…"}</strong>
+              {insufficient ? (
+                <small>Needs {amount(required - balance, token.decimals)} more</small>
+              ) : quote && balances ? (
+                <small>Sufficient</small>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      {maxLimitedBy !== null && (
+        <p className="liquidity-limiting-balance" role="status">
+          Maximum position is limited by your {tokens[maxLimitedBy].symbol} balance.
+        </p>
+      )}
+    </div>
+  );
+}
+
 export function LiquidityPage() {
   const wallet = useWalletState();
   if (wallet.status === "unconfigured") return <UnconfiguredSurface subject="Liquidity" />;
@@ -109,8 +251,9 @@ function LiquidityRuntime() {
   const [poolId, setPoolId] = useState("");
   const [tokenId, setTokenId] = useState("");
   const [positionId, setPositionId] = useState("");
-  const [amount0, setAmount0] = useState("");
-  const [amount1, setAmount1] = useState("");
+  const [inputSide, setInputSide] = useState<"basket" | "asset">("basket");
+  const [amountInput, setAmountInput] = useState("");
+  const [maxLimitedBy, setMaxLimitedBy] = useState<LiquidityTokenIndex | null>(null);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const catalog = useQuery({
@@ -154,17 +297,76 @@ function LiquidityRuntime() {
       pool.key.currency1 === pool.basketToken.address ? pool.basketToken : pool.asset,
     ] as const;
   }, [pool]);
-  const amountInputsReady = (() => {
-    if (!tokens) return false;
+  const selectedIndex: LiquidityTokenIndex =
+    tokens && pool
+      ? inputSide === "basket"
+        ? tokens[0].address === pool.basketToken.address
+          ? 0
+          : 1
+        : tokens[0].address === pool.asset.address
+          ? 0
+          : 1
+      : 0;
+  const balances = useMemo(
+    () => (pool && catalog.data ? liquidityWalletBalances(pool, catalog.data.baskets) : null),
+    [catalog.data, pool]
+  );
+  const parsedInput = useMemo(() => {
+    if (!tokens) return null;
     try {
-      return (
-        parseLocalizedUnits(amount0, tokens[0].decimals, locale) > 0n &&
-        parseLocalizedUnits(amount1, tokens[1].decimals, locale) > 0n
-      );
+      return parseLocalizedUnits(amountInput, tokens[selectedIndex].decimals, locale);
     } catch {
-      return false;
+      return null;
     }
-  })();
+  }, [amountInput, locale, selectedIndex, tokens]);
+  const contributionQuote = useMemo(
+    () =>
+      pool && parsedInput !== null ? quoteWalletLiquidity(pool, selectedIndex, parsedInput) : null,
+    [parsedInput, pool, selectedIndex]
+  );
+  const balanceShortfall: LiquidityTokenIndex | null =
+    contributionQuote && balances
+      ? contributionQuote.maximumAmounts[0] > balances[0]
+        ? 0
+        : contributionQuote.maximumAmounts[1] > balances[1]
+          ? 1
+          : null
+      : null;
+
+  const resetContribution = () => {
+    setInputSide("basket");
+    setAmountInput("");
+    setMaxLimitedBy(null);
+  };
+
+  const switchContributionAsset = () => {
+    if (!tokens) return;
+    const otherIndex: LiquidityTokenIndex = selectedIndex === 0 ? 1 : 0;
+    setAmountInput(
+      contributionQuote
+        ? inputAmount(
+            contributionQuote.maximumAmounts[otherIndex],
+            tokens[otherIndex].decimals,
+            locale
+          )
+        : ""
+    );
+    setInputSide(inputSide === "basket" ? "asset" : "basket");
+    setMaxLimitedBy(null);
+    setError(null);
+  };
+
+  const useMaximumContribution = () => {
+    if (!pool || !tokens || !balances) return;
+    const maximum = maximumWalletLiquidityInput(pool, balances, selectedIndex);
+    if (!maximum) {
+      setError("Both pool assets need a positive wallet balance before adding liquidity.");
+      return;
+    }
+    setAmountInput(inputAmount(maximum.inputAmount, tokens[selectedIndex].decimals, locale));
+    setMaxLimitedBy(maximum.limitingIndex);
+    setError(null);
+  };
 
   const send = async (
     kind:
@@ -211,7 +413,7 @@ function LiquidityRuntime() {
     });
   };
 
-  const create = async (selectedPool: CanonicalPoolRecord) => {
+  const create = async (selectedPool: CanonicalPoolRecord, quote: WalletLiquidityQuote) => {
     if (
       !tokens ||
       !wallet ||
@@ -222,21 +424,9 @@ function LiquidityRuntime() {
       return;
     if (selectedPool.decommissioned || !selectedPool.managerSynced)
       throw new Error("The pool must be live and manager-synced.");
-    const maximums = [
-      parseLocalizedUnits(amount0, tokens[0].decimals, locale),
-      parseLocalizedUnits(amount1, tokens[1].decimals, locale),
-    ] as const;
+    const maximums = quote.maximumAmounts;
     const [lower, upper] = canonicalFullRange(selectedPool.key.tickSpacing);
-    const liquidity =
-      (maximumLiquidityForAmounts(
-        selectedPool.sqrtPriceX96,
-        lower,
-        upper,
-        maximums[0],
-        maximums[1]
-      ) *
-        9_950n) /
-      10_000n;
+    const liquidity = quote.liquidity;
     if (liquidity === 0n) throw new Error("The entered amounts produce zero liquidity.");
     const contracts = deploymentState.deployment.liquidity.contracts;
     for (let index = 0; index < 2; index += 1) {
@@ -327,7 +517,10 @@ function LiquidityRuntime() {
     await send(
       "create-lp-nft",
       `Create ${selectedPool.basketSymbol}/${selectedPool.asset.symbol} liquidity position`,
-      `${liquidity} liquidity`,
+      `${amount(quote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${amount(
+        quote.estimatedAmounts[1],
+        tokens[1].decimals
+      )} ${tokens[1].symbol}`,
       contracts.positionManager,
       buildMintV4PositionCall({
         poolKey: selectedPool.key,
@@ -646,15 +839,9 @@ function LiquidityRuntime() {
         throw new Error("The selected liquidity position does not belong to the selected pool.");
       if (pool.decommissioned || !pool.managerSynced)
         throw new Error("The pool is not available for an increase.");
-      const maximums = [
-        parseLocalizedUnits(amount0, tokens[0].decimals, locale),
-        parseLocalizedUnits(amount1, tokens[1].decimals, locale),
-      ] as const;
-      const [lower, upper] = canonicalFullRange(pool.key.tickSpacing);
-      const delta =
-        (maximumLiquidityForAmounts(pool.sqrtPriceX96, lower, upper, maximums[0], maximums[1]) *
-          9_950n) /
-        10_000n;
+      if (!contributionQuote) throw new Error("Enter a valid liquidity contribution.");
+      const maximums = contributionQuote.maximumAmounts;
+      const delta = contributionQuote.liquidity;
       if (delta === 0n) throw new Error("The entered amounts produce zero liquidity.");
       for (let index = 0; index < 2; index += 1) {
         const token = tokens[index]!;
@@ -708,7 +895,10 @@ function LiquidityRuntime() {
       await send(
         "increase-lp-nft",
         `Increase Liquidity position #${position.tokenId}`,
-        `${delta} liquidity`,
+        `${amount(contributionQuote.estimatedAmounts[0], tokens[0].decimals)} ${tokens[0].symbol} + ${amount(
+          contributionQuote.estimatedAmounts[1],
+          tokens[1].decimals
+        )} ${tokens[1].symbol}`,
         diamond,
         buildIncreaseStakedLiquidityCall(
           position.positionId,
@@ -823,7 +1013,8 @@ function LiquidityRuntime() {
     try {
       if (resolvedMode === "create") {
         if (!pool) throw new Error("No pool is selected.");
-        await create(pool);
+        if (!contributionQuote) throw new Error("Enter a valid liquidity contribution.");
+        await create(pool, contributionQuote);
       } else await manage();
       await catalog.refetch();
     } catch (cause) {
@@ -850,15 +1041,28 @@ function LiquidityRuntime() {
   const selectedPool = position
     ? catalog.data?.pools.find((candidate) => candidate.poolId === position.poolId)
     : undefined;
+  const contributionReason = (() => {
+    if (!tokens) return "Select a canonical pool.";
+    if (!amountInput.trim()) return `Enter a maximum ${tokens[selectedIndex].symbol} amount.`;
+    if (parsedInput === null) return "Enter a valid token amount.";
+    if (parsedInput <= 0n) return "Enter a positive token amount.";
+    if (!contributionQuote) return "The entered amount is too small or exceeds the position limit.";
+    if (!balances) return "Wallet balances are still loading.";
+    if (balanceShortfall !== null) {
+      const token = tokens[balanceShortfall];
+      const missing =
+        contributionQuote.maximumAmounts[balanceShortfall] - balances[balanceShortfall];
+      return `Your wallet needs ${amount(missing, token.decimals)} more ${token.symbol}.`;
+    }
+    return null;
+  })();
   const managementReason =
     resolvedMode === "create"
       ? !pool
         ? "Select a canonical pool."
         : pool.decommissioned || !pool.managerSynced
           ? "The selected pool is not live and synced."
-          : !amountInputsReady
-            ? "Enter a positive maximum amount for both tokens."
-            : null
+          : contributionReason
       : !position
         ? "Select a liquidity position."
         : resolvedMode === "stake"
@@ -870,9 +1074,7 @@ function LiquidityRuntime() {
               ? `Activation becomes available at block ${position.eligibleAtBlock.toString()}.`
               : null
             : resolvedMode === "increase"
-              ? !amountInputsReady
-                ? "Enter a positive maximum amount for both tokens."
-                : null
+              ? contributionReason
               : resolvedMode === "claim"
                 ? position.claimable0 === 0n && position.claimable1 === 0n
                   ? "No LP rewards are currently claimable."
@@ -940,6 +1142,7 @@ function LiquidityRuntime() {
                 onClick={() => {
                   setPoolId(item.poolId);
                   setMode("create");
+                  resetContribution();
                   setError(null);
                 }}
               >
@@ -1012,6 +1215,7 @@ function LiquidityRuntime() {
               onClick={() => {
                 setTokenId(item.tokenId.toString());
                 setMode(recommendedLiquidityAction(item, currentBlock));
+                resetContribution();
                 setError(null);
               }}
             >
@@ -1034,6 +1238,7 @@ function LiquidityRuntime() {
               className={resolvedMode === "create" ? "active" : undefined}
               onClick={() => {
                 setMode("create");
+                resetContribution();
                 setError(null);
               }}
             >
@@ -1063,6 +1268,7 @@ function LiquidityRuntime() {
                     }
                     onClick={() => {
                       setMode(item);
+                      resetContribution();
                       setError(null);
                     }}
                   >
@@ -1090,6 +1296,7 @@ function LiquidityRuntime() {
                   value={pool?.poolId ?? ""}
                   onChange={(event) => {
                     setPoolId(event.target.value);
+                    resetContribution();
                     setError(null);
                   }}
                 >
@@ -1100,20 +1307,24 @@ function LiquidityRuntime() {
                   ))}
                 </select>
               </label>
-              {tokens?.map((token, index) => (
-                <label className="basket-field" key={token.address}>
-                  <span>Maximum {token.symbol}</span>
-                  <input
-                    inputMode="decimal"
-                    value={index === 0 ? amount0 : amount1}
-                    onChange={(event) => {
-                      if (index === 0) setAmount0(event.target.value);
-                      else setAmount1(event.target.value);
-                      setError(null);
-                    }}
-                  />
-                </label>
-              ))}
+              {tokens && (
+                <LiquidityContributionForm
+                  tokens={tokens}
+                  balances={balances}
+                  selectedIndex={selectedIndex}
+                  amountInput={amountInput}
+                  quote={contributionQuote}
+                  maxLimitedBy={maxLimitedBy}
+                  pending={pending}
+                  onAmountChange={(value) => {
+                    setAmountInput(value);
+                    setMaxLimitedBy(null);
+                    setError(null);
+                  }}
+                  onSwitch={switchContributionAsset}
+                  onMax={useMaximumContribution}
+                />
+              )}
             </>
           ) : (
             <>
@@ -1127,6 +1338,7 @@ function LiquidityRuntime() {
                     );
                     setTokenId(event.target.value);
                     if (next) setMode(recommendedLiquidityAction(next, currentBlock));
+                    resetContribution();
                     setError(null);
                   }}
                 >
@@ -1156,21 +1368,24 @@ function LiquidityRuntime() {
                   <small>LP rewards accrue to this PositionNFT after activation.</small>
                 </label>
               )}
-              {resolvedMode === "increase" &&
-                tokens?.map((token, index) => (
-                  <label className="basket-field" key={token.address}>
-                    <span>Maximum {token.symbol}</span>
-                    <input
-                      inputMode="decimal"
-                      value={index === 0 ? amount0 : amount1}
-                      onChange={(event) => {
-                        if (index === 0) setAmount0(event.target.value);
-                        else setAmount1(event.target.value);
-                        setError(null);
-                      }}
-                    />
-                  </label>
-                ))}
+              {resolvedMode === "increase" && tokens && (
+                <LiquidityContributionForm
+                  tokens={tokens}
+                  balances={balances}
+                  selectedIndex={selectedIndex}
+                  amountInput={amountInput}
+                  quote={contributionQuote}
+                  maxLimitedBy={maxLimitedBy}
+                  pending={pending}
+                  onAmountChange={(value) => {
+                    setAmountInput(value);
+                    setMaxLimitedBy(null);
+                    setError(null);
+                  }}
+                  onSwitch={switchContributionAsset}
+                  onMax={useMaximumContribution}
+                />
+              )}
               {activationWait !== null && (
                 <p className="dollar-warning">
                   New liquidity becomes eligible for activation in {activationWait.toString()} block

--- a/lib/liquidity/liquidity.ts
+++ b/lib/liquidity/liquidity.ts
@@ -13,6 +13,8 @@ import {
 import {
   BasketStatus,
   decodePositionInfo,
+  maximumLiquidityForAmounts,
+  quoteRangeAmounts,
   staticsAbi,
   staticsLiquidityManagerAbi,
   staticsSwapFeeHookAbi,
@@ -36,6 +38,10 @@ import {
 } from "@/lib/dollar/deployment";
 import { loadPositionCatalog, type PositionRecord } from "@/lib/positions/positions";
 import { loadEventHistoryInChunks } from "@/lib/protocol/event-history";
+
+const BPS = 10_000n;
+const MAX_POSITION_AMOUNT = (1n << 128n) - 1n;
+export const LIQUIDITY_TOLERANCE_BPS = 50n;
 
 export type CanonicalPoolRecord = Readonly<{
   basketId: bigint;
@@ -76,6 +82,20 @@ export type LpPositionRecord = Readonly<{
 
 export type LiquidityManageAction = "stake" | "activate" | "increase" | "claim" | "unstake";
 
+export type LiquidityTokenIndex = 0 | 1;
+
+export type WalletLiquidityQuote = Readonly<{
+  selectedIndex: LiquidityTokenIndex;
+  liquidity: bigint;
+  estimatedAmounts: readonly [bigint, bigint];
+  maximumAmounts: readonly [bigint, bigint];
+}>;
+
+export type MaximumWalletLiquidity = Readonly<{
+  inputAmount: bigint;
+  limitingIndex: LiquidityTokenIndex;
+}>;
+
 export type LiquidityCatalog = Readonly<{
   pools: readonly CanonicalPoolRecord[];
   positions: readonly LpPositionRecord[];
@@ -87,6 +107,100 @@ export type LiquidityCatalog = Readonly<{
 
 export function canonicalFullRange(spacing: number): readonly [number, number] {
   return [Math.ceil(-887_272 / spacing) * spacing, Math.floor(887_272 / spacing) * spacing];
+}
+
+function orderedPoolTokens(pool: CanonicalPoolRecord): readonly [TokenMetadata, TokenMetadata] {
+  return [
+    pool.key.currency0 === pool.basketToken.address ? pool.basketToken : pool.asset,
+    pool.key.currency1 === pool.basketToken.address ? pool.basketToken : pool.asset,
+  ];
+}
+
+export function liquidityWalletBalances(
+  pool: CanonicalPoolRecord,
+  baskets: readonly BasketRecord[]
+): readonly [bigint, bigint] | null {
+  const basket = baskets.find((candidate) => candidate.basketId === pool.basketId);
+  const constituent = basket?.constituents.find(
+    (candidate) => candidate.token.address === pool.asset.address
+  );
+  if (!basket || !constituent) return null;
+  const balancesByAddress = new Map<Address, bigint>([
+    [basket.token.address, basket.walletBalance],
+    [constituent.token.address, constituent.walletBalance],
+  ]);
+  const tokens = orderedPoolTokens(pool);
+  const balance0 = balancesByAddress.get(tokens[0].address);
+  const balance1 = balancesByAddress.get(tokens[1].address);
+  return balance0 === undefined || balance1 === undefined ? null : [balance0, balance1];
+}
+
+export function quoteWalletLiquidity(
+  pool: CanonicalPoolRecord,
+  selectedIndex: LiquidityTokenIndex,
+  selectedMaximum: bigint
+): WalletLiquidityQuote | null {
+  if (selectedMaximum <= 0n || selectedMaximum > MAX_POSITION_AMOUNT) return null;
+  const [tickLower, tickUpper] = canonicalFullRange(pool.key.tickSpacing);
+  const capacity = [MAX_POSITION_AMOUNT, MAX_POSITION_AMOUNT] as [bigint, bigint];
+  capacity[selectedIndex] = selectedMaximum;
+  const maximumLiquidity = maximumLiquidityForAmounts(
+    pool.sqrtPriceX96,
+    tickLower,
+    tickUpper,
+    capacity[0],
+    capacity[1]
+  );
+  const liquidity = (maximumLiquidity * (BPS - LIQUIDITY_TOLERANCE_BPS)) / BPS;
+  if (maximumLiquidity === 0n || liquidity === 0n) return null;
+  const maximumQuote = quoteRangeAmounts(pool.sqrtPriceX96, tickLower, tickUpper, maximumLiquidity);
+  const estimatedQuote = quoteRangeAmounts(pool.sqrtPriceX96, tickLower, tickUpper, liquidity);
+  const maximumAmounts = [maximumQuote.amount0, maximumQuote.amount1] as [bigint, bigint];
+  maximumAmounts[selectedIndex] = selectedMaximum;
+  return {
+    selectedIndex,
+    liquidity,
+    estimatedAmounts: [estimatedQuote.amount0, estimatedQuote.amount1],
+    maximumAmounts,
+  };
+}
+
+export function maximumWalletLiquidityInput(
+  pool: CanonicalPoolRecord,
+  balances: readonly [bigint, bigint],
+  selectedIndex: LiquidityTokenIndex
+): MaximumWalletLiquidity | null {
+  const [tickLower, tickUpper] = canonicalFullRange(pool.key.tickSpacing);
+  const limits = balances.map((balance) =>
+    balance > MAX_POSITION_AMOUNT ? MAX_POSITION_AMOUNT : balance
+  ) as [bigint, bigint];
+  if (limits[0] === 0n || limits[1] === 0n) return null;
+  const liquidity = maximumLiquidityForAmounts(
+    pool.sqrtPriceX96,
+    tickLower,
+    tickUpper,
+    limits[0],
+    limits[1]
+  );
+  if (liquidity === 0n) return null;
+  const amounts = quoteRangeAmounts(pool.sqrtPriceX96, tickLower, tickUpper, liquidity);
+  const nextAmounts =
+    liquidity < MAX_POSITION_AMOUNT
+      ? quoteRangeAmounts(pool.sqrtPriceX96, tickLower, tickUpper, liquidity + 1n)
+      : amounts;
+  const limitingIndex: LiquidityTokenIndex =
+    nextAmounts.amount0 > limits[0] ? 0 : nextAmounts.amount1 > limits[1] ? 1 : selectedIndex;
+  let inputAmount = selectedIndex === 0 ? amounts.amount0 : amounts.amount1;
+
+  // Integer rounding can let the selected amount represent a slightly larger
+  // liquidity plateau than the balance-constrained quote. Step down one token
+  // unit when needed so Max always remains executable by both wallet balances.
+  const selectedQuote = quoteWalletLiquidity(pool, selectedIndex, inputAmount);
+  const otherIndex: LiquidityTokenIndex = selectedIndex === 0 ? 1 : 0;
+  if (selectedQuote && selectedQuote.maximumAmounts[otherIndex] > limits[otherIndex]) {
+    inputAmount -= 1n;
+  }
+  return inputAmount > 0n ? { inputAmount, limitingIndex } : null;
 }
 
 export function borrowedLiquidityDeadline(blockTimestamp: bigint): bigint {

--- a/test/liquidity/liquidity.test.tsx
+++ b/test/liquidity/liquidity.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@/test/render";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  formatLiquidityAmount,
   LiquidityContributionForm,
   lpStakeEligibility,
   resolveLiquidityPool,
@@ -270,6 +271,13 @@ describe("canonical liquidity identifiers", () => {
 });
 
 describe("single-input liquidity contribution", () => {
+  it("formats very large amounts without Number precision loss", () => {
+    const whole = 123_456_789_012_345_678_901_234_567_890n;
+    const value = whole * unit + 123_456_789_000_000_000n;
+
+    expect(formatLiquidityAmount(value, 18)).toBe("123,456,789,012,345,678,901,234,567,890.123457");
+  });
+
   it("surfaces the paired requirement, balances, switch, and Max actions", () => {
     const onSwitch = vi.fn();
     const onMax = vi.fn();

--- a/test/liquidity/liquidity.test.tsx
+++ b/test/liquidity/liquidity.test.tsx
@@ -1,20 +1,67 @@
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@/test/render";
+import { describe, expect, it, vi } from "vitest";
 
-import { lpStakeEligibility, resolveLiquidityPool } from "@/components/liquidity/LiquidityPage";
+import {
+  LiquidityContributionForm,
+  lpStakeEligibility,
+  resolveLiquidityPool,
+} from "@/components/liquidity/LiquidityPage";
 import {
   basketLiquiditySnapshot,
   borrowedLiquidityDeadline,
   borrowedLiquidityReadiness,
   canonicalFullRange,
   canonicalPoolLabel,
+  liquidityWalletBalances,
   liquidityActivationWait,
   liquidityPositionActions,
+  maximumWalletLiquidityInput,
+  quoteWalletLiquidity,
   recommendedLiquidityAction,
   v4PoolId,
   type CanonicalPoolRecord,
   type LpPositionRecord,
 } from "@/lib/liquidity/liquidity";
 import type { BasketRecord } from "@/lib/baskets/baskets";
+
+const Q96 = 1n << 96n;
+const unit = 10n ** 18n;
+const basketAddress = "0x0000000000000000000000000000000000000002" as const;
+const assetAddress = "0x0000000000000000000000000000000000000001" as const;
+
+const basketToken = {
+  address: basketAddress,
+  name: "Test Pool Asset",
+  symbol: "TPA1",
+  decimals: 18,
+  metadataAvailable: true,
+};
+const assetToken = {
+  address: assetAddress,
+  name: "Test Asset",
+  symbol: "TST",
+  decimals: 18,
+  metadataAvailable: true,
+};
+
+function contributionPool(): CanonicalPoolRecord {
+  return {
+    basketId: 1n,
+    basketName: "Test Pool",
+    basketSymbol: "TPA1",
+    basketToken,
+    asset: assetToken,
+    poolId: `0x${"11".repeat(32)}`,
+    key: {
+      currency0: assetAddress,
+      currency1: basketAddress,
+      fee: 0,
+      tickSpacing: 10,
+      hooks: "0x0000000000000000000000000000000000000003",
+    },
+    sqrtPriceX96: Q96,
+  } as unknown as CanonicalPoolRecord;
+}
 
 describe("canonical liquidity identifiers", () => {
   it("anchors borrowed-liquidity deadlines to chain time", () => {
@@ -170,5 +217,115 @@ describe("canonical liquidity identifiers", () => {
     ]);
     expect(liquidityActivationWait(ready, 100n)).toBeNull();
     expect(recommendedLiquidityAction(ready, 100n)).toBe("activate");
+  });
+
+  it("maps basket and constituent balances into pool currency order", () => {
+    const basket = {
+      basketId: 1n,
+      token: basketToken,
+      walletBalance: 80n * unit,
+      constituents: [{ token: assetToken, walletBalance: 25n * unit }],
+    } as unknown as BasketRecord;
+
+    expect(liquidityWalletBalances(contributionPool(), [basket])).toEqual([25n * unit, 80n * unit]);
+  });
+
+  it("quotes the paired maximum and a buffered executable deposit from one asset", () => {
+    const quote = quoteWalletLiquidity(contributionPool(), 1, 100n * unit);
+
+    expect(quote).not.toBeNull();
+    expect(quote?.selectedIndex).toBe(1);
+    expect(quote?.maximumAmounts[1]).toBe(100n * unit);
+    expect(quote?.maximumAmounts[0]).toBeGreaterThan(0n);
+    expect(quote?.estimatedAmounts[0]).toBeLessThanOrEqual(quote!.maximumAmounts[0]);
+    expect(quote?.estimatedAmounts[1]).toBeLessThan(quote!.maximumAmounts[1]);
+  });
+
+  it("makes Max executable by both balances and reports the limiting side", () => {
+    const pool = contributionPool();
+    const balances = [20n * unit, 100n * unit] as const;
+    const maximum = maximumWalletLiquidityInput(pool, balances, 1);
+
+    expect(maximum).not.toBeNull();
+    expect(maximum?.limitingIndex).toBe(0);
+    const quote = quoteWalletLiquidity(pool, 1, maximum!.inputAmount);
+    expect(quote?.maximumAmounts[0]).toBeLessThanOrEqual(balances[0]);
+    expect(quote?.maximumAmounts[1]).toBeLessThanOrEqual(balances[1]);
+  });
+
+  it("preserves the quoted position size when the input asset switches", () => {
+    const pool = contributionPool();
+    const basketQuote = quoteWalletLiquidity(pool, 1, 100n * unit);
+    const assetQuote = quoteWalletLiquidity(pool, 0, basketQuote!.maximumAmounts[0]);
+
+    expect(assetQuote?.liquidity).toBe(basketQuote?.liquidity);
+    expect(assetQuote?.maximumAmounts).toEqual(basketQuote?.maximumAmounts);
+  });
+
+  it("rejects zero and uint128-overflowing single-asset requests", () => {
+    const pool = contributionPool();
+    expect(quoteWalletLiquidity(pool, 0, 0n)).toBeNull();
+    expect(quoteWalletLiquidity(pool, 0, 1n << 128n)).toBeNull();
+  });
+});
+
+describe("single-input liquidity contribution", () => {
+  it("surfaces the paired requirement, balances, switch, and Max actions", () => {
+    const onSwitch = vi.fn();
+    const onMax = vi.fn();
+    const quote = {
+      selectedIndex: 1 as const,
+      liquidity: 1n,
+      estimatedAmounts: [995n * unit, 1_990n * unit] as const,
+      maximumAmounts: [1_000n * unit, 2_000n * unit] as const,
+    };
+    render(
+      <LiquidityContributionForm
+        tokens={[assetToken, basketToken]}
+        balances={[1_000n * unit, 2_000n * unit]}
+        selectedIndex={1}
+        amountInput="2000"
+        quote={quote}
+        maxLimitedBy={0}
+        pending={false}
+        onAmountChange={vi.fn()}
+        onSwitch={onSwitch}
+        onMax={onMax}
+      />
+    );
+
+    expect(screen.getByRole("textbox", { name: "Maximum TPA1" })).toHaveValue("2000");
+    expect(screen.getByText("Up to 1,000 TST")).toBeInTheDocument();
+    expect(screen.getAllByText("Sufficient")).toHaveLength(2);
+    expect(screen.getByText(/limited by your TST balance/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Use TST as the input asset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Max" }));
+    expect(onSwitch).toHaveBeenCalledOnce();
+    expect(onMax).toHaveBeenCalledOnce();
+  });
+
+  it("shows the exact counterpart shortfall", () => {
+    render(
+      <LiquidityContributionForm
+        tokens={[assetToken, basketToken]}
+        balances={[900n * unit, 2_000n * unit]}
+        selectedIndex={1}
+        amountInput="2000"
+        quote={{
+          selectedIndex: 1,
+          liquidity: 1n,
+          estimatedAmounts: [995n * unit, 1_990n * unit],
+          maximumAmounts: [1_000n * unit, 2_000n * unit],
+        }}
+        maxLimitedBy={null}
+        pending={false}
+        onAmountChange={vi.fn()}
+        onSwitch={vi.fn()}
+        onMax={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Needs 100 more")).toBeInTheDocument();
+    expect(screen.getAllByText("Sufficient")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- replace the two manual liquidity maximum fields with one selected-asset input
- calculate and display the paired asset requirement, estimated deposit, maximum spend, and wallet sufficiency
- make Max choose the largest contribution supported by both wallet balances
- share the same quote and cap mapping across new LP creation and staked-position increases

## User impact

Liquidity providers choose a pool, enter one asset amount, and switch the sizing asset with one button. The app derives the other side using the current full-range Uniswap v4 quote, preserves the existing 0.50% execution buffer, and prevents submission when either balance cannot support the maximum spend.

## Validation

- npm run lint
- npm run lint:css
- npm run format:check
- npm run typecheck
- npm test — 79 files, 413 tests passed
- npm run test:e2e — production build passed; 42 Playwright tests passed across desktop, tablet, and mobile
- local changed-scope QA review — no confirmed findings
