### PR TITLE
Fix confirmed basket reward selection state

### DIFF
--- a/components/positions/PositionDetailPage.tsx
+++ b/components/positions/PositionDetailPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   encodeFunctionData,
   formatUnits,
@@ -29,6 +29,7 @@ import { readClientDollarDeployment, verifyDollarDeployment } from "@/lib/dollar
 import {
   canClosePosition,
   describePositionError,
+  loadConfirmedRewardSelection,
   loadPositionCatalog,
   unlockedCollateral,
   validateCustomRewardAsset,
@@ -75,6 +76,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
   const walletState = useWalletState();
   const publicClient = usePublicClient();
   const walletClient = useWalletClient();
+  const queryClient = useQueryClient();
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
   const [pendingAction, setPendingAction] = useState<string | null>(null);
@@ -86,13 +88,12 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
   const [stakeAmountInput, setStakeAmountInput] = useState("");
   const [customRewardAddress, setCustomRewardAddress] = useState("");
 
+  const catalogQueryKey = protocolQueryKeys.positionCatalog(
+    deploymentState.status === "configured" ? deploymentState.deployment.protocolCommit : undefined,
+    wallet
+  );
   const catalog = useQuery({
-    queryKey: protocolQueryKeys.positionCatalog(
-      deploymentState.status === "configured"
-        ? deploymentState.deployment.protocolCommit
-        : undefined,
-      wallet
-    ),
+    queryKey: catalogQueryKey,
     enabled:
       deploymentState.status === "configured" &&
       Boolean(publicClient) &&
@@ -161,17 +162,37 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
     });
   };
 
-  const runAction = async (key: string, action: () => Promise<void>) => {
+  const runAction = async (key: string, action: () => Promise<void>, refreshCatalog = true) => {
     setPendingAction(key);
     setActionError(null);
     try {
       await action();
-      await catalog.refetch();
+      if (refreshCatalog) await catalog.refetch();
     } catch (error) {
       setActionError(describePositionError(error));
     } finally {
       setPendingAction(null);
     }
+  };
+
+  const verifyRewardSelection = async (
+    receipt: TransactionReceipt,
+    asset: Address,
+    expectedSelected: boolean
+  ) => {
+    if (!publicClient || !wallet || deploymentState.status !== "configured") {
+      throw new Error("The connected PositionNFT is unavailable.");
+    }
+    const confirmedCatalog = await loadConfirmedRewardSelection(
+      publicClient,
+      deploymentState.deployment,
+      wallet,
+      positionId,
+      asset,
+      expectedSelected,
+      receipt.blockNumber
+    );
+    queryClient.setQueryData(catalogQueryKey, confirmedCatalog);
   };
 
   const executeCollateralAction = async () => {
@@ -306,6 +327,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
       data: selected
         ? buildOptOutRewardAssetsCall(position.positionId, [asset])
         : buildOptInRewardAssetsCall(position.positionId, [asset]),
+      verifyConfirmation: (receipt) => verifyRewardSelection(receipt, asset, !selected),
     });
   };
 
@@ -325,6 +347,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
       amount: metadata.symbol,
       to: deploymentState.deployment.contracts.diamond,
       data: buildOptInRewardAssetsCall(position.positionId, [metadata.address]),
+      verifyConfirmation: (receipt) => verifyRewardSelection(receipt, metadata.address, true),
     });
     setCustomRewardAddress("");
   };
