### PR TITLE
feat(transactions): orchestrate approvals and disclose permissions

### DIFF
--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -461,6 +461,37 @@
   cursor: not-allowed;
 }
 
+.dapp-approval-disclosure {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-lg);
+  background: var(--app-surface);
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.dapp-approval-disclosure p {
+  flex: 1 1 28rem;
+  margin: 0;
+  line-height: var(--leading-normal);
+}
+
+.dapp-approval-disclosure strong {
+  color: var(--app-text);
+}
+
+.dapp-approval-disclosure a {
+  color: var(--accent);
+  font-weight: 650;
+  text-decoration: none;
+}
+
 .dapp-header-actions,
 .dapp-wallet-actions {
   display: flex;

--- a/components/app-shell/AppShell.tsx
+++ b/components/app-shell/AppShell.tsx
@@ -16,6 +16,15 @@ function formatAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
+const approvalDisclosureRoutes = [
+  "/app/dollar",
+  "/app/baskets",
+  "/app/positions",
+  "/app/loans",
+  "/app/rewards",
+  "/app/liquidity",
+] as const;
+
 function WalletHeaderControls() {
   const wallet = useWalletState();
   const [accountOpen, setAccountOpen] = useState(false);
@@ -202,6 +211,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     description: tRoutes(`${routeId}.description`),
   };
   const showOverviewSummary = isDappOverviewPath(currentPath);
+  const showApprovalDisclosure = approvalDisclosureRoutes.some(
+    (route) => currentPath === route || currentPath.startsWith(`${route}/`)
+  );
 
   const closeNavigation = (restoreFocus = true) => {
     setOpenNavigationPath(null);
@@ -329,6 +341,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <p className="dapp-inline-error" role="alert">
               {wallet.error}
             </p>
+          )}
+
+          {showApprovalDisclosure && (
+            <aside className="dapp-approval-disclosure" aria-label={tShell("approvalsTitle")}>
+              <p>
+                <strong>{tShell("approvalsTitle")}</strong> {tShell("approvalsBody")}
+              </p>
+              <Link href="/app/tools">{tShell("manageApprovals")} →</Link>
+            </aside>
           )}
 
           {children}

--- a/components/baskets/BasketDetailPage.tsx
+++ b/components/baskets/BasketDetailPage.tsx
@@ -304,14 +304,7 @@ function BasketDetailRuntime({
       to,
       data,
       value,
-      sendTransaction: ({ to: transactionTarget, data: transactionData, value }) =>
-        walletClient.data!.sendTransaction({
-          account: wallet,
-          chain: walletClient.data!.chain,
-          to: transactionTarget,
-          data: transactionData,
-          value,
-        }),
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describeBasketError,
       validateSimulation: validate,
     });
