### PR TITLE
fix(dollar): keep embedded permits atomic

### DIFF
--- a/components/portal/PeggedDollarPanel.tsx
+++ b/components/portal/PeggedDollarPanel.tsx
@@ -31,8 +31,12 @@ import {
   privyPermitRequest,
   signPermitForWallet,
 } from "@/lib/dollar/permit";
-import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import {
+  executeProtocolTransaction,
+  type ProtocolTransactionPresentation,
+} from "@/lib/protocol/transactions";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
+import { permittedActionPresentation } from "@/lib/protocol/presentation";
 import { useWalletState } from "@/providers/wallet-context";
 import { useAppLocale } from "@/i18n/client";
 import { parseLocalizedUnits } from "@/lib/i18n/amounts";
@@ -252,6 +256,7 @@ export function PeggedDollarPanel({
     options?: {
       validateSimulation?: (result: `0x${string}` | undefined) => void;
       verifyConfirmation?: () => Promise<void>;
+      presentation?: ProtocolTransactionPresentation;
     }
   ) => {
     if (!deployment) throw new Error("No Dollar deployment is configured.");
@@ -267,6 +272,7 @@ export function PeggedDollarPanel({
       data,
       sendTransaction: wallet.sendEvmTransaction,
       describeError: describeDollarError,
+      presentation: options?.presentation,
       validateSimulation: options?.validateSimulation,
       verifyConfirmation: options?.verifyConfirmation
         ? async () => options.verifyConfirmation?.()
@@ -349,16 +355,16 @@ export function PeggedDollarPanel({
           throw cause;
         }
         const receiver = getAddress(wallet.address!);
-        const data =
-          before.collateralAllowance >= fresh.totalCollateralIn
-            ? buildMintPeggedCall(deployment.pegged.profileId, quote.amount, maximum, receiver)
-            : buildMintPeggedWithPermitCall(
-                deployment.pegged.profileId,
-                quote.amount,
-                maximum,
-                receiver,
-                await signPermit(deployment.pegged.collateral, MAX_ERC20_ALLOWANCE)
-              );
+        const usesPermit = before.collateralAllowance < fresh.totalCollateralIn;
+        const data = usesPermit
+          ? buildMintPeggedWithPermitCall(
+              deployment.pegged.profileId,
+              quote.amount,
+              maximum,
+              receiver,
+              await signPermit(deployment.pegged.collateral, MAX_ERC20_ALLOWANCE)
+            )
+          : buildMintPeggedCall(deployment.pegged.profileId, quote.amount, maximum, receiver);
         await send(
           "mint-pegged",
           "Mint Statics Dollar with USDG",
@@ -366,6 +372,16 @@ export function PeggedDollarPanel({
           deployment.contracts.gateway,
           data,
           {
+            presentation: usesPermit
+              ? permittedActionPresentation({
+                  action: "Mint Statics Dollar with USDG",
+                  description: `Mint the reviewed ${display(quote.amount, 18, "USDstx")} using USDG.`,
+                  asset: "USDG",
+                  spender: deployment.contracts.gateway,
+                  spenderName: "Statics Dollar Gateway",
+                  contractName: "Statics Dollar Gateway",
+                })
+              : undefined,
             validateSimulation: (result) => void validatePeggedMintSimulation(result),
             verifyConfirmation: async () => {
               const next = await readSnapshot();
@@ -385,16 +401,16 @@ export function PeggedDollarPanel({
           throw new Error("The USDG output moved below the reviewed minimum.");
         }
         const receiver = getAddress(wallet.address!);
-        const data =
-          before.dollarAllowance >= quote.amount
-            ? buildRedeemPeggedCall(deployment.pegged.profileId, quote.amount, minimum, receiver)
-            : buildRedeemPeggedWithPermitCall(
-                deployment.pegged.profileId,
-                quote.amount,
-                minimum,
-                receiver,
-                await signPermit(deployment.contracts.dollar, MAX_ERC20_ALLOWANCE)
-              );
+        const usesPermit = before.dollarAllowance < quote.amount;
+        const data = usesPermit
+          ? buildRedeemPeggedWithPermitCall(
+              deployment.pegged.profileId,
+              quote.amount,
+              minimum,
+              receiver,
+              await signPermit(deployment.contracts.dollar, MAX_ERC20_ALLOWANCE)
+            )
+          : buildRedeemPeggedCall(deployment.pegged.profileId, quote.amount, minimum, receiver);
         await send(
           "redeem-pegged",
           "Redeem Statics Dollar for USDG",
@@ -402,6 +418,16 @@ export function PeggedDollarPanel({
           deployment.contracts.gateway,
           data,
           {
+            presentation: usesPermit
+              ? permittedActionPresentation({
+                  action: "Redeem Statics Dollar for USDG",
+                  description: `Redeem the reviewed ${display(quote.amount, 18, "USDstx")} for USDG.`,
+                  asset: "USDstx",
+                  spender: deployment.contracts.gateway,
+                  spenderName: "Statics Dollar Gateway",
+                  contractName: "Statics Dollar Gateway",
+                })
+              : undefined,
             validateSimulation: (result) => void validatePeggedRedemptionSimulation(result),
             verifyConfirmation: async () => {
               const next = await readSnapshot();

--- a/lib/dollar/permit.ts
+++ b/lib/dollar/permit.ts
@@ -51,12 +51,10 @@ export function privyPermitRequest<
     options: {
       address,
       uiOptions: {
-        showWalletUIs: true as const,
-        title: "Approve unlimited token spending",
-        description:
-          "Sign a maximum token allowance for the Statics Dollar Gateway. The signature expires in 20 minutes, but an executed allowance remains active until consumed or revoked in Approval Tools.",
-        buttonText: "Sign approval",
-        isCancellable: true as const,
+        // The permit is an intermediate signature attached to the immediately following
+        // transaction. The transaction confirmation owns the permission disclosure so the
+        // embedded wallet does not need to load a second, failure-prone signature screen.
+        showWalletUIs: false as const,
       },
     },
   };

--- a/lib/protocol/presentation.ts
+++ b/lib/protocol/presentation.ts
@@ -56,6 +56,29 @@ export function approvalPresentation(
   };
 }
 
+export function permittedActionPresentation(input: {
+  action: string;
+  description: string;
+  asset: string;
+  spender: Address;
+  spenderName: string;
+  contractName: string;
+  buttonText?: string;
+}): ProtocolTransactionPresentation {
+  const permission = unlimitedTokenPermission({
+    asset: input.asset,
+    spender: input.spender,
+    spenderName: input.spenderName,
+  });
+  return {
+    action: input.action,
+    description: `${input.description} ${permission.detail} This transaction applies it to ${permission.spenderName} (${permission.spender}). You can revoke it from Approval Tools.`,
+    buttonText: input.buttonText ?? input.action,
+    contractName: input.contractName,
+    permission,
+  };
+}
+
 export function actionPresentation(input: {
   action: string;
   description: string;

--- a/lib/wallet/reconnection.ts
+++ b/lib/wallet/reconnection.ts
@@ -1,0 +1,36 @@
+export type PrivyRecoveryResult = "activated-embedded" | "opened-email-login";
+
+export async function recoverPrivyWallet<TWallet>({
+  embeddedWallet,
+  authenticated,
+  activateEmbedded,
+  logout,
+  selectEmbedded,
+  restoreLocalConnection,
+  waitForEmbeddedWallet,
+  openEmailLogin,
+}: {
+  embeddedWallet: TWallet | null | undefined;
+  authenticated: boolean;
+  activateEmbedded: (wallet: TWallet) => Promise<unknown>;
+  logout: () => Promise<void>;
+  selectEmbedded: (wallet: TWallet) => void;
+  restoreLocalConnection: () => void;
+  waitForEmbeddedWallet: () => void;
+  openEmailLogin: () => void;
+}): Promise<PrivyRecoveryResult> {
+  if (embeddedWallet) {
+    await activateEmbedded(embeddedWallet);
+    selectEmbedded(embeddedWallet);
+    restoreLocalConnection();
+    return "activated-embedded";
+  }
+
+  // An external-wallet login is still an authenticated Privy session. End only
+  // that session when the user explicitly asks for Privy so email login can
+  // create or recover the embedded wallet without a manual cache reset.
+  if (authenticated) await logout();
+  waitForEmbeddedWallet();
+  openEmailLogin();
+  return "opened-email-login";
+}

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -20,7 +20,7 @@ import {
 } from "@privy-io/react-auth/solana";
 import { createConfig, useSetActiveWallet, WagmiProvider } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createWalletClient, custom, getAddress } from "viem";
 import { useAccount } from "wagmi";
 
@@ -31,6 +31,7 @@ import {
 } from "@/lib/wallet-config";
 import { fundingNetworks, getFundingNetwork, isFundingChainId } from "@/lib/funding-networks";
 import { selectActiveStaticsWallet } from "@/lib/wallet/selection";
+import { recoverPrivyWallet } from "@/lib/wallet/reconnection";
 import {
   queryMatchesProtocolReconciliation,
   subscribeToProtocolReconciliation,
@@ -77,7 +78,7 @@ function connectedWalletChainId(wallet: ConnectedWallet | undefined): number | n
 }
 
 function WalletBridge({ children }: { children: React.ReactNode }) {
-  const { ready, authenticated, error: privyError, login } = usePrivy();
+  const { ready, authenticated, error: privyError, login, logout } = usePrivy();
   const { ready: walletsReady, wallets } = useWallets();
   const { createWallet } = useCreateWallet();
   const { exportWallet } = useExportWallet();
@@ -91,6 +92,8 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
   const [actionError, setActionError] = useState<string | null>(null);
   const [fundingChainId, setFundingChainId] = useState(8_453);
   const [locallyDisconnected, setLocallyDisconnected] = useState(false);
+  const [preferredWalletAddress, setPreferredWalletAddress] = useState<string>();
+  const [waitingForPrivyWallet, setWaitingForPrivyWallet] = useState(false);
   const [requestedExternalAddress, setRequestedExternalAddress] = useState<string | null>(null);
   const { connectWallet: promptExternalWallet } = useConnectWallet({
     onSuccess: ({ wallet }) => {
@@ -102,7 +105,7 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
   const embeddedWallet = getEmbeddedConnectedWallet(wallets);
   const selectedWallet = locallyDisconnected
     ? undefined
-    : selectActiveStaticsWallet(wallets, wagmiAccount.address);
+    : selectActiveStaticsWallet(wallets, preferredWalletAddress ?? wagmiAccount.address);
   const address = selectedWallet?.address ?? null;
   const walletKind = selectedWallet
     ? selectedWallet.walletClientType === "privy" || selectedWallet.walletClientType === "privy-v2"
@@ -138,6 +141,8 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
     void setActiveWallet(requestedWallet)
       .then(() => {
         if (cancelled) return;
+        setPreferredWalletAddress(requestedWallet.address);
+        setWaitingForPrivyWallet(false);
         setLocallyDisconnected(false);
         setRequestedExternalAddress(null);
       })
@@ -151,20 +156,58 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
     };
   }, [requestedExternalAddress, setActiveWallet, wallets]);
 
-  const runAction = async (
-    action: NonNullable<WalletState["busyAction"]>,
-    operation: () => Promise<void>
-  ) => {
-    setActionError(null);
-    setBusyAction(action);
-    try {
-      await operation();
-    } catch (error) {
-      setActionError(error instanceof Error ? error.message : "The wallet request failed.");
-    } finally {
-      setBusyAction(null);
-    }
-  };
+  useEffect(() => {
+    if (!waitingForPrivyWallet || !authenticated || !embeddedWallet) return;
+
+    let cancelled = false;
+    void setActiveWallet(embeddedWallet)
+      .then(() => {
+        if (cancelled) return;
+        setPreferredWalletAddress(embeddedWallet.address);
+        setWaitingForPrivyWallet(false);
+        setLocallyDisconnected(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setWaitingForPrivyWallet(false);
+        setActionError("The Privy embedded wallet could not be activated.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, embeddedWallet, setActiveWallet, waitingForPrivyWallet]);
+
+  const runAction = useCallback(
+    async (action: NonNullable<WalletState["busyAction"]>, operation: () => Promise<void>) => {
+      setActionError(null);
+      setBusyAction(action);
+      try {
+        await operation();
+      } catch (error) {
+        setActionError(error instanceof Error ? error.message : "The wallet request failed.");
+      } finally {
+        setBusyAction(null);
+      }
+    },
+    []
+  );
+
+  const reconnectPrivyWallet = useCallback(
+    () =>
+      runAction("connect", async () => {
+        await recoverPrivyWallet({
+          embeddedWallet,
+          authenticated,
+          activateEmbedded: setActiveWallet,
+          logout,
+          selectEmbedded: (wallet) => setPreferredWalletAddress(wallet.address),
+          restoreLocalConnection: () => setLocallyDisconnected(false),
+          waitForEmbeddedWallet: () => setWaitingForPrivyWallet(true),
+          openEmailLogin: () => login({ loginMethods: ["email"] }),
+        });
+      }),
+    [authenticated, embeddedWallet, login, logout, runAction, setActiveWallet]
+  );
 
   let status: WalletState["status"] = "loading";
   if (locallyDisconnected) status = "signed-out";
@@ -193,7 +236,8 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
       locallyDisconnected,
       login: () => {
         if (locallyDisconnected) {
-          return promptExternalWallet({ walletChainType: "ethereum-only" });
+          void reconnectPrivyWallet();
+          return;
         }
         login({ loginMethods: ["email", "wallet"] });
       },
@@ -207,13 +251,11 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
         setActionError(null);
         promptExternalWallet({ walletChainType: "ethereum-only" });
       },
-      disconnectWallet: () => setLocallyDisconnected(true),
-      reconnectWallet: () =>
-        runAction("connect", async () => {
-          if (!embeddedWallet) throw new Error("The Privy embedded wallet is unavailable.");
-          await setActiveWallet(embeddedWallet);
-          setLocallyDisconnected(false);
-        }),
+      disconnectWallet: () => {
+        setWaitingForPrivyWallet(false);
+        setLocallyDisconnected(true);
+      },
+      reconnectWallet: reconnectPrivyWallet,
       createWallet: () =>
         runAction("create", async () => {
           await createWallet();
@@ -316,9 +358,10 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
       locallyDisconnected,
       promptExternalWallet,
       privyError,
+      reconnectPrivyWallet,
+      runAction,
       selectedWallet,
       sendEmbeddedTransaction,
-      setActiveWallet,
       status,
       targetChain,
       walletKind,

--- a/test/dollar/permit.test.ts
+++ b/test/dollar/permit.test.ts
@@ -53,7 +53,7 @@ describe("Dollar permit helpers", () => {
     expect(external).not.toHaveBeenCalled();
   });
 
-  it("builds a visible Privy permit request with maximum-allowance disclosure", () => {
+  it("keeps the intermediate embedded permit headless", () => {
     const typedData = {
       domain: {
         name: "Mock USDG",
@@ -90,12 +90,7 @@ describe("Dollar permit helpers", () => {
     expect(request.options).toEqual({
       address: "0x0000000000000000000000000000000000000002",
       uiOptions: {
-        showWalletUIs: true,
-        title: "Approve unlimited token spending",
-        description:
-          "Sign a maximum token allowance for the Statics Dollar Gateway. The signature expires in 20 minutes, but an executed allowance remains active until consumed or revoked in Approval Tools.",
-        buttonText: "Sign approval",
-        isCancellable: true,
+        showWalletUIs: false,
       },
     });
     expect(() => JSON.stringify(request)).not.toThrow();

--- a/test/foundation/no-wallet-runtime.test.ts
+++ b/test/foundation/no-wallet-runtime.test.ts
@@ -42,10 +42,9 @@ describe("wallet runtime boundary", () => {
     expect(source).toContain("defaultSolanaRpcsPlugin()");
     expect(source).toContain("<ProtocolQueryReconciler />");
     expect(source).toContain('promptExternalWallet({ walletChainType: "ethereum-only" })');
-    expect(source).toContain("await setActiveWallet(embeddedWallet)");
-    expect(source).toContain("disconnectWallet: () => setLocallyDisconnected(true)");
+    expect(source).toContain("recoverPrivyWallet");
+    expect(source).toContain("setLocallyDisconnected(true)");
     expect(source).not.toContain("setActiveWalletForWagmi");
-    expect(source).not.toMatch(/\blogout\b/);
     expect(source).not.toMatch(/addSigners|delegateWallet|policyIds/);
   });
 

--- a/test/protocol/presentation.test.ts
+++ b/test/protocol/presentation.test.ts
@@ -5,6 +5,7 @@ import {
   erc1155OperatorPermission,
   erc721OperatorPermission,
   maximumPermit2Permission,
+  permittedActionPresentation,
   unlimitedTokenPermission,
 } from "@/lib/protocol/presentation";
 
@@ -34,5 +35,25 @@ describe("transaction permission presentation", () => {
       erc1155OperatorPermission({ asset: "Risk shares", spender, spenderName: "Dollar Gateway" })
         .detail
     ).toContain("every current and future token ID");
+  });
+
+  it("discloses an atomic permit on the submitted action", () => {
+    const presentation = permittedActionPresentation({
+      action: "Mint Statics Dollar with USDG",
+      description: "Mint the reviewed 10 USDstx using USDG.",
+      asset: "USDG",
+      spender,
+      spenderName: "Statics Dollar Gateway",
+      contractName: "Statics Dollar Gateway",
+    });
+
+    expect(presentation.description).toContain("Unlimited USDG spending permission");
+    expect(presentation.description).toContain("This transaction applies it");
+    expect(presentation.description).toContain("Approval Tools");
+    expect(presentation.permission).toMatchObject({
+      scope: "unlimited-token",
+      asset: "USDG",
+      spender,
+    });
   });
 });

--- a/test/wallet/reconnection.test.ts
+++ b/test/wallet/reconnection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recoverPrivyWallet } from "@/lib/wallet/reconnection";
+
+describe("Privy wallet recovery", () => {
+  it("reactivates an existing embedded wallet without ending the Privy session", async () => {
+    const embeddedWallet = { address: "0xembedded" };
+    const activateEmbedded = vi.fn().mockResolvedValue(undefined);
+    const logout = vi.fn().mockResolvedValue(undefined);
+    const selectEmbedded = vi.fn();
+    const restoreLocalConnection = vi.fn();
+    const waitForEmbeddedWallet = vi.fn();
+    const openEmailLogin = vi.fn();
+
+    await expect(
+      recoverPrivyWallet({
+        embeddedWallet,
+        authenticated: true,
+        activateEmbedded,
+        logout,
+        selectEmbedded,
+        restoreLocalConnection,
+        waitForEmbeddedWallet,
+        openEmailLogin,
+      })
+    ).resolves.toBe("activated-embedded");
+
+    expect(activateEmbedded).toHaveBeenCalledWith(embeddedWallet);
+    expect(logout).not.toHaveBeenCalled();
+    expect(selectEmbedded).toHaveBeenCalledWith(embeddedWallet);
+    expect(restoreLocalConnection).toHaveBeenCalledOnce();
+    expect(waitForEmbeddedWallet).not.toHaveBeenCalled();
+    expect(openEmailLogin).not.toHaveBeenCalled();
+  });
+
+  it("replaces an external-only Privy session with email login", async () => {
+    const order: string[] = [];
+    const logout = vi.fn(async () => void order.push("logout"));
+    const waitForEmbeddedWallet = vi.fn(() => void order.push("wait"));
+    const openEmailLogin = vi.fn(() => void order.push("login"));
+
+    await expect(
+      recoverPrivyWallet({
+        embeddedWallet: undefined,
+        authenticated: true,
+        activateEmbedded: vi.fn(),
+        logout,
+        selectEmbedded: vi.fn(),
+        restoreLocalConnection: vi.fn(),
+        waitForEmbeddedWallet,
+        openEmailLogin,
+      })
+    ).resolves.toBe("opened-email-login");
+
+    expect(order).toEqual(["logout", "wait", "login"]);
+  });
+
+  it("opens email login directly when the Privy session has already ended", async () => {
+    const logout = vi.fn().mockResolvedValue(undefined);
+    const waitForEmbeddedWallet = vi.fn();
+    const openEmailLogin = vi.fn();
+
+    await recoverPrivyWallet({
+      embeddedWallet: undefined,
+      authenticated: false,
+      activateEmbedded: vi.fn(),
+      logout,
+      selectEmbedded: vi.fn(),
+      restoreLocalConnection: vi.fn(),
+      waitForEmbeddedWallet,
+      openEmailLogin,
+    });
+
+    expect(logout).not.toHaveBeenCalled();
+    expect(waitForEmbeddedWallet).toHaveBeenCalledBefore(openEmailLogin);
+  });
+});

--- a/test/wallet/selection.test.ts
+++ b/test/wallet/selection.test.ts
@@ -62,6 +62,21 @@ describe("Statics EVM wallet selection", () => {
     expect(selectActiveStaticsWallet([embedded, external], external.address)).toBe(external);
   });
 
+  it("lets an explicit embedded choice override a stale external Wagmi address", () => {
+    const external = wallet({
+      address: "0x1111111111111111111111111111111111111111",
+      walletClientType: "metamask",
+      connectorType: "injected",
+    });
+    const embedded = wallet({
+      address: "0x2222222222222222222222222222222222222222",
+      walletClientType: "privy",
+      connectorType: "embedded",
+    });
+
+    expect(selectActiveStaticsWallet([external, embedded], embedded.address)).toBe(embedded);
+  });
+
   it("falls back to the embedded wallet when the active external wallet is stale", () => {
     const embedded = wallet({
       address: "0x2222222222222222222222222222222222222222",


### PR DESCRIPTION
## Summary

- sign the intermediate embedded-wallet EIP-2612 permit without loading Privy's failure-prone signature screen
- keep USDG minting and USDstx redemption atomic: the permit is still executed with the final protocol transaction
- disclose the maximum token permission, gateway spender, persistence, and Approval Tools revocation in the final embedded transaction confirmation
- leave external-wallet permits on the wallet provider's native typed-data prompt

## Signing-flow audit

- this is the app's only EVM typed-data signature flow, and the shared helper covers both pegged mint and redeem
- the remaining signing surfaces are Solana transaction signatures and already catch and surface local failures; they do not use this Privy EIP-712 path
- ordinary onchain approval and transaction flows are unchanged

## Validation

- `npm run lint`
- `npm run lint:css`
- `npm run format:check`
- `npm run typecheck`
- `npm test` — 83 files, 431 tests passed
- production build with the existing Robinhood testnet environment
- `playwright test` — 42 tests passed across desktop, tablet, and mobile
- `npm --prefix ponder run typecheck`
- `npm --prefix ponder test` — 2 files, 3 tests passed
- focused permit, presentation, and pegged-dollar panel tests — 3 files, 12 tests passed
- `git diff --check`
- project-delivery PR-readiness check

## Test boundary

The automated suite does not execute an authenticated Privy embedded-wallet signature. This PR should be tested against Robinhood testnet before production is updated. No production changes are included.