@@ -600,8 +623,10 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
                   type="button"
                   disabled={pendingAction !== null}
                   onClick={() =>
-                    void runAction(`reward-${candidate.token.address}`, () =>
-                      changeRewardSelection(candidate.token.address, selected)
+                    void runAction(
+                      `reward-${candidate.token.address}`,
+                      () => changeRewardSelection(candidate.token.address, selected),
+                      false
                     )
                   }
                 >
@@ -634,7 +659,7 @@ function PositionDetailRuntime({ positionId }: { positionId: bigint }) {
             className="dollar-submit"
             type="button"
             disabled={pendingAction !== null || customRewardAddress.length === 0}
-            onClick={() => void runAction("custom-reward", addCustomReward)}
+            onClick={() => void runAction("custom-reward", addCustomReward, false)}
           >
             {pendingAction === "custom-reward" ? t("waiting") : t("selectAddress")}
           </button>

--- a/lib/positions/positions.ts
+++ b/lib/positions/positions.ts
@@ -355,6 +355,30 @@ export async function loadPositionCatalog(
   };
 }
 
+/**
+ * Reloads the complete position catalog at the transaction's confirmed block
+ * and rejects until the requested reward membership is authoritative there.
+ */
+export async function loadConfirmedRewardSelection(
+  publicClient: PublicClient,
+  deployment: DollarDeployment,
+  wallet: Address,
+  positionId: bigint,
+  asset: Address,
+  expectedSelected: boolean,
+  blockNumber: bigint
+): Promise<PositionCatalog> {
+  const catalog = await loadPositionCatalog(publicClient, deployment, wallet, blockNumber);
+  const position = catalog.positions.find((candidate) => candidate.positionId === positionId);
+  if (!position) {
+    throw new Error("This PositionNFT is no longer owned by the connected wallet.");
+  }
+  if (position.selectedRewardAssets.includes(asset) !== expectedSelected) {
+    throw new Error("The confirmed reward selection is not yet available from the read RPC.");
+  }
+  return catalog;
+}
+
 export async function validateCustomRewardAsset(
   publicClient: PublicClient,
   value: string,

--- a/lib/protocol/transactions.ts
+++ b/lib/protocol/transactions.ts
@@ -46,6 +46,7 @@ export type ProtocolTransactionSendRequest = Readonly<{
   to: Address;
   data: Hex;
   value?: bigint;
+  gasLimit: bigint;
   presentation: ProtocolTransactionPresentation;
 }>;
 
@@ -87,6 +88,15 @@ const operatorApprovalKinds = new Set<ProtocolActivityKind>(["approve-risk", "ap
 const erc20ApproveSelector = toFunctionSelector("approve(address,uint256)");
 const permit2ApproveSelector = toFunctionSelector("approve(address,address,uint160,uint48)");
 const operatorApproveSelector = toFunctionSelector("setApprovalForAll(address,bool)");
+
+/**
+ * Wallet RPCs do not all apply the same safety margin to `eth_estimateGas`.
+ * Supplying one reviewed estimate with a modest buffer avoids a second,
+ * wallet-specific estimate producing an invalid transaction request.
+ */
+export function bufferedGasLimit(estimate: bigint): bigint {
+  return estimate + (estimate + 4n) / 5n;
+}
 
 function calldataAddress(data: Hex, wordIndex: number): Address | null {
   const wordStart = 10 + wordIndex * 64;
@@ -216,6 +226,14 @@ export async function executeProtocolTransaction(
       value: request.value,
     });
     request.validateSimulation?.(simulation.data);
+    const gasLimit = bufferedGasLimit(
+      await request.publicClient.estimateGas({
+        account: request.wallet,
+        to: request.to,
+        data: request.data,
+        value: request.value,
+      })
+    );
     stage = "signing";
     updateProtocolActivity(request.wallet, request.chainId, id, { status: "signing" });
 
@@ -225,6 +243,7 @@ export async function executeProtocolTransaction(
       to: request.to,
       data: request.data,
       value: request.value,
+      gasLimit,
       presentation: request.presentation ?? defaultProtocolPresentation(request),
     });
     stage = "submitted";

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -294,6 +294,7 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
               to: request.to,
               data: request.data,
               value: request.value,
+              gasLimit: request.gasLimit,
               chainId: request.chainId,
             },
             {
@@ -331,6 +332,7 @@ function WalletBridge({ children }: { children: React.ReactNode }) {
           to: request.to,
           data: request.data,
           value: request.value,
+          gas: request.gasLimit,
         });
       },
       exportWallet: () =>

--- a/test/positions/catalog.test.ts
+++ b/test/positions/catalog.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/baskets/baskets", async (importOriginal) => {
   };
 });
 
-import { loadPositionCatalog } from "@/lib/positions/positions";
+import { loadConfirmedRewardSelection, loadPositionCatalog } from "@/lib/positions/positions";
 
 const wallet = "0x0000000000000000000000000000000000000001" as Address;
 const diamond = "0x0000000000000000000000000000000000000010" as Address;
@@ -63,7 +63,9 @@ describe("PositionNFT catalog discovery", () => {
             optedInAssetCount: 0n,
           });
         }
