### PR TITLE
feat(app): reorganize NFT management and expand Genesis artwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ test-results/
 cache/
 .cache/
 .local/
+/ponder/.ponder/
 
 # Editors and operating systems
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ test-results
 vendor
 package-lock.json
 *.png
+ponder/.ponder

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -196,6 +196,28 @@
   overflow: hidden;
 }
 
+/* Form field */
+
+.ui-field {
+  display: grid;
+  gap: 0.5rem;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.ui-field input,
+.ui-field select {
+  width: 100%;
+  min-height: var(--control-height);
+  padding: 0 0.85rem;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-bg);
+  color: var(--app-text);
+  font: inherit;
+  border-radius: var(--radius-md);
+}
+
 /* Section headings */
 
 .ui-section-title {
@@ -5341,24 +5363,43 @@
   gap: 1rem;
 }
 
-.genesis-summary div,
 .genesis-card-heading {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
+  align-items: flex-start;
 }
 
-.genesis-summary span,
+.genesis-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.genesis-card-heading > div {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+}
+
+.genesis-summary .ui-stat__value {
+  font-size: var(--text-lg);
+  overflow-wrap: anywhere;
+}
+
+.genesis-action > p {
+  margin: 0;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
 .genesis-warning {
-  color: var(--muted);
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
 }
 
 .genesis-grid {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-}
-
-.genesis-card select {
-  width: 100%;
 }
 
 .genesis-contracts {

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -1258,6 +1258,27 @@
   background: var(--app-raised);
 }
 
+.wallet-nft-art-trigger {
+  display: block;
+  width: 48px;
+  height: 48px;
+  flex: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+  border-radius: var(--radius-md);
+}
+
+.wallet-nft-art-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.wallet-nft-art-trigger .wallet-nft-art {
+  display: block;
+}
+
 .wallet-nft-art.is-placeholder {
   display: flex;
   align-items: center;
@@ -1902,6 +1923,30 @@
 
 .wallet-dialog.is-wide {
   width: min(760px, 100%);
+}
+
+.nft-artwork-dialog {
+  width: min(960px, 100%);
+  overflow: hidden;
+}
+
+.nft-artwork-dialog-content {
+  grid-template-rows: auto minmax(0, 1fr);
+  max-height: calc(100vh - 2rem);
+}
+
+.nft-artwork-dialog-content h2 {
+  padding-right: 3rem;
+}
+
+.nft-artwork-full {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  max-height: calc(100vh - 8rem);
+  object-fit: contain;
+  background: var(--app-raised);
+  border-radius: var(--radius-md);
 }
 
 .wallet-dialog-close {

--- a/app/(dapp)/app/genesis/page.tsx
+++ b/app/(dapp)/app/genesis/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { GenesisPage } from "@/components/genesis/GenesisPage";
 
 export const metadata: Metadata = {
-  title: "Genesis | Statics",
+  title: "Genesis NFT | Statics",
   description:
     "Activate a Statics Genesis NFT and link it to one PositionNFT for increased reward weight.",
 };

--- a/app/(dapp)/app/positions/page.tsx
+++ b/app/(dapp)/app/positions/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { PositionListPage } from "@/components/positions/PositionListPage";
 
 export const metadata: Metadata = {
-  title: "Positions | Statics",
+  title: "Position NFT | Statics",
   description: "Discover and manage wallet-owned Statics PositionNFTs.",
 };
 

--- a/components/baskets/BasketCreatePage.tsx
+++ b/components/baskets/BasketCreatePage.tsx
@@ -270,7 +270,7 @@ function BasketCreateRuntime() {
 
   return (
     <div className="creation-workspace">
-      <section className="dapp-card">
+      <section className="ui-card">
         <p className="dapp-section-label">Permissionless launch</p>
         <h2>Configure and fund an index</h2>
         <p>
@@ -282,7 +282,7 @@ function BasketCreateRuntime() {
           {creation.data === undefined ? "Loading…" : `${formatEther(creation.data)} ETH`}
         </p>
       </section>
-      <section className="dapp-card creation-form">
+      <section className="ui-card creation-form">
         <label>
           Basket name
           <input value={name} onChange={(event) => setName(event.target.value)} />

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -216,18 +216,18 @@ function GenesisRuntime() {
 
   return (
     <div className="genesis-page">
-      <div className="genesis-summary dapp-card">
-        <div>
-          <span>STATICS balance</span>
-          <strong>{formatEther(portfolio.data.balance)} STATICS</strong>
+      <div className="genesis-summary ui-card">
+        <div className="ui-stat">
+          <span className="ui-stat__label">STATICS balance</span>
+          <strong className="ui-stat__value">{formatEther(portfolio.data.balance)} STATICS</strong>
         </div>
-        <div>
-          <span>Genesis collection</span>
-          <strong>5,555 fixed NFTs</strong>
+        <div className="ui-stat">
+          <span className="ui-stat__label">Genesis collection</span>
+          <strong className="ui-stat__value">5,555 fixed NFTs</strong>
         </div>
-        <div>
-          <span>Activation</span>
-          <strong>Burned STATICS; resets on transfer</strong>
+        <div className="ui-stat">
+          <span className="ui-stat__label">Activation</span>
+          <strong className="ui-stat__value">Burned STATICS; resets on transfer</strong>
         </div>
       </div>
       {error && (
@@ -248,11 +248,11 @@ function GenesisRuntime() {
           const needsApproval = portfolio.data.allowance < cost;
           const actionKey = id.toString();
           return (
-            <article className="dapp-card genesis-card" key={actionKey}>
+            <article className="ui-card genesis-card" key={actionKey}>
               <div className="genesis-card-heading">
                 <div>
-                  <h2>Genesis #{actionKey}</h2>
-                  <span>
+                  <h2 className="ui-section-title">Genesis #{actionKey}</h2>
+                  <span className="ui-pill">
                     Tier {currentTier} · {(Number(state.multiplierBps) / 10_000).toFixed(2)}×
                   </span>
                 </div>
@@ -270,10 +270,12 @@ function GenesisRuntime() {
                   }}
                 />
               </div>
-              <p>{linked ? `Linked to Position #${state.linkedPositionId}` : "Not linked"}</p>
+              <p className="ui-section-subtitle">
+                {linked ? `Linked to Position #${state.linkedPositionId}` : "Not linked"}
+              </p>
               {currentTier < 4 && (
                 <div className="genesis-action">
-                  <label>
+                  <label className="ui-field">
                     Activate through tier
                     <select
                       value={target}
@@ -297,6 +299,7 @@ function GenesisRuntime() {
                   <p>Burn cost: {formatEther(cost)} STATICS</p>
                   {needsApproval ? (
                     <button
+                      className="ui-button ui-button--primary ui-button--block"
                       disabled={busy !== null}
                       onClick={() =>
                         void act(actionKey, async () => {
@@ -323,6 +326,7 @@ function GenesisRuntime() {
                     </button>
                   ) : (
                     <button
+                      className="ui-button ui-button--primary ui-button--block"
                       disabled={busy !== null || portfolio.data.balance < cost}
                       onClick={() =>
                         void act(actionKey, async () => {
@@ -343,6 +347,7 @@ function GenesisRuntime() {
               )}
               {linked ? (
                 <button
+                  className="ui-button ui-button--secondary ui-button--block"
                   disabled={busy !== null}
                   onClick={() =>
                     void act(actionKey, async () => {
@@ -360,7 +365,7 @@ function GenesisRuntime() {
                 </button>
               ) : (
                 <div className="genesis-action">
-                  <label>
+                  <label className="ui-field">
                     Position
                     <select
                       value={selectedPosition}
@@ -379,6 +384,7 @@ function GenesisRuntime() {
                     </select>
                   </label>
                   <button
+                    className="ui-button ui-button--primary ui-button--block"
                     disabled={busy !== null || currentTier === 0 || !selectedPosition}
                     onClick={() =>
                       void act(actionKey, async () => {
@@ -409,7 +415,7 @@ function GenesisRuntime() {
           );
         })}
       </div>
-      <div className="genesis-contracts dapp-card">
+      <div className="genesis-contracts ui-card">
         <AddressDisplay
           address={genesisDeployment.collection}
           chainId={deployment.chainId}

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -409,8 +409,8 @@ function GenesisRuntime() {
                 </div>
               )}
               <p className="genesis-warning">
-                Unlink before transfer. A transfer keeps the NFT but resets its activation to tier
-                0.
+                Unlink before transfer. A transfer keeps the Position NFT but resets its activation
+                to tier 0.
               </p>
             </article>
           );

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -258,6 +258,7 @@ function GenesisRuntime() {
                 </div>
                 <NftArtwork
                   chainId={deployment.chainId}
+                  expandable
                   nft={{
                     kind: "collection",
                     tokenId: id,

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -185,6 +185,7 @@ function GenesisRuntime() {
 
   const checkpointPosition = async (positionId: bigint) => {
     const selected = await publicClient!.readContract({
+      account: wallet,
       address: deployment.contracts.diamond,
       abi: staticsAbi,
       functionName: "positionRewardAssets",

--- a/components/rewards/ProtocolRevenueCard.tsx
+++ b/components/rewards/ProtocolRevenueCard.tsx
@@ -160,7 +160,7 @@ export function ProtocolRevenueCard() {
               minimumReceived = null;
             }
             return (
-              <article className="dapp-card" key={token.address}>
+              <article className="ui-card" key={token.address}>
                 <h3>{token.symbol}</h3>
                 <p>Creator credit: {formatUnits(creatorCredit, token.decimals)}</p>
                 <label>

--- a/components/wallet/NftArtwork.tsx
+++ b/components/wallet/NftArtwork.tsx
@@ -2,9 +2,11 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Boxes, Droplets, Image as ImageIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { usePublicClient } from "wagmi";
 
+import { NftArtworkDialog } from "@/components/wallet/NftArtworkDialog";
 import { resolveNftImage } from "@/lib/wallet/nft-image";
 import type { WalletNft } from "@/lib/wallet/nfts";
 
@@ -16,9 +18,19 @@ import type { WalletNft } from "@/lib/wallet/nfts";
  * self-contained artwork, while the placeholder remains the ordinary fallback
  * for collections that do not.
  */
-export function NftArtwork({ nft, chainId }: { nft: WalletNft; chainId: number }) {
+export function NftArtwork({
+  nft,
+  chainId,
+  expandable = false,
+}: {
+  nft: WalletNft;
+  chainId: number;
+  expandable?: boolean;
+}) {
   const publicClient = usePublicClient({ chainId });
+  const t = useTranslations("nftArtwork");
   const [failed, setFailed] = useState(false);
+  const [viewerOpen, setViewerOpen] = useState(false);
 
   const image = useQuery({
     queryKey: ["nft-image", chainId, nft.contract, nft.tokenId.toString()],
@@ -32,7 +44,7 @@ export function NftArtwork({ nft, chainId }: { nft: WalletNft; chainId: number }
   });
 
   if (image.data && !failed) {
-    return (
+    const artwork = (
       /* eslint-disable-next-line @next/next/no-img-element --
          Arbitrary remote hosts: next/image would need every collection's
          domain allow-listed up front, which is impossible for user-added
@@ -44,6 +56,22 @@ export function NftArtwork({ nft, chainId }: { nft: WalletNft; chainId: number }
         loading="lazy"
         onError={() => setFailed(true)}
       />
+    );
+    if (!expandable) return artwork;
+    return (
+      <>
+        <button
+          className="wallet-nft-art-trigger"
+          type="button"
+          aria-label={t("viewFullSize", { name: nft.name })}
+          onClick={() => setViewerOpen(true)}
+        >
+          {artwork}
+        </button>
+        {viewerOpen && (
+          <NftArtworkDialog name={nft.name} src={image.data} onClose={() => setViewerOpen(false)} />
+        )}
+      </>
     );
   }
 

--- a/components/wallet/NftArtworkDialog.tsx
+++ b/components/wallet/NftArtworkDialog.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export function NftArtworkDialog({
+  name,
+  src,
+  onClose,
+}: Readonly<{
+  name: string;
+  src: string;
+  onClose: () => void;
+}>) {
+  const t = useTranslations("nftArtwork");
+  const tCommon = useTranslations("common");
+  const titleId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const returnFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const priorOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+      } else if (event.key === "Tab") {
+        // The close control is deliberately the viewer's only interactive
+        // element. Keep focus there instead of letting it reach the page behind
+        // the modal.
+        event.preventDefault();
+        closeButtonRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = priorOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+      returnFocus?.focus();
+    };
+  }, []);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="wallet-dialog-backdrop" role="presentation" onMouseDown={onClose}>
+      <section
+        className="wallet-dialog nft-artwork-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <button
+          ref={closeButtonRef}
+          className="wallet-dialog-close"
+          type="button"
+          onClick={onClose}
+          aria-label={tCommon("close")}
+        >
+          ×
+        </button>
+        <div className="wallet-dialog-content nft-artwork-dialog-content">
+          <h2 id={titleId}>{t("title", { name })}</h2>
+          {/* eslint-disable-next-line @next/next/no-img-element -- the same
+              arbitrary, already-resolved URI used by the NFT thumbnail is
+              reused here without imposing a remote-host allow list. */}
+          <img className="nft-artwork-full" src={src} alt={t("alt", { name })} />
+        </div>
+      </section>
+    </div>,
+    document.body
+  );
+}

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -60,9 +60,9 @@ const routePresentations = {
       "Mint or redeem a fixed bundle of assets as one unit. You will see exactly what a basket holds before you mint.",
   },
   positions: {
-    label: "Positions",
-    status: "Positions",
-    title: "Your positions",
+    label: "Position NFT",
+    status: "Position NFT",
+    title: "Your Position NFTs",
     description:
       "Each position holds your baskets, loans, and Dollar together. Manage collateral, staking, and rewards from here.",
   },
@@ -81,9 +81,9 @@ const routePresentations = {
       "Stake a position to earn a share of protocol fees. Pick which assets to earn in and claim what you have built up.",
   },
   genesis: {
-    label: "Genesis",
-    status: "Genesis",
-    title: "Genesis staking boost",
+    label: "Genesis NFT",
+    status: "Genesis NFT",
+    title: "Manage your Genesis NFTs",
     description:
       "Activate a Genesis NFT by burning STATICS, then link it to one Position to increase that Position's reward weight.",
   },

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -118,7 +118,6 @@ export const appNavigationGroups: readonly AppNavigationGroup[] = [
         href: "/app/rewards",
         tabLabel: "Earn",
       },
-      { label: "Genesis", messageKey: "genesis", enabled: true, href: "/app/genesis" },
       { label: "Liquidity", messageKey: "liquidity", enabled: true, href: "/app/liquidity" },
     ],
   },
@@ -147,7 +146,18 @@ export const appNavigationGroups: readonly AppNavigationGroup[] = [
     label: "Manage",
     messageKey: "manage",
     items: [
-      { label: "Positions", messageKey: "positions", enabled: true, href: "/app/positions" },
+      {
+        label: "Position NFT",
+        messageKey: "positions",
+        enabled: true,
+        href: "/app/positions",
+      },
+      {
+        label: "Genesis NFT",
+        messageKey: "genesis",
+        enabled: true,
+        href: "/app/genesis",
+      },
       { label: "Loans", messageKey: "loans", enabled: true, href: "/app/loans" },
     ],
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,6 +12,11 @@
     "planned": "Planned",
     "comingSoon": "{label} link coming soon"
   },
+  "nftArtwork": {
+    "viewFullSize": "View {name} full size",
+    "title": "{name} artwork",
+    "alt": "Full-size artwork for {name}"
+  },
   "metadata": {
     "title": "Statics Protocol",
     "titleTemplate": "{page} | Statics Protocol",

--- a/messages/en.json
+++ b/messages/en.json
@@ -33,7 +33,6 @@
     "groups": {
       "overview": "Overview",
       "earn": "Earn",
-      "genesis": "Genesis",
       "assets": "Assets",
       "manage": "Manage",
       "account": "Account"
@@ -41,12 +40,12 @@
     "items": {
       "overview": "Overview",
       "earn": "Earn",
-      "genesis": "Genesis",
+      "genesis": "Genesis NFT",
       "liquidity": "Liquidity",
       "baskets": "Baskets",
       "create": "Create basket",
       "dollar": "Dollar",
-      "positions": "Positions",
+      "positions": "Position NFT",
       "loans": "Loans",
       "wallet": "Wallet",
       "faucet": "Faucet",
@@ -100,9 +99,9 @@
       "description": "Mint or redeem a fixed bundle of assets as one unit. You will see exactly what a basket holds before you mint."
     },
     "positions": {
-      "label": "Positions",
-      "status": "Positions",
-      "title": "Your positions",
+      "label": "Position NFT",
+      "status": "Position NFT",
+      "title": "Your Position NFTs",
       "description": "Each position holds your baskets, loans, and Dollar together. Manage collateral, staking, and rewards from here."
     },
     "loans": {
@@ -118,9 +117,9 @@
       "description": "Stake a position to earn a share of protocol fees. Pick which assets to earn in and claim what you have built up."
     },
     "genesis": {
-      "label": "Genesis",
-      "status": "Genesis",
-      "title": "Genesis staking boost",
+      "label": "Genesis NFT",
+      "status": "Genesis NFT",
+      "title": "Manage your Genesis NFTs",
       "description": "Activate a Genesis NFT by burning STATICS, then link it to one Position to increase that Position's reward weight."
     },
     "liquidity": {
@@ -365,7 +364,7 @@
     "confirmBridge": "Confirm bridge"
   },
   "positions": {
-    "subject": "positions",
+    "subject": "Position NFTs",
     "collateralLabel": "BasketTokens held by this position",
     "collateralDescription": "These BasketTokens belong to this PositionNFT. The Diamond holds them in custody while they earn basket fees and support loans.",
     "noCollateral": "No BasketTokens are deposited.",
@@ -379,7 +378,7 @@
     "switchNetwork": "Switch to {network}",
     "walletLoading": "Wallet loading…",
     "creatingPosition": "Creating position…",
-    "title": "Your positions",
+    "title": "Your Position NFTs",
     "description": "A position holds your collateral, staking, rewards, loans, and liquidity together. Move the position and everything inside it moves with it.",
     "creationFee": "Opening a new Position costs {fee} ETH. Reusing one you own is free.",
     "stale": "Position data is temporarily unavailable. Showing the last received state.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -33,7 +33,6 @@
     "groups": {
       "overview": "Resumen",
       "earn": "Ganar",
-      "genesis": "Genesis",
       "assets": "Activos",
       "manage": "Gestionar",
       "account": "Cuenta"
@@ -41,12 +40,12 @@
     "items": {
       "overview": "Resumen",
       "earn": "Ganar",
-      "genesis": "Genesis",
+      "genesis": "Genesis NFT",
       "liquidity": "Liquidez",
       "baskets": "Cestas",
       "create": "Crear cesta",
       "dollar": "Dólar",
-      "positions": "Posiciones",
+      "positions": "Position NFT",
       "loans": "Préstamos",
       "wallet": "Billetera",
       "faucet": "Faucet",
@@ -100,9 +99,9 @@
       "description": "Compra o vende un conjunto fijo de activos como una sola unidad. Verás exactamente qué contiene una cesta antes de comprar."
     },
     "positions": {
-      "label": "Posiciones",
-      "status": "Posiciones",
-      "title": "Tus posiciones",
+      "label": "Position NFT",
+      "status": "Position NFT",
+      "title": "Tus Position NFTs",
       "description": "Cada posición reúne tus cestas, préstamos y dólares. Gestiona la garantía, el staking y las recompensas desde aquí."
     },
     "loans": {
@@ -118,9 +117,9 @@
       "description": "Haz staking de una posición para obtener una parte de las comisiones del protocolo. Elige en qué activos quieres ganar y reclama lo acumulado."
     },
     "genesis": {
-      "label": "Genesis",
-      "status": "Genesis",
-      "title": "Impulso de staking Genesis",
+      "label": "Genesis NFT",
+      "status": "Genesis NFT",
+      "title": "Gestiona tus Genesis NFTs",
       "description": "Activa un NFT Genesis quemando STATICS y enlázalo a una Posición para aumentar su peso de recompensas."
     },
     "liquidity": {
@@ -365,7 +364,7 @@
     "confirmBridge": "Confirmar puente"
   },
   "positions": {
-    "subject": "posiciones",
+    "subject": "Position NFTs",
     "collateralLabel": "BasketTokens de esta posición",
     "collateralDescription": "Estos BasketTokens pertenecen a este PositionNFT. El Diamond los mantiene en custodia mientras generan comisiones de cesta y respaldan préstamos.",
     "noCollateral": "No hay BasketTokens depositados.",
@@ -379,7 +378,7 @@
     "switchNetwork": "Cambiar a {network}",
     "walletLoading": "Cargando billetera…",
     "creatingPosition": "Creando posición…",
-    "title": "Tus posiciones",
+    "title": "Tus Position NFTs",
     "description": "Una posición reúne tu garantía, staking, recompensas, préstamos y liquidez. Al mover la posición, todo lo que contiene se mueve con ella.",
     "creationFee": "Abrir una posición nueva cuesta {fee} ETH. Reutilizar una propia es gratis.",
     "stale": "Los datos de las posiciones no están disponibles temporalmente. Se muestra el último estado recibido.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -12,6 +12,11 @@
     "planned": "Planeado",
     "comingSoon": "El enlace {label} estará disponible próximamente"
   },
+  "nftArtwork": {
+    "viewFullSize": "Ver {name} a tamaño completo",
+    "title": "Ilustración de {name}",
+    "alt": "Ilustración a tamaño completo de {name}"
+  },
   "metadata": {
     "title": "Statics Protocol",
     "titleTemplate": "{page} | Statics Protocol",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -33,7 +33,6 @@
     "groups": {
       "overview": "概览",
       "earn": "赚取",
-      "genesis": "Genesis",
       "assets": "资产",
       "manage": "管理",
       "account": "账户"
@@ -41,12 +40,12 @@
     "items": {
       "overview": "概览",
       "earn": "赚取",
-      "genesis": "Genesis",
+      "genesis": "Genesis NFT",
       "liquidity": "流动性",
       "baskets": "篮子",
       "create": "创建篮子",
       "dollar": "美元",
-      "positions": "头寸",
+      "positions": "Position NFT",
       "loans": "贷款",
       "wallet": "钱包",
       "faucet": "水龙头",
@@ -100,9 +99,9 @@
       "description": "将一组固定资产作为一个整体买卖。购买前可查看篮子中包含的确切资产。"
     },
     "positions": {
-      "label": "头寸",
-      "status": "头寸",
-      "title": "你的头寸",
+      "label": "Position NFT",
+      "status": "Position NFT",
+      "title": "你的 Position NFTs",
       "description": "每个头寸汇集你的篮子、贷款和美元。在这里管理抵押品、质押和奖励。"
     },
     "loans": {
@@ -118,9 +117,9 @@
       "description": "质押一个头寸以获得协议费用分成。选择希望赚取的资产并领取累积奖励。"
     },
     "genesis": {
-      "label": "Genesis",
-      "status": "Genesis",
-      "title": "Genesis 质押加成",
+      "label": "Genesis NFT",
+      "status": "Genesis NFT",
+      "title": "管理你的 Genesis NFTs",
       "description": "燃烧 STATICS 激活 Genesis NFT，再将其绑定到一个 Position，以提高该 Position 的奖励权重。"
     },
     "liquidity": {
@@ -365,7 +364,7 @@
     "confirmBridge": "确认跨链"
   },
   "positions": {
-    "subject": "头寸",
+    "subject": "Position NFTs",
     "collateralLabel": "此头寸持有的 BasketTokens",
     "collateralDescription": "这些 BasketTokens 属于此 PositionNFT。Diamond 托管它们，使其赚取篮子费用并支持贷款。",
     "noCollateral": "尚未存入 BasketTokens。",
@@ -379,7 +378,7 @@
     "switchNetwork": "切换到 {network}",
     "walletLoading": "正在加载钱包…",
     "creatingPosition": "正在创建头寸…",
-    "title": "你的头寸",
+    "title": "你的 Position NFTs",
     "description": "一个头寸汇集你的抵押品、质押、奖励、贷款和流动性。转移头寸时，其中的一切都会随之转移。",
     "creationFee": "新建头寸需支付 {fee} ETH。复用已有头寸免费。",
     "stale": "头寸数据暂时不可用，正在显示最近收到的状态。",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -12,6 +12,11 @@
     "planned": "计划中",
     "comingSoon": "{label} 链接即将推出"
   },
+  "nftArtwork": {
+    "viewFullSize": "查看 {name} 的完整尺寸",
+    "title": "{name} 图像",
+    "alt": "{name} 的完整尺寸图像"
+  },
   "metadata": {
     "title": "Statics Protocol",
     "titleTemplate": "{page} | Statics Protocol",

--- a/test/components/nft-artwork.test.tsx
+++ b/test/components/nft-artwork.test.tsx
@@ -1,0 +1,93 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@/test/render";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NftArtwork } from "@/components/wallet/NftArtwork";
+
+const mocks = vi.hoisted(() => ({
+  resolveNftImage: vi.fn(),
+}));
+
+vi.mock("wagmi", () => ({
+  usePublicClient: () => ({}),
+}));
+
+vi.mock("@/lib/wallet/nft-image", () => ({
+  resolveNftImage: mocks.resolveNftImage,
+}));
+
+const nft = {
+  kind: "collection" as const,
+  tokenId: 4n,
+  contract: "0x0000000000000000000000000000000000000004" as const,
+  name: "Genesis #4",
+  summary: "Tier 2",
+  carries: [],
+  blockedReason: null,
+};
+
+function renderArtwork(expandable = true) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NftArtwork nft={nft} chainId={46630} expandable={expandable} />
+    </QueryClientProvider>
+  );
+}
+
+describe("NFT artwork viewer", () => {
+  beforeEach(() => {
+    mocks.resolveNftImage.mockReset();
+    mocks.resolveNftImage.mockResolvedValue(
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"
+    );
+  });
+
+  it("opens the resolved artwork, traps focus, and restores it after Escape", async () => {
+    renderArtwork();
+    const trigger = await screen.findByRole("button", {
+      name: "View Genesis #4 full size",
+    });
+
+    trigger.focus();
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole("dialog", { name: "Genesis #4 artwork" });
+    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Full-size artwork for Genesis #4" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("closes when the backdrop is pressed", async () => {
+    renderArtwork();
+    fireEvent.click(await screen.findByRole("button", { name: "View Genesis #4 full size" }));
+    fireEvent.mouseDown(document.querySelector(".wallet-dialog-backdrop")!);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("leaves ordinary thumbnails and missing artwork noninteractive", async () => {
+    const first = renderArtwork(false);
+    await waitFor(() =>
+      expect(first.container.querySelector("img.wallet-nft-art")).toBeInTheDocument()
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    first.unmount();
+
+    mocks.resolveNftImage.mockResolvedValueOnce(null);
+    renderArtwork();
+    await waitFor(() => expect(mocks.resolveNftImage).toHaveBeenCalled());
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/test/foundation/dapp-navigation.test.ts
+++ b/test/foundation/dapp-navigation.test.ts
@@ -18,10 +18,10 @@ describe("DApp route presentation", () => {
     ["/app/dollar", "Dollar", "Get Statics Dollar"],
     ["/app/baskets", "Baskets", "Baskets"],
     ["/app/create", "Create basket", "Launch an index basket"],
-    ["/app/positions", "Positions", "Your positions"],
+    ["/app/positions", "Position NFT", "Your Position NFTs"],
     ["/app/loans", "Loans", "Your loans"],
     ["/app/rewards", "Rewards", "Your rewards"],
-    ["/app/genesis", "Genesis", "Genesis staking boost"],
+    ["/app/genesis", "Genesis NFT", "Manage your Genesis NFTs"],
     ["/app/liquidity", "Liquidity", "Provide liquidity"],
     ["/app/activity", "Activity", "Your activity"],
     ["/app/tools", "Tools", "Approval tools"],
@@ -31,7 +31,7 @@ describe("DApp route presentation", () => {
 
   it("inherits parent presentation for detail routes", () => {
     expect(getDappRoutePresentation("/app/baskets/42").label).toBe("Baskets");
-    expect(getDappRoutePresentation("/app/positions/1042").label).toBe("Positions");
+    expect(getDappRoutePresentation("/app/positions/1042").label).toBe("Position NFT");
   });
 
   it("falls back to overview for an unknown application route", () => {

--- a/test/foundation/reward-boundaries.test.ts
+++ b/test/foundation/reward-boundaries.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("reward surface boundaries", () => {
+  const genesisSource = readFileSync("components/genesis/GenesisPage.tsx", "utf8");
   const positionSource = readFileSync("components/positions/PositionDetailPage.tsx", "utf8");
   const rewardsSource = readFileSync("components/rewards/RewardsPage.tsx", "utf8");
 
@@ -17,5 +18,11 @@ describe("reward surface boundaries", () => {
   it("keeps specialized liquidity earnings discoverable without duplicating LP controls", () => {
     expect(rewardsSource).toContain('href="/app/liquidity"');
     expect(rewardsSource).not.toContain("buildClaimLiquidityRewardsCall");
+  });
+
+  it("simulates owner-gated Genesis reward reads from the connected wallet", () => {
+    expect(genesisSource).toMatch(
+      /readContract\(\{\s*account: wallet,\s*address: deployment\.contracts\.diamond,\s*abi: staticsAbi,\s*functionName: "positionRewardAssets"/
+    );
   });
 });

--- a/test/foundation/route-copy.test.ts
+++ b/test/foundation/route-copy.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { getDappRoutePresentation } from "@/lib/dapp-navigation";
 import { appNavigation, appNavigationGroups, appTabNavigation } from "@/lib/site-config";
+import english from "@/messages/en.json";
+import spanish from "@/messages/es.json";
+import chinese from "@/messages/zh-CN.json";
 
 /**
  * Guards the consumer-copy rewrite the same way stylelint guards the type
@@ -117,12 +120,12 @@ describe("sidebar completeness", () => {
     expect(appNavigation.map((item) => item.label)).toEqual([
       "Overview",
       "Earn",
-      "Genesis",
       "Liquidity",
       "Baskets",
       "Create basket",
       "Dollar",
-      "Positions",
+      "Position NFT",
+      "Genesis NFT",
       "Loans",
       "Wallet",
       "Faucet",
@@ -133,7 +136,18 @@ describe("sidebar completeness", () => {
 
   it("keeps position management directly discoverable", () => {
     const manage = appNavigationGroups.find((group) => group.label === "Manage");
-    expect(manage?.items.map((item) => item.href)).toEqual(["/app/positions", "/app/loans"]);
+    expect(manage?.items.map((item) => item.href)).toEqual([
+      "/app/positions",
+      "/app/genesis",
+      "/app/loans",
+    ]);
+  });
+
+  it("uses the exact NFT product labels in every locale", () => {
+    for (const messages of [english, spanish, chinese]) {
+      expect(messages.navigation.items.positions).toBe("Position NFT");
+      expect(messages.navigation.items.genesis).toBe("Genesis NFT");
+    }
   });
 
   it("keeps account plumbing grouped rather than promoted", () => {

--- a/test/foundation/style-primitives.test.ts
+++ b/test/foundation/style-primitives.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migratedSurfaces = [
+  "components/baskets/BasketCreatePage.tsx",
+  "components/genesis/GenesisPage.tsx",
+  "components/rewards/ProtocolRevenueCard.tsx",
+] as const;
+
+describe("DApp style primitives", () => {
+  it("uses the shared card primitive instead of the undefined dapp-card class", () => {
+    for (const file of migratedSurfaces) {
+      const source = readFileSync(file, "utf8");
+      expect(source, file).not.toContain("dapp-card");
+      expect(source, file).toContain("ui-card");
+    }
+  });
+
+  it("composes the Genesis cards from the shared UI primitives", () => {
+    const source = readFileSync("components/genesis/GenesisPage.tsx", "utf8");
+    for (const primitive of ["ui-stat", "ui-section-title", "ui-pill", "ui-field", "ui-button"]) {
+      expect(source).toContain(primitive);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- move Genesis NFT from Earn to Manage and rename the two NFT management destinations
- add an accessible, reusable full-size NFT artwork viewer and enable it for Genesis cards
- replace the undefined `dapp-card` class with the shared `ui-card` system across the affected Genesis, basket-creation, and revenue surfaces
- compose Genesis cards from the existing stat, heading, pill, field, and button primitives
- keep generated Ponder runtime state outside Git and formatting inputs

## Stack
- depends on #23
- base branch: `feat/genesis-economy`
- no contract, SDK, indexer schema, deployment manifest, or redeployment changes

## Verification
- `NEXT_PUBLIC_STATICS_CHAIN_ID= npm run verify` (88 unit-test files / 460 tests and 42 browser tests across desktop, tablet, and mobile)
- `npm --prefix ponder run typecheck`
- `npm --prefix ponder test` (3 tests)
- connected Robinhood testnet Genesis page visually verified with five owned NFTs at desktop and 390x844; no horizontal overflow

The explicit empty chain ID gives Playwright the unconfigured deployment state its foundation tests assert; this checkout has an ignored `.env.local` that otherwise points at the live Robinhood testnet deployment.