@@ -327,146 +320,146 @@ function BasketDetailRuntime({
       if (!availability.executable || !currentQuote || slippageBps === null) {
         throw new Error(availability.reason || "Wait for a fresh basket quote.");
       }
-      if (availability.kind === "approve" && availability.approvalIndex !== undefined) {
-        const constituent = basket.constituents[availability.approvalIndex];
-        const quoted = currentQuote.amounts[availability.approvalIndex];
-        if (!constituent || quoted === undefined)
-          throw new Error("The approval quote is incomplete.");
-        await recordAndSend({
-          kind: "approve-basket-asset",
-          label: `Approve ${constituent.token.symbol}`,
-          to: constituent.token.address,
-          data: encodeFunctionData({
-            abi: basketTokenAbi,
-            functionName: "approve",
-            args: [deploymentState.deployment.contracts.diamond, MAX_ERC20_ALLOWANCE],
-          }),
-        });
-      } else if (availability.kind === "execute") {
-        const refreshed = await quote.refetch();
-        if (
-          !refreshed.data ||
-          refreshed.data.mode !== mode ||
-          refreshed.data.amount !== amount ||
-          refreshed.data.amounts.length !== basket.constituents.length
-        ) {
-          throw new Error("The basket quote could not be refreshed for the current input.");
-        }
-        const bounds =
-          mode === "mint"
-            ? refreshed.data.amounts.map((value) => maximumWithSlippage(value, slippageBps))
-            : refreshed.data.amounts.map((value) => minimumWithSlippage(value, slippageBps));
-        if (mode === "mint") {
-          const refreshedCatalog = await catalog.refetch();
-          const currentBasket = refreshedCatalog.data?.baskets.find(
-            (candidate) => candidate.basketId === basketId
-          );
-          if (
-            !currentBasket ||
-            currentBasket.constituents.some(
-              (constituent, index) =>
-                constituent.walletBalance < (bounds[index] ?? 0n) ||
-                constituent.allowance < (bounds[index] ?? 0n)
-            )
-          ) {
-            throw new Error("The fresh quote requires another underlying approval.");
+      if (mode === "mint") {
+        for (let index = 0; index < basket.constituents.length; index += 1) {
+          const constituent = basket.constituents[index];
+          const quoted = currentQuote.amounts[index];
+          if (!constituent || quoted === undefined) {
+            throw new Error("The approval quote is incomplete.");
           }
+          const required = maximumWithSlippage(quoted, slippageBps);
+          if (constituent.allowance >= required) continue;
+          await recordAndSend({
+            kind: "approve-basket-asset",
+            label: `Approve unlimited ${constituent.token.symbol}`,
+            to: constituent.token.address,
+            data: encodeFunctionData({
+              abi: basketTokenAbi,
+              functionName: "approve",
+              args: [deploymentState.deployment.contracts.diamond, MAX_ERC20_ALLOWANCE],
+            }),
+            activityAmount: `Unlimited ${constituent.token.symbol}`,
+          });
         }
-        // A minted basket held in the wallet earns nothing: rewards accrue
-        // against a PositionNFT. So the default mints straight into one --
-        // creating the position in the same call when there is not one yet --
-        // and only an explicit opt-out leaves the shares in the wallet.
-        const refreshedPositions = await positions.refetch();
-        const targetPositionId = selectedPositionId(conversionSelection);
-        const targetPosition =
-          targetPositionId === null
-            ? null
-            : (refreshedPositions.data?.positions.find(
-                (position) => position.positionId === targetPositionId
-              ) ?? null);
-        if (targetPositionId !== null && !targetPosition) {
-          throw new Error("The selected position is no longer owned by this wallet.");
-        }
-        const collateralFunction =
-          mode === "mint"
-            ? conversionSelection === "new-position"
-              ? ("createAndMintBasketCollateral" as const)
-              : targetPosition
-                ? ("mintBasketCollateral" as const)
-                : null
-            : targetPosition
-              ? ("redeemBasketCollateral" as const)
-              : null;
-
-        let data: Hex;
-        if (mode === "redeem" && targetPosition) {
-          const freshCollateral = targetPosition.collateral.find(
-            (collateral) => collateral.basket.basketId === basketId
-          );
-          if (!freshCollateral || unlockedCollateral(freshCollateral) < amount) {
-            throw new Error("The selected position does not have enough unlocked BasketToken.");
-          }
-          if (
-            refreshedPositions.data &&
-            refreshedPositions.data.currentBlock < freshCollateral.withdrawableAfterBlock
-          ) {
-            throw new Error("Basket collateral becomes redeemable in the next block.");
-          }
-          data = buildRedeemBasketCollateralCall(
-            targetPosition.positionId,
-            basketId,
-            amount,
-            wallet,
-            bounds
-          );
-        } else if (mode === "redeem") {
-          data = buildRedeemCall(basketId, amount, wallet, bounds);
-        } else if (collateralFunction === "mintBasketCollateral") {
-          data = buildMintBasketCollateralCall(
-            targetPosition!.positionId,
-            basketId,
-            amount,
-            bounds
-          );
-        } else if (collateralFunction === "createAndMintBasketCollateral") {
-          data = buildCreateAndMintBasketCollateralCall(basketId, amount, wallet, bounds);
-        } else {
-          data = buildMintCall(basketId, amount, wallet, bounds);
-        }
-
-        await recordAndSend({
-          kind: mode === "mint" ? "mint-basket" : "redeem-basket",
-          label:
-            mode === "redeem"
-              ? collateralFunction === "redeemBasketCollateral"
-                ? `Redeem ${basket.symbol} from position`
-                : `Redeem ${basket.symbol}`
-              : collateralFunction
-                ? `Mint and deposit ${basket.symbol}`
-                : `Mint ${basket.symbol}`,
-          to: deploymentState.deployment.contracts.diamond,
-          data,
-          value:
-            collateralFunction === "createAndMintBasketCollateral"
-              ? (refreshedPositions.data?.positionCreationFee ?? 0n)
-              : 0n,
-          activityAmount:
-            collateralFunction === "createAndMintBasketCollateral"
-              ? `${amountInput || "0"} ${basket.symbol} + ${formatEther(
-                  refreshedPositions.data?.positionCreationFee ?? 0n
-                )} ETH account fee`
-              : undefined,
-          validate: (result) =>
-            void (collateralFunction
-              ? validateBasketCollateralSimulation(
-                  collateralFunction,
-                  result,
-                  basket.constituents.length
-                )
-              : validateBasketSimulation(mode, result, basket.constituents.length)),
-        });
-        setAmountInput("");
       }
+      const refreshed = await quote.refetch();
+      if (
+        !refreshed.data ||
+        refreshed.data.mode !== mode ||
+        refreshed.data.amount !== amount ||
+        refreshed.data.amounts.length !== basket.constituents.length
+      ) {
+        throw new Error("The basket quote could not be refreshed for the current input.");
+      }
+      const bounds =
+        mode === "mint"
+          ? refreshed.data.amounts.map((value) => maximumWithSlippage(value, slippageBps))
+          : refreshed.data.amounts.map((value) => minimumWithSlippage(value, slippageBps));
+      if (mode === "mint") {
+        const refreshedCatalog = await catalog.refetch();
+        const currentBasket = refreshedCatalog.data?.baskets.find(
+          (candidate) => candidate.basketId === basketId
+        );
+        if (
+          !currentBasket ||
+          currentBasket.constituents.some(
+            (constituent, index) =>
+              constituent.walletBalance < (bounds[index] ?? 0n) ||
+              constituent.allowance < (bounds[index] ?? 0n)
+          )
+        ) {
+          throw new Error("The fresh quote requires another underlying approval.");
+        }
+      }
+      // A minted basket held in the wallet earns nothing: rewards accrue
+      // against a PositionNFT. So the default mints straight into one --
+      // creating the position in the same call when there is not one yet --
+      // and only an explicit opt-out leaves the shares in the wallet.
+      const refreshedPositions = await positions.refetch();
+      const targetPositionId = selectedPositionId(conversionSelection);
+      const targetPosition =
+        targetPositionId === null
+          ? null
+          : (refreshedPositions.data?.positions.find(
+              (position) => position.positionId === targetPositionId
+            ) ?? null);
+      if (targetPositionId !== null && !targetPosition) {
+        throw new Error("The selected position is no longer owned by this wallet.");
+      }
+      const collateralFunction =
+        mode === "mint"
+          ? conversionSelection === "new-position"
+            ? ("createAndMintBasketCollateral" as const)
+            : targetPosition
+              ? ("mintBasketCollateral" as const)
+              : null
+          : targetPosition
+            ? ("redeemBasketCollateral" as const)
+            : null;
+
+      let data: Hex;
+      if (mode === "redeem" && targetPosition) {
+        const freshCollateral = targetPosition.collateral.find(
+          (collateral) => collateral.basket.basketId === basketId
+        );
+        if (!freshCollateral || unlockedCollateral(freshCollateral) < amount) {
+          throw new Error("The selected position does not have enough unlocked BasketToken.");
+        }
+        if (
+          refreshedPositions.data &&
+          refreshedPositions.data.currentBlock < freshCollateral.withdrawableAfterBlock
+        ) {
+          throw new Error("Basket collateral becomes redeemable in the next block.");
+        }
+        data = buildRedeemBasketCollateralCall(
+          targetPosition.positionId,
+          basketId,
+          amount,
+          wallet,
+          bounds
+        );
+      } else if (mode === "redeem") {
+        data = buildRedeemCall(basketId, amount, wallet, bounds);
+      } else if (collateralFunction === "mintBasketCollateral") {
+        data = buildMintBasketCollateralCall(targetPosition!.positionId, basketId, amount, bounds);
+      } else if (collateralFunction === "createAndMintBasketCollateral") {
+        data = buildCreateAndMintBasketCollateralCall(basketId, amount, wallet, bounds);
+      } else {
+        data = buildMintCall(basketId, amount, wallet, bounds);
+      }
+
+      await recordAndSend({
+        kind: mode === "mint" ? "mint-basket" : "redeem-basket",
+        label:
+          mode === "redeem"
+            ? collateralFunction === "redeemBasketCollateral"
+              ? `Redeem ${basket.symbol} from position`
+              : `Redeem ${basket.symbol}`
+            : collateralFunction
+              ? `Mint and deposit ${basket.symbol}`
+              : `Mint ${basket.symbol}`,
+        to: deploymentState.deployment.contracts.diamond,
+        data,
+        value:
+          collateralFunction === "createAndMintBasketCollateral"
+            ? (refreshedPositions.data?.positionCreationFee ?? 0n)
+            : 0n,
+        activityAmount:
+          collateralFunction === "createAndMintBasketCollateral"
+            ? `${amountInput || "0"} ${basket.symbol} + ${formatEther(
+                refreshedPositions.data?.positionCreationFee ?? 0n
+              )} ETH account fee`
+            : undefined,
+        validate: (result) =>
+          void (collateralFunction
+            ? validateBasketCollateralSimulation(
+                collateralFunction,
+                result,
+                basket.constituents.length
+              )
+            : validateBasketSimulation(mode, result, basket.constituents.length)),
+      });
+      setAmountInput("");
       await Promise.all([catalog.refetch(), positions.refetch(), quote.refetch()]);
     } catch (error) {
       setActionError(describeBasketError(error));

--- a/components/baskets/BasketSwapPanel.tsx
+++ b/components/baskets/BasketSwapPanel.tsx
@@ -259,14 +259,7 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
           amount: `${display(amount, inputToken.decimals)} ${inputToken.symbol}`,
           to: inputToken.address,
           data: buildSwapTokenApproval(liquidity.contracts.permit2, amount),
-          sendTransaction: ({ to, data, value }) =>
-            walletClient.data!.sendTransaction({
-              account: wallet,
-              chain: walletClient.data!.chain,
-              to,
-              data,
-              value,
-            }),
+          sendTransaction: walletState.sendEvmTransaction,
           describeError: describeBasketError,
           verifyConfirmation: async () => {
             const allowance = await publicClient.readContract({
@@ -279,7 +272,6 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
           },
         });
         await permit2Approval.refetch();
-        return;
       }
       if (!freshQuote.data) throw new Error("The refreshed canonical quote returned no result.");
       const [freshAmountOut] = decodeFunctionResult({
@@ -316,14 +308,7 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
             functionName: "approve",
             args: [inputToken.address, router, MAX_PERMIT2_ALLOWANCE, MAX_PERMIT2_EXPIRATION],
           }),
-          sendTransaction: ({ to, data, value }) =>
-            walletClient.data!.sendTransaction({
-              account: wallet,
-              chain: walletClient.data!.chain,
-              to,
-              data,
-              value,
-            }),
+          sendTransaction: walletState.sendEvmTransaction,
           describeError: describeBasketError,
           verifyConfirmation: async () => {
             const confirmed = await publicClient.readContract({
@@ -344,7 +329,6 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
             }
           },
         });
-        return;
       }
       const execution = buildV4ExactInputSingleSwap({
         router,
@@ -370,14 +354,7 @@ export function BasketSwapPanel({ basket }: { basket: BasketRecord }) {
         to: execution.target,
         data: execution.calldata,
         value: execution.value,
-        sendTransaction: ({ to, data, value }) =>
-          walletClient.data!.sendTransaction({
-            account: wallet,
-            chain: walletClient.data!.chain,
-            to,
-            data,
-            value,
-          }),
+        sendTransaction: walletState.sendEvmTransaction,
         describeError: describeBasketError,
         verifyConfirmation: async () => {
           const outputAfter = await publicClient.readContract({

--- a/components/dollar/DollarPage.tsx
+++ b/components/dollar/DollarPage.tsx
@@ -533,6 +533,7 @@ function DollarActionPanel({
 }) {
   const t = useTranslations("dollar");
   const locale = useAppLocale();
+  const walletState = useWalletState();
   const publicClient = usePublicClient({ chainId: deployment.chainId });
   const walletClient = useWalletClient({ chainId: deployment.chainId });
   const snapshot = useDollarSnapshot(deployment, wallet);
@@ -659,18 +660,7 @@ function DollarActionPanel({
       to,
       data,
       value,
-      sendTransaction: ({
-        to: transactionTarget,
-        data: transactionData,
-        value: transactionValue,
-      }) =>
-        walletClient.data!.sendTransaction({
-          account: wallet,
-          chain: walletClient.data!.chain,
-          to: transactionTarget,
-          data: transactionData,
-          value: transactionValue,
-        }),
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describeDollarError,
       validateSimulation,
     });
@@ -725,7 +715,8 @@ function DollarActionPanel({
             to: deployment.contracts.risk,
             data: buildApproveRiskForPeripheryCall(periphery),
           });
-        } else if (actionAvailability.kind === "stake") {
+        }
+        if (mode === "supply") {
           const refreshedSupply = await supplyState.refetch();
           if (!refreshedSupply.data) throw new Error("The current Position state is unavailable.");
           if (
@@ -754,7 +745,7 @@ function DollarActionPanel({
             value: freshTargetPositionId === null ? refreshedSupply.data.positionCreationFee : 0n,
           });
           setAmountInput("");
-        } else if (actionAvailability.kind === "unstake") {
+        } else if (mode === "unsupply") {
           if (supply.positionId === null)
             throw new Error("No position holds this Risk series yet.");
           await recordAndSend({
@@ -766,154 +757,160 @@ function DollarActionPanel({
           setAmountInput("");
         }
         await supplyState.refetch();
-      } else if (actionAvailability.kind === "approve-weth") {
-        await recordAndSend({
-          kind: "approve-weth",
-          label: "Enable WETH deposits",
-          to: deployment.contracts.weth,
-          data: encodeFunctionData({
-            abi: wethAbi,
-            functionName: "approve",
-            args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
-          }),
-        });
-      } else if (actionAvailability.kind === "approve-dollar") {
-        await recordAndSend({
-          kind: "approve-dollar",
-          label: "Enable Dollar recombination",
-          to: deployment.contracts.dollar,
-          data: encodeFunctionData({
-            abi: staticsDollarTokenAbi,
-            functionName: "approve",
-            args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
-          }),
-        });
-      } else if (actionAvailability.kind === "approve-dollar-periphery") {
-        if (!snapshot.data.periphery || snapshot.data.periphery === zeroAddress) {
-          throw new Error("This deployment has no periphery to approve.");
-        }
-        await recordAndSend({
-          kind: "approve-dollar",
-          label: "Enable Dollar redemptions",
-          to: deployment.contracts.dollar,
-          data: encodeFunctionData({
-            abi: staticsDollarTokenAbi,
-            functionName: "approve",
-            args: [snapshot.data.periphery, MAX_ERC20_ALLOWANCE],
-          }),
-        });
-      } else if (actionAvailability.kind === "execute" && currentQuote?.mode === "redeem") {
-        const preview = await quote.refetch();
-        if (
-          !preview.data ||
-          preview.data.mode !== "redeem" ||
-          preview.data.amount !== amount ||
-          preview.data.seriesId !== snapshot.data.seriesId
-        ) {
-          throw new Error("Preview refresh failed.");
-        }
-        if (!snapshot.data.periphery || snapshot.data.periphery === zeroAddress) {
-          throw new Error("This deployment has no periphery, so Dollar cannot be redeemed alone.");
-        }
-        const fill = preview.data.preview.staticsDollarRedeemed;
-        if (fill === 0n) throw new Error("There is no redemption liquidity to fill this amount.");
-        // The rate guard is collateral per Dollar, WAD-normalized -- the same
-        // number the contract recomputes after the split, so a fee or price
-        // move between preview and execution is caught rather than absorbed.
-        const rateWad = (preview.data.preview.collateralToRedeemer * WAD) / fill;
-        const data = encodeFunctionData({
-          abi: staticsDollarPeripheryAbi,
-          functionName: asset === "ETH" ? "redeemToETH" : "redeem",
-          args: [
-            snapshot.data.seriesId,
-            amount,
-            minimumWithTolerance(fill),
-            minimumWithTolerance(rateWad),
-            redeemDeadline(),
-            wallet,
-          ],
-        });
-        await recordAndSend({
-          kind: asset === "ETH" ? "redeem-eth" : "redeem-weth",
-          label: `Redeem Dollar for ${asset}`,
-          to: snapshot.data.periphery,
-          data,
-        });
-        setAmountInput("");
-      } else if (actionAvailability.kind === "approve-risk") {
-        await recordAndSend({
-          kind: "approve-risk",
-          label: "Approve Risk share operator",
-          to: deployment.contracts.risk,
-          data: encodeFunctionData({
-            abi: staticsDollarRiskTokenAbi,
-            functionName: "setApprovalForAll",
-            args: [deployment.contracts.gateway, true],
-          }),
-        });
-      } else if (actionAvailability.kind === "execute" && currentQuote?.mode === "deposit") {
-        const preview = await quote.refetch();
-        if (
-          !preview.data ||
-          preview.data.mode !== "deposit" ||
-          preview.data.amount !== amount ||
-          preview.data.seriesId !== snapshot.data.seriesId
-        ) {
-          throw new Error("Preview refresh failed.");
-        }
-        const minimumDollar = minimumWithTolerance(preview.data.preview.staticsDollarMinted);
-        const minimumShares = minimumWithTolerance(preview.data.preview.sharesMinted);
-        const transaction =
-          asset === "ETH"
-            ? buildDepositETHTransaction(amount, wallet, wallet, minimumDollar, minimumShares)
-            : {
-                data: buildDepositWETHCall(amount, wallet, wallet, minimumDollar, minimumShares),
-                value: 0n,
-              };
-        await recordAndSend({
-          kind: asset === "ETH" ? "deposit-eth" : "deposit-weth",
-          label: `Deposit ${asset}`,
-          to: deployment.contracts.gateway,
-          data: transaction.data,
-          value: transaction.value,
-        });
-        setAmountInput("");
       } else {
-        const preview = await quote.refetch();
-        if (
-          !preview.data ||
-          preview.data.mode !== "recombine" ||
-          preview.data.amount !== amount ||
-          preview.data.seriesId !== snapshot.data.seriesId
-        ) {
-          throw new Error("Preview refresh failed.");
+        if (actionAvailability.kind === "approve-weth") {
+          await recordAndSend({
+            kind: "approve-weth",
+            label: "Enable WETH deposits",
+            to: deployment.contracts.weth,
+            data: encodeFunctionData({
+              abi: wethAbi,
+              functionName: "approve",
+              args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
+            }),
+          });
+        } else if (actionAvailability.kind === "approve-dollar") {
+          await recordAndSend({
+            kind: "approve-dollar",
+            label: "Enable Dollar recombination",
+            to: deployment.contracts.dollar,
+            data: encodeFunctionData({
+              abi: staticsDollarTokenAbi,
+              functionName: "approve",
+              args: [deployment.contracts.gateway, MAX_ERC20_ALLOWANCE],
+            }),
+          });
+        } else if (actionAvailability.kind === "approve-dollar-periphery") {
+          if (!snapshot.data.periphery || snapshot.data.periphery === zeroAddress) {
+            throw new Error("This deployment has no periphery to approve.");
+          }
+          await recordAndSend({
+            kind: "approve-dollar",
+            label: "Enable Dollar redemptions",
+            to: deployment.contracts.dollar,
+            data: encodeFunctionData({
+              abi: staticsDollarTokenAbi,
+              functionName: "approve",
+              args: [snapshot.data.periphery, MAX_ERC20_ALLOWANCE],
+            }),
+          });
+        } else if (actionAvailability.kind === "approve-risk") {
+          await recordAndSend({
+            kind: "approve-risk",
+            label: "Approve Risk share operator",
+            to: deployment.contracts.risk,
+            data: encodeFunctionData({
+              abi: staticsDollarRiskTokenAbi,
+              functionName: "setApprovalForAll",
+              args: [deployment.contracts.gateway, true],
+            }),
+          });
         }
-        const functionName = asset === "ETH" ? "recombineToETH" : "recombineToWETH";
-        const data =
-          functionName === "recombineToETH"
-            ? buildRecombineToETHCall(
-                snapshot.data.seriesId,
-                amount,
-                maximumWithTolerance(preview.data.preview.sharesBurned),
-                wallet,
-                minimumWithTolerance(preview.data.preview.collateralOut)
-              )
-            : buildRecombineToWETHCall(
-                snapshot.data.seriesId,
-                amount,
-                maximumWithTolerance(preview.data.preview.sharesBurned),
-                wallet,
-                minimumWithTolerance(preview.data.preview.collateralOut)
-              );
-        await recordAndSend({
-          kind: asset === "ETH" ? "recombine-eth" : "recombine-weth",
-          label: `Recombine to ${asset}`,
-          to: deployment.contracts.gateway,
-          data,
-          validateSimulation: (result) =>
-            void validateRecombinationSimulation(functionName, result),
-        });
-        setAmountInput("");
+
+        if (currentQuote?.mode === "redeem") {
+          const preview = await quote.refetch();
+          if (
+            !preview.data ||
+            preview.data.mode !== "redeem" ||
+            preview.data.amount !== amount ||
+            preview.data.seriesId !== snapshot.data.seriesId
+          ) {
+            throw new Error("Preview refresh failed.");
+          }
+          if (!snapshot.data.periphery || snapshot.data.periphery === zeroAddress) {
+            throw new Error(
+              "This deployment has no periphery, so Dollar cannot be redeemed alone."
+            );
+          }
+          const fill = preview.data.preview.staticsDollarRedeemed;
+          if (fill === 0n) throw new Error("There is no redemption liquidity to fill this amount.");
+          // The rate guard is collateral per Dollar, WAD-normalized -- the same
+          // number the contract recomputes after the split, so a fee or price
+          // move between preview and execution is caught rather than absorbed.
+          const rateWad = (preview.data.preview.collateralToRedeemer * WAD) / fill;
+          const data = encodeFunctionData({
+            abi: staticsDollarPeripheryAbi,
+            functionName: asset === "ETH" ? "redeemToETH" : "redeem",
+            args: [
+              snapshot.data.seriesId,
+              amount,
+              minimumWithTolerance(fill),
+              minimumWithTolerance(rateWad),
+              redeemDeadline(),
+              wallet,
+            ],
+          });
+          await recordAndSend({
+            kind: asset === "ETH" ? "redeem-eth" : "redeem-weth",
+            label: `Redeem Dollar for ${asset}`,
+            to: snapshot.data.periphery,
+            data,
+          });
+          setAmountInput("");
+        } else if (currentQuote?.mode === "deposit") {
+          const preview = await quote.refetch();
+          if (
+            !preview.data ||
+            preview.data.mode !== "deposit" ||
+            preview.data.amount !== amount ||
+            preview.data.seriesId !== snapshot.data.seriesId
+          ) {
+            throw new Error("Preview refresh failed.");
+          }
+          const minimumDollar = minimumWithTolerance(preview.data.preview.staticsDollarMinted);
+          const minimumShares = minimumWithTolerance(preview.data.preview.sharesMinted);
+          const transaction =
+            asset === "ETH"
+              ? buildDepositETHTransaction(amount, wallet, wallet, minimumDollar, minimumShares)
+              : {
+                  data: buildDepositWETHCall(amount, wallet, wallet, minimumDollar, minimumShares),
+                  value: 0n,
+                };
+          await recordAndSend({
+            kind: asset === "ETH" ? "deposit-eth" : "deposit-weth",
+            label: `Deposit ${asset}`,
+            to: deployment.contracts.gateway,
+            data: transaction.data,
+            value: transaction.value,
+          });
+          setAmountInput("");
+        } else {
+          const preview = await quote.refetch();
+          if (
+            !preview.data ||
+            preview.data.mode !== "recombine" ||
+            preview.data.amount !== amount ||
+            preview.data.seriesId !== snapshot.data.seriesId
+          ) {
+            throw new Error("Preview refresh failed.");
+          }
+          const functionName = asset === "ETH" ? "recombineToETH" : "recombineToWETH";
+          const data =
+            functionName === "recombineToETH"
+              ? buildRecombineToETHCall(
+                  snapshot.data.seriesId,
+                  amount,
+                  maximumWithTolerance(preview.data.preview.sharesBurned),
+                  wallet,
+                  minimumWithTolerance(preview.data.preview.collateralOut)
+                )
+              : buildRecombineToWETHCall(
+                  snapshot.data.seriesId,
+                  amount,
+                  maximumWithTolerance(preview.data.preview.sharesBurned),
+                  wallet,
+                  minimumWithTolerance(preview.data.preview.collateralOut)
+                );
+          await recordAndSend({
+            kind: asset === "ETH" ? "recombine-eth" : "recombine-weth",
+            label: `Recombine to ${asset}`,
+            to: deployment.contracts.gateway,
+            data,
+            validateSimulation: (result) =>
+              void validateRecombinationSimulation(functionName, result),
+          });
+          setAmountInput("");
+        }
       }
       await Promise.all([
         snapshot.refetch(),

--- a/components/liquidity/LiquidityPage.tsx
+++ b/components/liquidity/LiquidityPage.tsx
@@ -399,14 +399,7 @@ function LiquidityRuntime() {
       amount: summary,
       to,
       data,
-      sendTransaction: ({ to, data: nextData, value }) =>
-        walletClient.data!.sendTransaction({
-          account: wallet,
-          chain: walletClient.data!.chain,
-          to,
-          data: nextData,
-          value,
-        }),
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describePositionError,
       validateSimulation: options?.validateSimulation,
       verifyConfirmation: options?.verifyConfirmation,
@@ -471,7 +464,6 @@ function LiquidityRuntime() {
             },
           }
         );
-        return;
       }
       const permit = await publicClient.readContract({
         address: contracts.permit2,
@@ -506,7 +498,6 @@ function LiquidityRuntime() {
             },
           }
         );
-        return;
       }
     }
     const nextTokenId = await publicClient.readContract({
@@ -638,7 +629,6 @@ function LiquidityRuntime() {
             },
           }
         );
-        return;
       }
       await send(
         "stake-lp-nft",
@@ -883,7 +873,6 @@ function LiquidityRuntime() {
               },
             }
           );
-          return;
         }
       }
       const liquidityBefore = await publicClient.readContract({
@@ -1083,10 +1072,10 @@ function LiquidityRuntime() {
                   ? "The selected liquidity position is not staked."
                   : null;
   const actionLabels: Record<Mode, string> = {
-    create: "Approve or add liquidity",
-    stake: "Approve or stake LP position",
+    create: "Add liquidity",
+    stake: "Stake LP position",
     activate: "Activate LP rewards",
-    increase: "Approve or add liquidity",
+    increase: "Add liquidity",
     claim: "Claim LP rewards",
     unstake: "Unstake LP position",
   };

--- a/components/loans/LoansPage.tsx
+++ b/components/loans/LoansPage.tsx
@@ -9,7 +9,6 @@ import {
   getAddress,
   parseEventLogs,
   type Address,
-  type Hex,
   type TransactionReceipt,
 } from "viem";
 import { usePublicClient, useWalletClient } from "wagmi";
@@ -361,17 +360,6 @@ function LoansRuntime({
     }
   };
 
-  const send = (to: Address, data: Hex, value?: bigint) => {
-    if (!walletClient.data || !wallet) throw new Error("The wallet client is unavailable.");
-    return walletClient.data.sendTransaction({
-      account: wallet,
-      chain: walletClient.data.chain,
-      to,
-      data,
-      value,
-    });
-  };
-
   const assertLoanClosed = async (loanId: bigint) => {
     if (!publicClient || deploymentState.status !== "configured") return;
     try {
@@ -491,7 +479,7 @@ function LoansRuntime({
         quote.pools,
         wallet
       ),
-      sendTransaction: ({ to, data, value }) => send(to, data, value),
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describeLoanError,
       validateSimulation: (result) => {
         if (!result) throw new Error("The borrowed-liquidity simulation returned no result.");
@@ -671,8 +659,7 @@ function LoansRuntime({
           amount: `${displayAmount(shares, basket.token.decimals)} ${basket.symbol}`,
           to: deploymentState.deployment.contracts.diamond,
           data,
-          sendTransaction: ({ to, data: transactionData, value }) =>
-            send(to, transactionData, value),
+          sendTransaction: walletState.sendEvmTransaction,
           describeError: describeLoanError,
           validateSimulation: (result) => {
             if (!result) throw new Error("The borrow simulation returned no loan ID.");
@@ -733,12 +720,14 @@ function LoansRuntime({
         if (insufficientBalance >= 0) {
           throw new Error(`The wallet lacks required asset ${insufficientBalance + 1}.`);
         }
-        const approvalIndex = currentRequirements.findIndex(
-          (amount, index) => (freshLoan.assets[index]?.allowance ?? 0n) < amount
-        );
-        if (approvalIndex >= 0) {
-          const loanAsset = freshLoan.assets[approvalIndex];
+        for (
+          let approvalIndex = 0;
+          approvalIndex < currentRequirements.length;
+          approvalIndex += 1
+        ) {
           const amount = currentRequirements[approvalIndex] ?? 0n;
+          const loanAsset = freshLoan.assets[approvalIndex];
+          if ((loanAsset?.allowance ?? 0n) >= amount) continue;
           if (!loanAsset || loanAsset.walletBalance < amount) {
             throw new Error(`The wallet lacks required asset ${approvalIndex + 1}.`);
           }
@@ -756,8 +745,7 @@ function LoansRuntime({
             amount: `${displayAmount(amount, loanAsset.token.decimals)} ${loanAsset.token.symbol}`,
             to: loanAsset.token.address,
             data,
-            sendTransaction: ({ to, data: transactionData, value }) =>
-              send(to, transactionData, value),
+            sendTransaction: walletState.sendEvmTransaction,
             describeError: describeLoanError,
             validateSimulation: (result) => {
               if (!result) return;
@@ -780,7 +768,8 @@ function LoansRuntime({
               }
             },
           });
-        } else if (mode === "repay") {
+        }
+        if (mode === "repay") {
           const collateralBefore = await publicClient.readContract({
             address: deploymentState.deployment.contracts.diamond,
             abi: staticsAbi,
@@ -796,8 +785,7 @@ function LoansRuntime({
             amount: `${freshLoan.assets.length} principal assets`,
             to: deploymentState.deployment.contracts.diamond,
             data: buildRepayCall(freshLoan.loanId),
-            sendTransaction: ({ to, data: transactionData, value }) =>
-              send(to, transactionData, value),
+            sendTransaction: walletState.sendEvmTransaction,
             describeError: describeLoanError,
             verifyConfirmation: async () => {
               await assertLoanClosed(freshLoan.loanId);
@@ -828,8 +816,7 @@ function LoansRuntime({
             amount: `${currentRequirements.length} extension fees`,
             to: deploymentState.deployment.contracts.diamond,
             data: buildExtendCall(freshLoan.loanId, currentRequirements),
-            sendTransaction: ({ to, data: transactionData, value }) =>
-              send(to, transactionData, value),
+            sendTransaction: walletState.sendEvmTransaction,
             describeError: describeLoanError,
             verifyConfirmation: async () => {
               const after = await publicClient.readContract({
@@ -865,8 +852,7 @@ function LoansRuntime({
             )} ${freshLoan.basket.symbol}`,
             to: deploymentState.deployment.contracts.diamond,
             data: buildRecoverCall(freshLoan.loanId),
-            sendTransaction: ({ to, data: transactionData, value }) =>
-              send(to, transactionData, value),
+            sendTransaction: walletState.sendEvmTransaction,
             describeError: describeLoanError,
             verifyConfirmation: async () => {
               await assertLoanClosed(freshLoan.loanId);

--- a/components/portal/AcrossBridgePanel.tsx
+++ b/components/portal/AcrossBridgePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
-import { createPublicClient, createWalletClient, custom, formatUnits, getAddress } from "viem";
+import { createPublicClient, custom, formatUnits, getAddress } from "viem";
 
 import {
   SlippageInlineControl,
@@ -427,11 +427,6 @@ export function AcrossBridgePanel() {
       chain: network.chain,
       transport: custom(provider),
     });
-    const walletClient = createWalletClient({
-      account,
-      chain: network.chain,
-      transport: custom(provider),
-    });
     return executeProtocolTransaction({
       publicClient,
       wallet: account,
@@ -442,8 +437,7 @@ export function AcrossBridgePanel() {
       to: transaction.to,
       data: transaction.data,
       value: transaction.value,
-      sendTransaction: ({ to, data, value }) =>
-        walletClient.sendTransaction({ account, chain: network.chain, to, data, value }),
+      sendTransaction: wallet.sendEvmTransaction,
       describeError: (cause) =>
         cause instanceof Error ? cause.message : "The bridge transaction failed.",
     });

--- a/components/portal/EvmSwapPanel.tsx
+++ b/components/portal/EvmSwapPanel.tsx
@@ -2,14 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import {
-  createPublicClient,
-  createWalletClient,
-  custom,
-  formatUnits,
-  getAddress,
-  type Address,
-} from "viem";
+import { createPublicClient, custom, formatUnits, getAddress, type Address } from "viem";
 
 import {
   getDefaultEvmSwapTokens,
@@ -263,11 +256,6 @@ export function EvmSwapPanel() {
       chain: network.chain,
       transport: custom(provider),
     });
-    const walletClient = createWalletClient({
-      account,
-      chain: network.chain,
-      transport: custom(provider),
-    });
     return executeProtocolTransaction({
       publicClient,
       wallet: account,
@@ -278,8 +266,7 @@ export function EvmSwapPanel() {
       to: transaction.to,
       data: transaction.data,
       value: transaction.value,
-      sendTransaction: ({ to, data, value }) =>
-        walletClient.sendTransaction({ account, chain: network.chain, to, data, value }),
+      sendTransaction: wallet.sendEvmTransaction,
       describeError: (cause) =>
         cause instanceof Error ? cause.message : "The wallet transaction failed.",
     });

--- a/components/portal/PeggedDollarPanel.tsx
+++ b/components/portal/PeggedDollarPanel.tsx
@@ -255,7 +255,7 @@ export function PeggedDollarPanel({
     }
   ) => {
     if (!deployment) throw new Error("No Dollar deployment is configured.");
-    const { account, publicClient, walletClient } = await walletClients(wallet);
+    const { account, publicClient } = await walletClients(wallet);
     return executeProtocolTransaction({
       publicClient,
       wallet: account,
@@ -265,8 +265,7 @@ export function PeggedDollarPanel({
       amount: activityAmount,
       to: target,
       data,
-      sendTransaction: ({ to, data, value }) =>
-        walletClient.sendTransaction({ account, chain: null, to, data, value }),
+      sendTransaction: wallet.sendEvmTransaction,
       describeError: describeDollarError,
       validateSimulation: options?.validateSimulation,
       verifyConfirmation: options?.verifyConfirmation

--- a/components/positions/PositionDetailPage.tsx
+++ b/components/positions/PositionDetailPage.tsx
@@ -155,14 +155,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
       to,
       data,
       value,
-      sendTransaction: ({ to: target, data: transactionData, value: transactionValue }) =>
-        walletClient.data.sendTransaction({
-          account: wallet,
-          chain: walletClient.data.chain,
-          to: target,
-          data: transactionData,
-          value: transactionValue,
-        }),
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describePositionError,
       validateSimulation,
       verifyConfirmation,
@@ -214,7 +207,6 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
             args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
-        return;
       }
       await sendTransaction({
         kind: "deposit-basket-collateral",
@@ -281,7 +273,6 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
             args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
-        return;
       }
       await sendTransaction({
         kind: "stake-position",

--- a/components/positions/PositionListPage.tsx
+++ b/components/positions/PositionListPage.tsx
@@ -93,14 +93,7 @@ function PositionListRuntime() {
         to: deploymentState.deployment.contracts.diamond,
         data,
         value: creationFee,
-        sendTransaction: ({ to, data: transactionData, value }) =>
-          walletClient.data.sendTransaction({
-            account: wallet,
-            chain: walletClient.data.chain,
-            to,
-            data: transactionData,
-            value,
-          }),
+        sendTransaction: walletState.sendEvmTransaction,
         describeError: describePositionError,
         validateSimulation: (result) => {
           if (!result) throw new Error("The position simulation returned no token ID.");

--- a/components/rewards/RewardsPage.tsx
+++ b/components/rewards/RewardsPage.tsx
@@ -209,22 +209,7 @@ function RewardsRuntime({ initialPositionId }: { initialPositionId: bigint | nul
         publicClient,
         wallet,
         chainId: deploymentState.deployment.chainId,
-        sendTransaction: ({
-          to,
-          data,
-          value,
-        }: {
-          to: `0x${string}`;
-          data: `0x${string}`;
-          value?: bigint;
-        }) =>
-          walletClient.data.sendTransaction({
-            account: wallet,
-            chain: walletClient.data.chain,
-            to,
-            data,
-            value,
-          }),
+        sendTransaction: walletState.sendEvmTransaction,
         describeError: describePositionError,
       };
       if (refreshed.data.stakingTokenBalance < amount) {
@@ -243,42 +228,41 @@ function RewardsRuntime({ initialPositionId }: { initialPositionId: bigint | nul
             args: [diamond, MAX_ERC20_ALLOWANCE],
           }),
         });
-      } else {
-        await executeProtocolTransaction({
-          ...common,
-          kind: stakePositionId === null ? "create-and-stake" : "stake-position",
-          label:
-            stakePositionId === null
-              ? `Create position and stake ${token.symbol}`
-              : `Stake ${token.symbol} in Position #${stakePositionId.toString()}`,
-          amount:
-            stakePositionId === null
-              ? `${amountInput} ${token.symbol} + ${formatEther(refreshed.data.positionCreationFee)} ETH account fee`
-              : `${amountInput} ${token.symbol}`,
-          to: diamond,
-          data:
-            stakePositionId === null
-              ? buildCreateAndStakeCall(amount, wallet, [])
-              : buildStakeCall(stakePositionId, amount),
-          value: stakePositionId === null ? refreshed.data.positionCreationFee : 0n,
-          validateSimulation:
-            stakePositionId === null
-              ? (result) => {
-                  if (!result)
-                    throw new Error("The create-and-stake simulation returned no position.");
-                  const positionId = decodeFunctionResult({
-                    abi: staticsAbi,
-                    functionName: "createAndStake",
-                    data: result,
-                  });
-                  if (positionId === 0n) {
-                    throw new Error("The create-and-stake simulation returned an invalid ID.");
-                  }
-                }
-              : undefined,
-        });
-        setAmountInput("");
       }
+      await executeProtocolTransaction({
+        ...common,
+        kind: stakePositionId === null ? "create-and-stake" : "stake-position",
+        label:
+          stakePositionId === null
+            ? `Create position and stake ${token.symbol}`
+            : `Stake ${token.symbol} in Position #${stakePositionId.toString()}`,
+        amount:
+          stakePositionId === null
+            ? `${amountInput} ${token.symbol} + ${formatEther(refreshed.data.positionCreationFee)} ETH account fee`
+            : `${amountInput} ${token.symbol}`,
+        to: diamond,
+        data:
+          stakePositionId === null
+            ? buildCreateAndStakeCall(amount, wallet, [])
+            : buildStakeCall(stakePositionId, amount),
+        value: stakePositionId === null ? refreshed.data.positionCreationFee : 0n,
+        validateSimulation:
+          stakePositionId === null
+            ? (result) => {
+                if (!result)
+                  throw new Error("The create-and-stake simulation returned no position.");
+                const positionId = decodeFunctionResult({
+                  abi: staticsAbi,
+                  functionName: "createAndStake",
+                  data: result,
+                });
+                if (positionId === 0n) {
+                  throw new Error("The create-and-stake simulation returned an invalid ID.");
+                }
+              }
+            : undefined,
+      });
+      setAmountInput("");
       await catalog.refetch();
     } catch (error) {
       setActionError(describePositionError(error));
@@ -330,14 +314,7 @@ function RewardsRuntime({ initialPositionId }: { initialPositionId: bigint | nul
           .join(" + "),
         to: deploymentState.deployment.contracts.diamond,
         data: buildClaimRewardsCall(positionId, assets, wallet, minimums),
-        sendTransaction: ({ to, data, value }) =>
-          walletClient.data!.sendTransaction({
-            account: wallet,
-            chain: walletClient.data!.chain,
-            to,
-            data,
-            value,
-          }),
+        sendTransaction: walletState.sendEvmTransaction,
         describeError: describePositionError,
         validateSimulation: (result) => {
           if (!result) throw new Error("The reward claim simulation returned no amounts.");
@@ -429,14 +406,7 @@ function RewardsRuntime({ initialPositionId }: { initialPositionId: bigint | nul
           .join(" + "),
         to: deploymentState.deployment.contracts.diamond,
         data: buildClaimBasketRewardsCall(entry.positionId, entry.basketId, wallet),
-        sendTransaction: ({ to, data, value }) =>
-          walletClient.data!.sendTransaction({
-            account: wallet,
-            chain: walletClient.data!.chain,
-            to,
-            data,
-            value,
-          }),
+        sendTransaction: walletState.sendEvmTransaction,
         describeError: describePositionError,
         validateSimulation: (result) => {
           if (!result) throw new Error("The basket reward claim simulation returned no amounts.");

--- a/components/tools/ApprovalToolsPage.tsx
+++ b/components/tools/ApprovalToolsPage.tsx
@@ -20,6 +20,15 @@ import {
   type ApprovalRecord,
 } from "@/lib/protocol/approval-inventory";
 import { approvalClockTimestamp, approvalStatusLabel } from "@/lib/protocol/approvals";
+import { executeProtocolActionPlan } from "@/lib/protocol/action-plan";
+import {
+  actionPresentation,
+  approvalPresentation,
+  erc1155OperatorPermission,
+  erc721OperatorPermission,
+  maximumPermit2Permission,
+  unlimitedTokenPermission,
+} from "@/lib/protocol/presentation";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import { useWalletState } from "@/providers/wallet-context";
 
@@ -149,6 +158,45 @@ function ApprovalToolsRuntime() {
       throw new Error("The connected wallet is unavailable.");
     }
     const transaction = buildApprovalUpdate(approval, enabled);
+    const permissionPresentation =
+      approval.kind === "erc20"
+        ? approvalPresentation(
+            unlimitedTokenPermission({
+              asset: approval.tokenSymbol,
+              spender: approval.spender,
+              spenderName: approval.spenderLabel,
+            }),
+            approval.tokenName
+          )
+        : approval.kind === "permit2"
+          ? approvalPresentation(
+              maximumPermit2Permission({
+                asset: approval.tokenSymbol,
+                spender: approval.spender,
+                spenderName: approval.spenderLabel,
+              }),
+              "Permit2"
+            )
+          : approval.kind === "operator"
+            ? approvalPresentation(
+                approval.token === deploymentState.deployment.contracts.risk
+                  ? erc1155OperatorPermission({
+                      asset: approval.tokenName,
+                      spender: approval.spender,
+                      spenderName: approval.spenderLabel,
+                    })
+                  : erc721OperatorPermission({
+                      asset: approval.tokenName,
+                      spender: approval.spender,
+                      spenderName: approval.spenderLabel,
+                    }),
+                approval.tokenName
+              )
+            : actionPresentation({
+                action: `Approve ${approval.tokenSymbol}`,
+                description: `Approve only ${approval.tokenSymbol} for ${approval.spenderLabel} (${approval.spender}). This does not grant collection-wide operator access.`,
+                contractName: approval.tokenName,
+              });
     await executeProtocolTransaction({
       publicClient,
       wallet,
@@ -158,14 +206,8 @@ function ApprovalToolsRuntime() {
       amount: `${approvalKindLabel(approval.kind)} for ${approval.spenderLabel}`,
       to: transaction.target,
       data: transaction.data,
-      sendTransaction: ({ to, data, value }) =>
-        walletClient.data!.sendTransaction({
-          account: wallet,
-          chain: walletClient.data!.chain,
-          to,
-          data,
-          value,
-        }),
+      presentation: enabled ? permissionPresentation : undefined,
+      sendTransaction: walletState.sendEvmTransaction,
       describeError: describeApprovalError,
       verifyConfirmation: async () => {
         const confirmed = await readApprovalState(publicClient, wallet, approval);
@@ -200,10 +242,14 @@ function ApprovalToolsRuntime() {
     setPendingKey("all");
     setError(null);
     try {
-      for (let index = 0; index < active.length; index += 1) {
-        setBulkProgress({ current: index + 1, total: active.length });
-        await updateApproval(active[index]!, false);
-      }
+      await executeProtocolActionPlan(
+        active.map((approval) => ({
+          id: approval.key,
+          label: `Revoke ${approval.tokenSymbol} for ${approval.spenderLabel}`,
+          run: () => updateApproval(approval, false),
+        })),
+        ({ current, total }) => setBulkProgress({ current, total })
+      );
       await approvals.refetch();
     } catch (cause) {
       setError(

--- a/components/wallet/TestnetFaucetCard.tsx
+++ b/components/wallet/TestnetFaucetCard.tsx
@@ -2,14 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useFormatter, useTranslations } from "next-intl";
-import {
-  createPublicClient,
-  createWalletClient,
-  custom,
-  formatUnits,
-  getAddress,
-  type Address,
-} from "viem";
+import { createPublicClient, custom, formatUnits, getAddress, type Address } from "viem";
 
 import {
   basketTokenAbi,
@@ -204,11 +197,6 @@ export function TestnetFaucetCard() {
         chain: network.chain,
         transport: custom(provider),
       });
-      const walletClient = createWalletClient({
-        account,
-        chain: network.chain,
-        transport: custom(provider),
-      });
       const before = snapshot ?? (await readSnapshot());
       if (!before) throw new Error("Faucet inventory is unavailable.");
       if (before.assets.some((asset) => asset.inventory < asset.amount)) {
@@ -225,8 +213,7 @@ export function TestnetFaucetCard() {
           .join(" + "),
         to: faucet.address,
         data: buildTestnetFaucetClaimCall(),
-        sendTransaction: ({ to, data, value }) =>
-          walletClient.sendTransaction({ account, chain: network.chain, to, data, value }),
+        sendTransaction: wallet.sendEvmTransaction,
         describeError: describeDollarError,
         verifyConfirmation: async () => {
           const next = await readSnapshot();

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   createPublicClient,
-  createWalletClient,
   custom,
   encodeFunctionData,
   formatUnits,
@@ -805,11 +804,6 @@ function SendDialog({
         chain: network.chain,
         transport: custom(provider),
       });
-      const walletClient = createWalletClient({
-        account,
-        chain: network.chain,
-        transport: custom(provider),
-      });
       const to = asset.kind === "native" ? getAddress(recipient) : asset.address!;
       let data: Hex = "0x";
       if (asset.kind === "erc20") {
@@ -837,14 +831,7 @@ function SendDialog({
         to,
         data,
         value: asset.kind === "native" ? amountRaw : 0n,
-        sendTransaction: ({ to: target, data: transactionData, value }) =>
-          walletClient.sendTransaction({
-            account,
-            chain: network.chain,
-            to: target,
-            data: transactionData,
-            value,
-          }),
+        sendTransaction: wallet.sendEvmTransaction,
         describeError: (cause) => (cause instanceof Error ? cause.message : "The transfer failed."),
       });
       await onConfirmed();
@@ -1010,14 +997,7 @@ function NftTransferForm({ nft, onDone }: { nft: WalletNft; onDone: () => void }
           functionName: "safeTransferFrom",
           args: [sender, to, nft.tokenId],
         }),
-        sendTransaction: ({ to: target, data, value }) =>
-          walletClient.data!.sendTransaction({
-            account: sender,
-            chain: walletClient.data!.chain,
-            to: target,
-            data,
-            value,
-          }),
+        sendTransaction: wallet.sendEvmTransaction,
         describeError: (cause) =>
           cause instanceof Error ? cause.message : "The transfer did not complete.",
         // Confirms the chain actually reassigned the token, rather than

--- a/lib/baskets/baskets.ts
+++ b/lib/baskets/baskets.ts
@@ -347,7 +347,7 @@ export function deriveBasketActionAvailability(input: {
       if (constituent.allowance < maximum) {
         return {
           kind: "approve",
-          label: `Approve underlying ${index + 1}`,
+          label: "Mint basket",
           reason: null,
           approvalIndex: index,
           executable: true,

--- a/lib/dollar/permit.ts
+++ b/lib/dollar/permit.ts
@@ -51,7 +51,12 @@ export function privyPermitRequest<
     options: {
       address,
       uiOptions: {
-        showWalletUIs: false as const,
+        showWalletUIs: true as const,
+        title: "Approve unlimited token spending",
+        description:
+          "Sign a maximum token allowance for the Statics Dollar Gateway. The signature expires in 20 minutes, but an executed allowance remains active until consumed or revoked in Approval Tools.",
+        buttonText: "Sign approval",
+        isCancellable: true as const,
       },
     },
   };

--- a/lib/loans/loans.ts
+++ b/lib/loans/loans.ts
@@ -489,7 +489,7 @@ export function deriveLoanActionAvailability(input: {
       if ((input.allowances?.[index] ?? 0n) < required) {
         return {
           kind: "approve",
-          label: `Approve asset ${index + 1}`,
+          label: input.mode === "extend" ? "Extend loan" : "Repay loan",
           reason: null,
           approvalIndex: index,
           executable: true,

--- a/lib/protocol/action-plan.ts
+++ b/lib/protocol/action-plan.ts
@@ -30,13 +30,13 @@ export async function executeProtocolActionPlan(
         status,
       });
 
-    if (step.isSatisfied && (await step.isSatisfied())) {
-      progress("skipped");
-      continue;
-    }
-
-    progress("active");
     try {
+      if (step.isSatisfied && (await step.isSatisfied())) {
+        progress("skipped");
+        continue;
+      }
+
+      progress("active");
       await step.run();
       progress("confirmed");
     } catch (error) {

--- a/lib/protocol/action-plan.ts
+++ b/lib/protocol/action-plan.ts
@@ -1,0 +1,57 @@
+export type ProtocolActionStepStatus = "pending" | "active" | "confirmed" | "skipped" | "failed";
+
+export type ProtocolActionStep = Readonly<{
+  id: string;
+  label: string;
+  isSatisfied?: () => Promise<boolean>;
+  run: () => Promise<void>;
+}>;
+
+export type ProtocolActionProgress = Readonly<{
+  current: number;
+  total: number;
+  stepId: string;
+  label: string;
+  status: ProtocolActionStepStatus;
+}>;
+
+export async function executeProtocolActionPlan(
+  steps: readonly ProtocolActionStep[],
+  onProgress?: (progress: ProtocolActionProgress) => void
+): Promise<void> {
+  for (let index = 0; index < steps.length; index += 1) {
+    const step = steps[index]!;
+    const progress = (status: ProtocolActionStepStatus) =>
+      onProgress?.({
+        current: index + 1,
+        total: steps.length,
+        stepId: step.id,
+        label: step.label,
+        status,
+      });
+
+    if (step.isSatisfied && (await step.isSatisfied())) {
+      progress("skipped");
+      continue;
+    }
+
+    progress("active");
+    try {
+      await step.run();
+      progress("confirmed");
+    } catch (error) {
+      progress("failed");
+      throw error;
+    }
+  }
+}
+
+export function protocolActionProgressLabel(
+  progress: ProtocolActionProgress | null
+): string | null {
+  if (!progress) return null;
+  if (progress.status === "failed") {
+    return `Stopped at ${progress.current} of ${progress.total}: ${progress.label}`;
+  }
+  return `${progress.current} of ${progress.total} — ${progress.label}`;
+}

--- a/lib/protocol/presentation.ts
+++ b/lib/protocol/presentation.ts
@@ -1,0 +1,71 @@
+import type { Address } from "viem";
+
+import type {
+  ProtocolPermissionDisclosure,
+  ProtocolTransactionPresentation,
+} from "@/lib/protocol/transactions";
+
+type PermissionInput = Readonly<{
+  asset: string;
+  spender: Address;
+  spenderName: string;
+}>;
+
+export function unlimitedTokenPermission(input: PermissionInput): ProtocolPermissionDisclosure {
+  return {
+    scope: "unlimited-token",
+    ...input,
+    detail: `Unlimited ${input.asset} spending permission. It remains active until revoked.`,
+  };
+}
+
+export function maximumPermit2Permission(input: PermissionInput): ProtocolPermissionDisclosure {
+  return {
+    scope: "maximum-permit2",
+    ...input,
+    detail: `Maximum Permit2 permission for ${input.asset} with no practical expiry. It remains active until revoked.`,
+  };
+}
+
+export function erc721OperatorPermission(input: PermissionInput): ProtocolPermissionDisclosure {
+  return {
+    scope: "erc721-operator",
+    ...input,
+    detail: `Operator access to every current and future ${input.asset} NFT in this wallet. It remains active until revoked.`,
+  };
+}
+
+export function erc1155OperatorPermission(input: PermissionInput): ProtocolPermissionDisclosure {
+  return {
+    scope: "erc1155-operator",
+    ...input,
+    detail: `Operator access to ${input.asset} across every current and future token ID. It remains active until revoked.`,
+  };
+}
+
+export function approvalPresentation(
+  permission: ProtocolPermissionDisclosure,
+  contractName: string
+): ProtocolTransactionPresentation {
+  return {
+    action: `Approve ${permission.asset}`,
+    description: `${permission.detail} Spender: ${permission.spenderName} (${permission.spender}). You can revoke it from Approval Tools.`,
+    buttonText: `Approve ${permission.asset}`,
+    contractName,
+    permission,
+  };
+}
+
+export function actionPresentation(input: {
+  action: string;
+  description: string;
+  contractName: string;
+  buttonText?: string;
+}): ProtocolTransactionPresentation {
+  return {
+    action: input.action,
+    description: input.description,
+    buttonText: input.buttonText ?? input.action,
+    contractName: input.contractName,
+  };
+}

--- a/lib/protocol/transactions.ts
+++ b/lib/protocol/transactions.ts
@@ -98,6 +98,17 @@ function calldataAddress(data: Hex, wordIndex: number): Address | null {
   }
 }
 
+function calldataUint(data: Hex, wordIndex: number): bigint | null {
+  const wordStart = 10 + wordIndex * 64;
+  const encoded = data.slice(wordStart, wordStart + 64);
+  if (encoded.length !== 64) return null;
+  try {
+    return BigInt(`0x${encoded}`);
+  } catch {
+    return null;
+  }
+}
+
 export function defaultProtocolPresentation(
   request: Pick<ProtocolTransactionRequest, "kind" | "label" | "amount" | "data">
 ): ProtocolTransactionPresentation {
@@ -105,6 +116,8 @@ export function defaultProtocolPresentation(
   const isOperatorApproval = operatorApprovalKinds.has(request.kind);
   const isPermit2Approval = request.kind === "approve-permit2";
   const isBoundedApproval = request.kind === "approve-swap" || request.kind === "approve-bridge";
+  const isErc20Approval = request.data.startsWith(erc20ApproveSelector);
+  const erc20Allowance = isErc20Approval ? calldataUint(request.data, 1) : null;
   const spender = isPermit2Approval
     ? request.data.startsWith(permit2ApproveSelector)
       ? calldataAddress(request.data, 1)
@@ -113,7 +126,7 @@ export function defaultProtocolPresentation(
       ? request.data.startsWith(operatorApproveSelector)
         ? calldataAddress(request.data, 0)
         : null
-      : request.data.startsWith(erc20ApproveSelector)
+      : isErc20Approval
         ? calldataAddress(request.data, 0)
         : null;
   const spenderCopy = spender ? ` Spender: ${spender}.` : "";
@@ -143,7 +156,7 @@ export function defaultProtocolPresentation(
       contractName: request.kind === "approve-lp-nft" ? "Position Manager" : "Risk shares",
     };
   }
-  if (isBoundedApproval && /^(reset|revoke)\b/i.test(request.label)) {
+  if (isBoundedApproval && erc20Allowance === 0n) {
     return {
       action: request.label,
       description: `${request.label}. This removes the existing token spending allowance.${spenderCopy}`,

--- a/lib/protocol/transactions.ts
+++ b/lib/protocol/transactions.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import type { Address, Hex, PublicClient, TransactionReceipt } from "viem";
+import {
+  getAddress,
+  toFunctionSelector,
+  type Address,
+  type Hex,
+  type PublicClient,
+  type TransactionReceipt,
+} from "viem";
 
 import {
   updateProtocolActivity,
@@ -16,6 +23,31 @@ import {
   waitForRpcBlock,
 } from "@/lib/protocol/reconciliation";
 
+export type ProtocolPermissionDisclosure = Readonly<{
+  scope: "unlimited-token" | "maximum-permit2" | "erc721-operator" | "erc1155-operator";
+  asset: string;
+  spender: Address;
+  spenderName: string;
+  detail: string;
+}>;
+
+export type ProtocolTransactionPresentation = Readonly<{
+  action: string;
+  description: string;
+  buttonText: string;
+  contractName: string;
+  permission?: ProtocolPermissionDisclosure;
+}>;
+
+export type ProtocolTransactionSendRequest = Readonly<{
+  wallet: Address;
+  chainId: number;
+  to: Address;
+  data: Hex;
+  value?: bigint;
+  presentation: ProtocolTransactionPresentation;
+}>;
+
 export type ProtocolTransactionRequest = Readonly<{
   publicClient: PublicClient;
   wallet: Address;
@@ -26,7 +58,8 @@ export type ProtocolTransactionRequest = Readonly<{
   to: Address;
   data: Hex;
   value?: bigint;
-  sendTransaction: (request: { to: Address; data: Hex; value?: bigint }) => Promise<Hex>;
+  presentation?: ProtocolTransactionPresentation;
+  sendTransaction: (request: ProtocolTransactionSendRequest) => Promise<Hex>;
   describeError: (error: unknown) => string;
   validateSimulation?: (result: Hex | undefined) => void;
   verifyConfirmation?: (receipt: TransactionReceipt) => Promise<void>;
@@ -37,6 +70,110 @@ export class ConfirmationVerificationError extends Error {
     super(message, options);
     this.name = "ConfirmationVerificationError";
   }
+}
+
+const maximumTokenApprovalKinds = new Set<ProtocolActivityKind>([
+  "approve-weth",
+  "approve-dollar",
+  "approve-basket-asset",
+  "approve-basket-token",
+  "approve-staking-token",
+  "approve-lp-token",
+  "approve-loan-asset",
+]);
+
+const operatorApprovalKinds = new Set<ProtocolActivityKind>(["approve-risk", "approve-lp-nft"]);
+const erc20ApproveSelector = toFunctionSelector("approve(address,uint256)");
+const permit2ApproveSelector = toFunctionSelector("approve(address,address,uint160,uint48)");
+const operatorApproveSelector = toFunctionSelector("setApprovalForAll(address,bool)");
+
+function calldataAddress(data: Hex, wordIndex: number): Address | null {
+  const wordStart = 10 + wordIndex * 64;
+  const encoded = data.slice(wordStart + 24, wordStart + 64);
+  if (encoded.length !== 40) return null;
+  try {
+    return getAddress(`0x${encoded}`);
+  } catch {
+    return null;
+  }
+}
+
+export function defaultProtocolPresentation(
+  request: Pick<ProtocolTransactionRequest, "kind" | "label" | "amount" | "data">
+): ProtocolTransactionPresentation {
+  const isMaximumTokenApproval = maximumTokenApprovalKinds.has(request.kind);
+  const isOperatorApproval = operatorApprovalKinds.has(request.kind);
+  const isPermit2Approval = request.kind === "approve-permit2";
+  const isBoundedApproval = request.kind === "approve-swap" || request.kind === "approve-bridge";
+  const spender = isPermit2Approval
+    ? request.data.startsWith(permit2ApproveSelector)
+      ? calldataAddress(request.data, 1)
+      : null
+    : isOperatorApproval
+      ? request.data.startsWith(operatorApproveSelector)
+        ? calldataAddress(request.data, 0)
+        : null
+      : request.data.startsWith(erc20ApproveSelector)
+        ? calldataAddress(request.data, 0)
+        : null;
+  const spenderCopy = spender ? ` Spender: ${spender}.` : "";
+
+  if (isMaximumTokenApproval) {
+    return {
+      action: request.label,
+      description: `${request.label}. This grants unlimited token spending until you revoke it.${spenderCopy} You can review or revoke it from Approval Tools.`,
+      buttonText: "Approve unlimited spending",
+      contractName: "Token approval",
+    };
+  }
+  if (isPermit2Approval) {
+    return {
+      action: request.label,
+      description: `${request.label}. This grants the maximum Permit2 allowance with no practical expiry; it remains active until revoked.${spenderCopy} You can review or revoke it from Approval Tools.`,
+      buttonText: "Approve maximum allowance",
+      contractName: "Permit2",
+    };
+  }
+  if (isOperatorApproval) {
+    const asset = request.kind === "approve-lp-nft" ? "liquidity-position NFTs" : "Risk share IDs";
+    return {
+      action: request.label,
+      description: `${request.label}. This grants operator access to all current and future ${asset} until revoked.${spenderCopy} You can review or revoke it from Approval Tools.`,
+      buttonText: "Approve operator access",
+      contractName: request.kind === "approve-lp-nft" ? "Position Manager" : "Risk shares",
+    };
+  }
+  if (isBoundedApproval && /^(reset|revoke)\b/i.test(request.label)) {
+    return {
+      action: request.label,
+      description: `${request.label}. This removes the existing token spending allowance.${spenderCopy}`,
+      buttonText: "Reset token approval",
+      contractName: "Token approval",
+    };
+  }
+  if (isBoundedApproval) {
+    return {
+      action: request.label,
+      description: `${request.label}. This approval is bounded to the reviewed route amount: ${request.amount}.${spenderCopy}`,
+      buttonText: "Approve reviewed amount",
+      contractName: "Token approval",
+    };
+  }
+
+  const contractName =
+    request.kind === "swap"
+      ? "Swap router"
+      : request.kind === "bridge"
+        ? "Across bridge"
+        : request.kind === "send"
+          ? "Wallet transfer"
+          : "Statics protocol";
+  return {
+    action: request.label,
+    description: `${request.label}. Reviewed amount: ${request.amount}.`,
+    buttonText: request.label,
+    contractName,
+  };
 }
 
 export async function executeProtocolTransaction(
@@ -69,9 +206,12 @@ export async function executeProtocolTransaction(
     updateProtocolActivity(request.wallet, request.chainId, id, { status: "signing" });
 
     const hash = await request.sendTransaction({
+      wallet: request.wallet,
+      chainId: request.chainId,
       to: request.to,
       data: request.data,
       value: request.value,
+      presentation: request.presentation ?? defaultProtocolPresentation(request),
     });
     stage = "submitted";
     updateProtocolActivity(request.wallet, request.chainId, id, {

--- a/messages/en.json
+++ b/messages/en.json
@@ -160,7 +160,10 @@
     "switching": "Switching…",
     "switchNetwork": "Switch network",
     "application": "Statics application",
-    "primary": "Primary"
+    "primary": "Primary",
+    "approvalsTitle": "How approvals work.",
+    "approvalsBody": "Statics uses maximum token and operator approvals so setup confirmations can run in sequence and routine actions do not ask again. Each wallet prompt identifies the permission and spender. Authority remains active until revoked.",
+    "manageApprovals": "Review or revoke approvals"
   },
   "surface": {
     "notConfigured": "Statics is not configured",
@@ -404,7 +407,7 @@
     "withdraw": "Withdraw",
     "basket": "Basket",
     "waiting": "Waiting for confirmation…",
-    "approveDeposit": "Approve or deposit BasketToken",
+    "approveDeposit": "Deposit BasketToken",
     "withdrawBasket": "Withdraw BasketToken",
     "mintInto": "Mint {symbol} into this position",
     "redeemFrom": "Redeem this position's {symbol}",
@@ -416,7 +419,7 @@
     "walletBalance": "Wallet balance",
     "positionStake": "Position stake",
     "maturityDescription": "Your stake is always withdrawable. New stake and newly selected reward assets start earning once they mature; withdrawals take from stake that is not yet earning first.",
-    "approveStake": "Approve or stake {symbol}",
+    "approveStake": "Stake {symbol}",
     "unstakeToken": "Unstake {symbol}",
     "selectedRewards": "Position-selected rewards",
     "chooseAssets": "Choose up to {count} fee assets",
@@ -438,7 +441,7 @@
   },
   "rewards": {
     "subject": "rewards",
-    "approveOrCreate": "Approve or create staking position",
+    "approveOrCreate": "Create staking position",
     "signIn": "Sign in to continue",
     "createWallet": "Create embedded wallet",
     "switchTo": "Switch to {network}",

--- a/messages/es.json
+++ b/messages/es.json
@@ -160,7 +160,10 @@
     "switching": "Cambiando…",
     "switchNetwork": "Cambiar de red",
     "application": "Aplicación Statics",
-    "primary": "Principal"
+    "primary": "Principal",
+    "approvalsTitle": "Cómo funcionan las aprobaciones.",
+    "approvalsBody": "Statics usa aprobaciones máximas de tokens y operadores para confirmar la configuración en secuencia y evitar solicitudes repetidas. Cada aviso de la billetera identifica el permiso y el gastador. La autoridad permanece activa hasta que la revoques.",
+    "manageApprovals": "Revisar o revocar aprobaciones"
   },
   "surface": {
     "notConfigured": "Statics no está configurado",
@@ -404,7 +407,7 @@
     "withdraw": "Retirar",
     "basket": "Canasta",
     "waiting": "Esperando confirmación…",
-    "approveDeposit": "Aprobar o depositar BasketToken",
+    "approveDeposit": "Depositar BasketToken",
     "withdrawBasket": "Retirar BasketToken",
     "mintInto": "Acuñar {symbol} en esta posición",
     "redeemFrom": "Reembolsar {symbol} de esta posición",
@@ -416,7 +419,7 @@
     "walletBalance": "Saldo de cartera",
     "positionStake": "Stake de la posición",
     "maturityDescription": "Tu stake siempre puede retirarse. El stake nuevo y los activos recién seleccionados empiezan a ganar al madurar; los retiros usan primero el stake que aún no gana.",
-    "approveStake": "Aprobar o depositar {symbol}",
+    "approveStake": "Depositar {symbol}",
     "unstakeToken": "Retirar {symbol}",
     "selectedRewards": "Recompensas elegidas por la posición",
     "chooseAssets": "Elige hasta {count} activos de comisión",
@@ -438,7 +441,7 @@
   },
   "rewards": {
     "subject": "recompensas",
-    "approveOrCreate": "Aprobar o crear posición de staking",
+    "approveOrCreate": "Crear posición de staking",
     "signIn": "Inicia sesión para continuar",
     "createWallet": "Crear cartera integrada",
     "switchTo": "Cambiar a {network}",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -160,7 +160,10 @@
     "switching": "正在切换…",
     "switchNetwork": "切换网络",
     "application": "Statics 应用",
-    "primary": "主要"
+    "primary": "主要",
+    "approvalsTitle": "授权的工作方式。",
+    "approvalsBody": "Statics 使用最大代币和操作员授权，让设置确认按顺序完成，并避免常规操作重复请求。每个钱包提示都会标明权限和支出方。授权会持续有效，直到你撤销。",
+    "manageApprovals": "查看或撤销授权"
   },
   "surface": {
     "notConfigured": "Statics 尚未配置",
@@ -404,7 +407,7 @@
     "withdraw": "取出",
     "basket": "篮子",
     "waiting": "等待确认…",
-    "approveDeposit": "授权或存入 BasketToken",
+    "approveDeposit": "存入 BasketToken",
     "withdrawBasket": "取出 BasketToken",
     "mintInto": "将 {symbol} 铸造到此仓位",
     "redeemFrom": "从此仓位赎回 {symbol}",
@@ -416,7 +419,7 @@
     "walletBalance": "钱包余额",
     "positionStake": "仓位质押",
     "maturityDescription": "质押始终可以取出。新增质押和新选奖励资产会在成熟后开始赚取；取出时会先使用尚未开始赚取的质押。",
-    "approveStake": "授权或质押 {symbol}",
+    "approveStake": "质押 {symbol}",
     "unstakeToken": "解除质押 {symbol}",
     "selectedRewards": "仓位选择的奖励",
     "chooseAssets": "最多选择 {count} 种手续费资产",
@@ -438,7 +441,7 @@
   },
   "rewards": {
     "subject": "奖励",
-    "approveOrCreate": "授权或创建质押仓位",
+    "approveOrCreate": "创建质押仓位",
     "signIn": "登录以继续",
     "createWallet": "创建内置钱包",
     "switchTo": "切换到 {network}",

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -7,6 +7,7 @@ import {
   useCreateWallet,
   useExportWallet,
   usePrivy,
+  useSendTransaction,
   useWallets,
   type ConnectedWallet,
 } from "@privy-io/react-auth";
@@ -20,6 +21,7 @@ import {
 import { createConfig, useSetActiveWallet, WagmiProvider } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
+import { createWalletClient, custom, getAddress } from "viem";
 import { useAccount } from "wagmi";
 
 import {
@@ -76,6 +78,7 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
   const { ready: walletsReady, wallets } = useWallets();
   const { createWallet } = useCreateWallet();
   const { exportWallet } = useExportWallet();
+  const { sendTransaction: sendEmbeddedTransaction } = useSendTransaction();
   const wagmiAccount = useAccount();
   const { setActiveWallet } = useSetActiveWallet();
   const { createWallet: createSolanaWallet } = useCreateSolanaWallet();
@@ -230,6 +233,58 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
         if (!selectedWallet) return null;
         return selectedWallet.getEthereumProvider();
       },
+      sendEvmTransaction: async (request) => {
+        if (!selectedWallet || !address) throw new Error("Connect a wallet before continuing.");
+        if (getAddress(address) !== getAddress(request.wallet)) {
+          throw new Error("The transaction was prepared for a different wallet.");
+        }
+        if (chainId !== request.chainId) {
+          throw new Error("Switch the connected wallet to the transaction network.");
+        }
+
+        if (walletKind === "embedded") {
+          const result = await sendEmbeddedTransaction(
+            {
+              from: request.wallet,
+              to: request.to,
+              data: request.data,
+              value: request.value,
+              chainId: request.chainId,
+            },
+            {
+              address,
+              uiOptions: {
+                showWalletUIs: true,
+                description: request.presentation.description,
+                buttonText: request.presentation.buttonText,
+                transactionInfo: {
+                  title: "Transaction details",
+                  action: request.presentation.action,
+                  contractInfo: { name: request.presentation.contractName },
+                },
+                successHeader: `${request.presentation.action} submitted`,
+                successDescription: "The app will wait for onchain confirmation before continuing.",
+                isCancellable: true,
+              },
+            }
+          );
+          return result.hash;
+        }
+
+        const provider = await selectedWallet.getEthereumProvider();
+        const client = createWalletClient({
+          account: request.wallet,
+          chain: undefined,
+          transport: custom(provider),
+        });
+        return client.sendTransaction({
+          account: request.wallet,
+          chain: undefined,
+          to: request.to,
+          data: request.data,
+          value: request.value,
+        });
+      },
       exportWallet: () =>
         runAction("export", async () => {
           if (!embeddedWallet) throw new Error("Only an embedded wallet can be exported here.");
@@ -256,6 +311,7 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
       promptExternalWallet,
       privyError,
       selectedWallet,
+      sendEmbeddedTransaction,
       setActiveWallet,
       status,
       targetChain,
@@ -294,6 +350,7 @@ function ConfiguredWalletProviders({ children }: { children: React.ReactNode }) 
           ethereum: { createOnLogin: "users-without-wallets" },
           solana: { createOnLogin: "off" },
           showWalletUIs: true,
+          extendedCalldataDecoding: true,
         },
         externalWallets: {
           solana: { connectors: toSolanaWalletConnectors() },

--- a/providers/wallet-context.tsx
+++ b/providers/wallet-context.tsx
@@ -2,6 +2,9 @@
 
 import { createContext, useContext } from "react";
 import type { ConnectedWallet } from "@privy-io/react-auth";
+import type { Hex } from "viem";
+
+import type { ProtocolTransactionSendRequest } from "@/lib/protocol/transactions";
 
 export type WalletRuntimeStatus =
   "unconfigured" | "loading" | "signed-out" | "wallet-missing" | "ready" | "error";
@@ -51,11 +54,15 @@ export type WalletState = Readonly<{
   switchNetwork: () => Promise<void>;
   selectFundingNetwork: (chainId: number) => Promise<void>;
   getEthereumProvider: () => Promise<WalletEthereumProvider | null>;
+  sendEvmTransaction: (request: ProtocolTransactionSendRequest) => Promise<Hex>;
   exportWallet: () => Promise<void>;
   copyAddress: () => Promise<void>;
 }>;
 
 const unavailable = async () => undefined;
+const unavailableTransaction = async (): Promise<Hex> => {
+  throw new Error("The wallet transaction runtime is unavailable.");
+};
 
 export const defaultWalletState: WalletState = {
   status: "unconfigured",
@@ -83,6 +90,7 @@ export const defaultWalletState: WalletState = {
   switchNetwork: unavailable,
   selectFundingNetwork: unavailable,
   getEthereumProvider: async () => null,
+  sendEvmTransaction: unavailableTransaction,
   exportWallet: unavailable,
   copyAddress: unavailable,
 };

--- a/test/dollar/permit.test.ts
+++ b/test/dollar/permit.test.ts
@@ -53,7 +53,7 @@ describe("Dollar permit helpers", () => {
     expect(external).not.toHaveBeenCalled();
   });
 
-  it("builds Privy's headless intermediate permit request", () => {
+  it("builds a visible Privy permit request with maximum-allowance disclosure", () => {
     const typedData = {
       domain: {
         name: "Mock USDG",
@@ -90,7 +90,12 @@ describe("Dollar permit helpers", () => {
     expect(request.options).toEqual({
       address: "0x0000000000000000000000000000000000000002",
       uiOptions: {
-        showWalletUIs: false,
+        showWalletUIs: true,
+        title: "Approve unlimited token spending",
+        description:
+          "Sign a maximum token allowance for the Statics Dollar Gateway. The signature expires in 20 minutes, but an executed allowance remains active until consumed or revoked in Approval Tools.",
+        buttonText: "Sign approval",
+        isCancellable: true,
       },
     });
     expect(() => JSON.stringify(request)).not.toThrow();

--- a/test/loans/loans.test.ts
+++ b/test/loans/loans.test.ts
@@ -173,7 +173,7 @@ describe("loan lifecycle state", () => {
     ).toMatchObject({
       kind: "approve",
       approvalIndex: 1,
-      label: "Approve asset 2",
+      label: "Repay loan",
     });
     expect(
       deriveLoanActionAvailability({

--- a/test/protocol/action-plan.test.ts
+++ b/test/protocol/action-plan.test.ts
@@ -64,4 +64,30 @@ describe("protocol action plans", () => {
       "Stopped at 1 of 2: Approve token"
     );
   });
+
+  it("reports a failed step when its satisfaction check throws", async () => {
+    const failure = new Error("Allowance RPC unavailable");
+    const approval = vi.fn();
+    const finalAction = vi.fn();
+    const progress: ProtocolActionProgress[] = [];
+
+    await expect(
+      executeProtocolActionPlan(
+        [
+          {
+            id: "approval",
+            label: "Check token approval",
+            isSatisfied: async () => Promise.reject(failure),
+            run: approval,
+          },
+          { id: "action", label: "Deposit token", run: finalAction },
+        ],
+        (value) => progress.push(value)
+      )
+    ).rejects.toBe(failure);
+
+    expect(approval).not.toHaveBeenCalled();
+    expect(finalAction).not.toHaveBeenCalled();
+    expect(progress.at(-1)).toMatchObject({ stepId: "approval", status: "failed" });
+  });
 });

--- a/test/protocol/action-plan.test.ts
+++ b/test/protocol/action-plan.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeProtocolActionPlan,
+  protocolActionProgressLabel,
+  type ProtocolActionProgress,
+} from "@/lib/protocol/action-plan";
+
+describe("protocol action plans", () => {
+  it("runs unsatisfied steps in order and waits for each one", async () => {
+    const order: string[] = [];
+    const first = vi.fn(async () => void order.push("first"));
+    const second = vi.fn(async () => void order.push("second"));
+
+    await executeProtocolActionPlan([
+      { id: "first", label: "Approve token", run: first },
+      { id: "second", label: "Deposit token", run: second },
+    ]);
+
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("skips permissions already satisfied onchain", async () => {
+    const approval = vi.fn();
+    const action = vi.fn();
+    const progress: ProtocolActionProgress[] = [];
+
+    await executeProtocolActionPlan(
+      [
+        {
+          id: "approval",
+          label: "Approve token",
+          isSatisfied: async () => true,
+          run: approval,
+        },
+        { id: "action", label: "Deposit token", run: action },
+      ],
+      (value) => progress.push(value)
+    );
+
+    expect(approval).not.toHaveBeenCalled();
+    expect(action).toHaveBeenCalledOnce();
+    expect(progress[0]).toMatchObject({ stepId: "approval", status: "skipped" });
+  });
+
+  it("halts after a rejected or failed step", async () => {
+    const failure = new Error("User rejected the request");
+    const finalAction = vi.fn();
+    const progress: ProtocolActionProgress[] = [];
+
+    await expect(
+      executeProtocolActionPlan(
+        [
+          { id: "approval", label: "Approve token", run: async () => Promise.reject(failure) },
+          { id: "action", label: "Deposit token", run: finalAction },
+        ],
+        (value) => progress.push(value)
+      )
+    ).rejects.toBe(failure);
+
+    expect(finalAction).not.toHaveBeenCalled();
+    expect(progress.at(-1)).toMatchObject({ stepId: "approval", status: "failed" });
+    expect(protocolActionProgressLabel(progress.at(-1) ?? null)).toBe(
+      "Stopped at 1 of 2: Approve token"
+    );
+  });
+});

--- a/test/protocol/presentation.test.ts
+++ b/test/protocol/presentation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  approvalPresentation,
+  erc1155OperatorPermission,
+  erc721OperatorPermission,
+  maximumPermit2Permission,
+  unlimitedTokenPermission,
+} from "@/lib/protocol/presentation";
+
+const spender = "0x0000000000000000000000000000000000000001" as const;
+
+describe("transaction permission presentation", () => {
+  it("spells out unlimited token and maximum Permit2 permissions", () => {
+    const token = unlimitedTokenPermission({ asset: "TPA1", spender, spenderName: "Permit2" });
+    const permit2 = maximumPermit2Permission({
+      asset: "TPA1",
+      spender,
+      spenderName: "PositionManager",
+    });
+
+    expect(token.detail).toContain("Unlimited TPA1");
+    expect(token.detail).toContain("until revoked");
+    expect(permit2.detail).toContain("no practical expiry");
+    expect(approvalPresentation(token, "TPA1 token").description).toContain("Approval Tools");
+  });
+
+  it("spells out collection-wide operator authority", () => {
+    expect(
+      erc721OperatorPermission({ asset: "liquidity position", spender, spenderName: "Statics" })
+        .detail
+    ).toContain("every current and future liquidity position NFT");
+    expect(
+      erc1155OperatorPermission({ asset: "Risk shares", spender, spenderName: "Dollar Gateway" })
+        .detail
+    ).toContain("every current and future token ID");
+  });
+});

--- a/test/protocol/transactions.test.ts
+++ b/test/protocol/transactions.test.ts
@@ -111,7 +111,7 @@ describe("protocol transaction execution", () => {
     expect(
       defaultProtocolPresentation({
         kind: "approve-swap",
-        label: "Reset swap approval",
+        label: "Ajustar permiso de intercambio",
         amount: "10 TPA1",
         data: resetData,
       })
@@ -119,6 +119,16 @@ describe("protocol transaction execution", () => {
       buttonText: "Reset token approval",
       description: expect.stringContaining("removes the existing token spending allowance"),
     });
+
+    const boundedData = `0x095ea7b3${"0".repeat(24)}${spender}${"0".repeat(63)}1` as Hex;
+    expect(
+      defaultProtocolPresentation({
+        kind: "approve-swap",
+        label: "Reset swap approval",
+        amount: "10 TPA1",
+        data: boundedData,
+      }).buttonText
+    ).toBe("Approve reviewed amount");
   });
 
   it("does not request a signature when simulation validation fails", async () => {

--- a/test/protocol/transactions.test.ts
+++ b/test/protocol/transactions.test.ts
@@ -2,7 +2,10 @@ import type { Address, Hex, PublicClient } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { readProtocolActivity } from "@/lib/dollar/activity";
-import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import {
+  defaultProtocolPresentation,
+  executeProtocolTransaction,
+} from "@/lib/protocol/transactions";
 
 const wallet = "0x0000000000000000000000000000000000000001" as Address;
 const target = "0x0000000000000000000000000000000000000002" as Address;
@@ -43,6 +46,17 @@ describe("protocol transaction execution", () => {
     ).resolves.toBe(hash);
 
     expect(call).toHaveBeenCalledBefore(sendTransaction);
+    expect(sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wallet,
+        chainId: 31_337,
+        to: target,
+        presentation: expect.objectContaining({
+          action: "Create PositionNFT",
+          buttonText: "Create PositionNFT",
+        }),
+      })
+    );
     expect(waitForTransactionReceipt).toHaveBeenCalledWith(
       expect.objectContaining({ hash, confirmations: 1 })
     );
@@ -51,6 +65,59 @@ describe("protocol transaction execution", () => {
       kind: "create-position",
       status: "confirmed",
       confirmedHash: hash,
+    });
+  });
+
+  it("discloses maximum approvals and the encoded spender", async () => {
+    const spender = "0000000000000000000000000000000000000003";
+    const approvalData = `0x095ea7b3${"0".repeat(24)}${spender}${"f".repeat(64)}` as Hex;
+    const sendTransaction = vi.fn().mockResolvedValue(hash);
+
+    await executeProtocolTransaction({
+      publicClient: {
+        call: vi.fn().mockResolvedValue({ data: "0x01" }),
+        waitForTransactionReceipt: vi.fn().mockResolvedValue({
+          status: "success",
+          transactionHash: hash,
+        }),
+      } as unknown as PublicClient,
+      wallet,
+      chainId: 31_337,
+      kind: "approve-loan-asset",
+      label: "Approve TPA1 for loan repayment",
+      amount: "1 TPA1",
+      to: target,
+      data: approvalData,
+      sendTransaction,
+      describeError: (error) => (error instanceof Error ? error.message : "Unknown error"),
+    });
+
+    expect(sendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presentation: expect.objectContaining({
+          buttonText: "Approve unlimited spending",
+          description: expect.stringContaining(
+            "Spender: 0x0000000000000000000000000000000000000003"
+          ),
+        }),
+      })
+    );
+  });
+
+  it("describes allowance resets as revocations instead of new approval authority", () => {
+    const spender = "0000000000000000000000000000000000000003";
+    const resetData = `0x095ea7b3${"0".repeat(24)}${spender}${"0".repeat(64)}` as Hex;
+
+    expect(
+      defaultProtocolPresentation({
+        kind: "approve-swap",
+        label: "Reset swap approval",
+        amount: "10 TPA1",
+        data: resetData,
+      })
+    ).toMatchObject({
+      buttonText: "Reset token approval",
+      description: expect.stringContaining("removes the existing token spending allowance"),
     });
   });
 


### PR DESCRIPTION
## Summary

- route every EVM submission through one wallet runtime so embedded-wallet prompts show the action, contract context, reviewed amount, and permission scope
- automatically continue basket, Dollar, liquidity, position, reward, loan, swap, and bridge flows through all required confirmations and then the intended action
- distinguish unlimited ERC-20 approvals, maximum Permit2 allowances, NFT/share operators, bounded route approvals, and allowance resets
- explain the maximum-approval policy on protocol action pages and link directly to Approval Tools for review and revocation
- add a reusable sequential action runner and focused regression coverage

## Approval behavior

A rejection or failed transaction stops the sequence. Confirmed approvals remain onchain and can be reviewed or revoked from Approval Tools. External swap and bridge approvals remain bounded; Statics protocol approvals retain their intentional maximum scope.

## Validation

- npm run verify
- 420 unit tests passed
- production build passed
- 42 Playwright tests passed across desktop, tablet, and mobile
- lint, CSS lint, formatting, and typecheck passed

## Stack

This PR is intentionally based on PR #15 (feat/single-input-liquidity) and should be reviewed and merged after it.