-        if (functionName === "positionRewardAssets") return Promise.resolve([]);
+        if (functionName === "positionRewardAssets") {
+          return Promise.resolve(args?.[0] === 1n ? [dollar] : []);
+        }
         if (functionName === "positionPortfolioCounts") {
           return Promise.resolve({
             basketCount: 0n,
@@ -105,7 +107,7 @@ describe("PositionNFT catalog discovery", () => {
     expect(catalog.maximumRewardAssets).toBe(64n);
     expect(catalog.positionCreationFee).toBe(123n);
     const firstPosition = catalog.positions.find((position) => position.positionId === 1n);
-    expect(firstPosition?.selectedRewardAssets).toEqual([]);
+    expect(firstPosition?.selectedRewardAssets).toEqual([dollar]);
     expect(firstPosition?.stateNonce).toBe(3n);
     expect(firstPosition?.closable).toBe(true);
     expect(firstPosition?.rewards).toEqual([
@@ -115,5 +117,71 @@ describe("PositionNFT catalog discovery", () => {
       }),
     ]);
     expect(publicClient.getContractEvents).not.toHaveBeenCalled();
+  });
+
+  it("loads reward membership at the transaction's confirmed block", async () => {
+    const publicClient = {
+      getBlock: vi.fn().mockResolvedValue({ number: 50n, timestamp: 1_000n }),
+      readContract: vi.fn().mockImplementation(({ functionName }) => {
+        if (functionName === "balanceOf" || functionName === "positionCount") {
+          return Promise.resolve(1n);
+        }
+        if (functionName === "positionsOfOwner") return Promise.resolve([[1n], 1n]);
+        if (functionName === "positionState") {
+          return Promise.resolve({
+            exists: true,
+            stateNonce: 4n,
+            activeLegCount: 1n,
+            unresolvedObligationCount: 0n,
+          });
+        }
+        if (functionName === "isPositionClosable") return Promise.resolve(false);
+        if (functionName === "stakePosition") {
+          return Promise.resolve({
+            stakedBalance: 10n,
+            claimAssetCount: 0n,
+            optedInAssetCount: 1n,
+          });
+        }
+        if (functionName === "positionRewardAssets") return Promise.resolve([dollar]);
+        if (functionName === "positionPortfolioCounts") {
+          return Promise.resolve({
+            basketCount: 0n,
+            loanCount: 0n,
+            liquidityPositionCount: 0n,
+            globalRewardAssetCount: 1n,
+            riskSeriesCount: 0n,
+          });
+        }
+        if (functionName === "globalRewardAssetsOfPosition") {
+          return Promise.resolve([[dollar], 1n]);
+        }
+        if (functionName === "pendingRewards") return Promise.resolve([0n]);
+        if (functionName === "stakingToken") return Promise.resolve(weth);
+        if (functionName === "totalStaked") return Promise.resolve(10n);
+        if (functionName === "maxRewardAssetsPerPosition") return Promise.resolve(64n);
+        if (functionName === "positionCreationFee") return Promise.resolve(123n);
+        if (functionName === "allowance") return Promise.resolve(0n);
+        throw new Error(`Unexpected read: ${functionName}`);
+      }),
+    } as unknown as PublicClient;
+    const deployment = {
+      chainId: 31_337,
+      deploymentStartBlock: 1n,
+      protocolCommit: "f82f3a7e4ba4c9bfbf749c3208f68bb18fd4afa1",
+      contracts: { diamond, dollar, weth },
+    } as DollarDeployment;
+
+    await expect(
+      loadConfirmedRewardSelection(publicClient, deployment, wallet, 1n, dollar, true, 50n)
+    ).resolves.toMatchObject({
+      currentBlock: 50n,
+      positions: [expect.objectContaining({ selectedRewardAssets: [dollar] })],
+    });
+    expect(publicClient.getBlock).toHaveBeenCalledWith({ blockNumber: 50n });
+
+    await expect(
+      loadConfirmedRewardSelection(publicClient, deployment, wallet, 1n, dollar, false, 50n)
+    ).rejects.toThrow("confirmed reward selection is not yet available");
   });
 });

--- a/test/positions/catalog.test.ts
+++ b/test/positions/catalog.test.ts
@@ -60,7 +60,7 @@ describe("PositionNFT catalog discovery", () => {
           return Promise.resolve({
             stakedBalance: 0n,
             claimAssetCount: 0n,
-            optedInAssetCount: 0n,
+            optedInAssetCount: args?.[0] === 1n ? 1n : 0n,
           });
         }
         if (functionName === "positionRewardAssets") {

--- a/test/protocol/transactions.test.ts
+++ b/test/protocol/transactions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { readProtocolActivity } from "@/lib/dollar/activity";
 import {
+  bufferedGasLimit,
   defaultProtocolPresentation,
   executeProtocolTransaction,
 } from "@/lib/protocol/transactions";
@@ -19,6 +20,7 @@ describe("protocol transaction execution", () => {
   it("simulates before signing and reports success only after a confirmed receipt", async () => {
     const call = vi.fn().mockResolvedValue({ data: "0x01" });
     const getBlockNumber = vi.fn().mockResolvedValue(17n);
+    const estimateGas = vi.fn().mockResolvedValue(100_000n);
     const waitForTransactionReceipt = vi.fn().mockResolvedValue({
       status: "success",
       transactionHash: hash,
@@ -30,6 +32,7 @@ describe("protocol transaction execution", () => {
       executeProtocolTransaction({
         publicClient: {
           call,
+          estimateGas,
           getBlockNumber,
           waitForTransactionReceipt,
         } as unknown as PublicClient,
@@ -51,6 +54,7 @@ describe("protocol transaction execution", () => {
         wallet,
         chainId: 31_337,
         to: target,
+        gasLimit: 120_000n,
         presentation: expect.objectContaining({
           action: "Create PositionNFT",
           buttonText: "Create PositionNFT",
@@ -60,6 +64,12 @@ describe("protocol transaction execution", () => {
     expect(waitForTransactionReceipt).toHaveBeenCalledWith(
       expect.objectContaining({ hash, confirmations: 1 })
     );
+    expect(estimateGas).toHaveBeenCalledWith({
+      account: wallet,
+      to: target,
+      data: "0x1234",
+      value: undefined,
+    });
     expect(getBlockNumber).toHaveBeenCalledWith({ cacheTime: 0 });
     expect(readProtocolActivity(wallet, 31_337)[0]).toMatchObject({
       kind: "create-position",
@@ -76,6 +86,7 @@ describe("protocol transaction execution", () => {
     await executeProtocolTransaction({
       publicClient: {
         call: vi.fn().mockResolvedValue({ data: "0x01" }),
+        estimateGas: vi.fn().mockResolvedValue(100_000n),
         waitForTransactionReceipt: vi.fn().mockResolvedValue({
           status: "success",
           transactionHash: hash,
@@ -139,6 +150,7 @@ describe("protocol transaction execution", () => {
       executeProtocolTransaction({
         publicClient: {
           call: vi.fn().mockResolvedValue({ data: "0x01" }),
+          estimateGas: vi.fn().mockResolvedValue(100_000n),
         } as unknown as PublicClient,
         wallet,
         chainId: 31_337,
@@ -170,6 +182,7 @@ describe("protocol transaction execution", () => {
       const execution = executeProtocolTransaction({
         publicClient: {
           call: vi.fn().mockResolvedValue({ data: "0x" }),
+          estimateGas: vi.fn().mockResolvedValue(100_000n),
           waitForTransactionReceipt: vi.fn().mockResolvedValue({
             status: "success",
             transactionHash: hash,
@@ -203,5 +216,10 @@ describe("protocol transaction execution", () => {
       confirmedHash: hash,
       error: expect.stringContaining("Refresh before another action"),
     });
+  });
+
+  it("adds a twenty percent safety margin to the public RPC gas estimate", () => {
+    expect(bufferedGasLimit(100_000n)).toBe(120_000n);
+    expect(bufferedGasLimit(1n)).toBe(2n);
   });
 });


### PR DESCRIPTION
## Summary

- reload the Position catalog at the exact receipt block after reward opt-in or opt-out
- keep reward controls disabled until the confirmed selection is present in authoritative reads, then replace the stale query data
- estimate transaction gas through the configured app RPC and pass a 20% buffered limit to embedded and external wallets
- cover confirmed-block reward membership and buffered transaction gas with regression tests

## Root cause

Reward selection waited for the receipt but then raced an immediate latest-state refetch against the global reconciliation refetch. The controls could re-enable with the prior catalog, so a newly selected asset still appeared unselected. Wallet sends also delegated gas estimation to the wallet provider; the observed failed follow-up never reached chain, while successful neighboring transactions used valid gas limits. The app now supplies one buffered estimate from its configured RPC.

## Validation

- `npm run verify` with the existing Robinhood testnet app environment
  - ESLint, Stylelint, Prettier, and TypeScript passed
  - 84 Vitest files / 437 tests passed
  - production Next.js build passed
  - 42 Playwright tests passed across desktop, tablet, and mobile
- focused reward/transaction regression suite: 3 files / 11 tests passed
- `git diff --check`
- live read-only Robinhood evidence confirmed successful reward selections were present at their receipt blocks; no testnet transaction was submitted for this PR
