### PR TITLE
feat(genesis): complete the launch UI surface

### DIFF
--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { encodeFunctionData, formatEther, getAddress, parseEther } from "viem";
+import { usePublicClient } from "wagmi";
+import { dopplerStaticsTokenAbi } from "@statics-protocol/sdk";
+import {
+  GENESIS_MAX_CREDIT_PRINCIPAL,
+  buildExtendGenesisCreditTransaction,
+  buildOpenGenesisCreditTransaction,
+  buildRecoverGenesisCreditCall,
+  buildRepayGenesisCreditCall,
+  staticsGenesisCreditAbi,
+} from "@statics-protocol/sdk/genesis-credit";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
+import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { useWalletState } from "@/providers/wallet-context";
+
+function describeCreditError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/rejected/i.test(message)) return "The wallet request was rejected.";
+  if (message.includes("CreditUnavailableDuringEpoch")) return "Secured credit opens after the Genesis Epoch.";
+  if (message.includes("CreditOriginationsPaused")) return "New Genesis credit is temporarily paused.";
+  if (message.includes("CreditExpired")) return "This credit has expired and can no longer be extended.";
+  if (message.includes("CreditNotRecoverable")) return "This credit is not recoverable yet.";
+  return message || "The Genesis credit transaction failed.";
+}
+
+function formatTimestamp(timestamp: bigint): string {
+  if (timestamp === 0n) return "—";
+  return new Date(Number(timestamp) * 1000).toLocaleString();
+}
+
+export function GenesisCreditPanel({
+  deployment,
+  genesisId,
+}: {
+  deployment: LaunchDeployment;
+  genesisId: bigint;
+}) {
+  const walletState = useWalletState();
+  const publicClient = usePublicClient({ chainId: deployment.descriptor.chainId });
+  const queryClient = useQueryClient();
+  const wallet =
+    walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
+  const [amount, setAmount] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const state = useQuery({
+    queryKey: ["launch-genesis-credit", deployment.descriptor.deploymentId, genesisId, wallet],
+    enabled: Boolean(publicClient && wallet),
+    queryFn: async () => {
+      if (!publicClient || !wallet) throw new Error("Connect a wallet first.");
+      await verifyLaunchDeployment(publicClient, deployment);
+      const [epochActive, originationsPaused, credit, limit] = await Promise.all([
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: staticsGenesisCreditAbi,
+          functionName: "epochActive",
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: staticsGenesisCreditAbi,
+          functionName: "creditOriginationsPaused",
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: staticsGenesisCreditAbi,
+          functionName: "credit",
+          args: [genesisId],
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: staticsGenesisCreditAbi,
+          functionName: "creditLimit",
+          args: [genesisId],
+        }),
+      ]);
+      return { epochActive, originationsPaused, credit, limit };
+    },
+  });
+
+  const refresh = async () => {
+    await queryClient.invalidateQueries({
+      predicate: (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey.includes(deployment.descriptor.deploymentId) &&
+        (String(query.queryKey[0]).startsWith("launch-genesis-credit") ||
+          String(query.queryKey[0]).startsWith("launch-genesis-owned") ||
+          String(query.queryKey[0]).startsWith("genesis-vault")),
+    });
+  };
+
+  const send = async (
+    key: "open-genesis-credit" | "extend-genesis-credit" | "repay-genesis-credit" | "recover-genesis-credit",
+    label: string,
+    data: `0x${string}`,
+    reviewedAmount: string,
+    value?: bigint
+  ) => {
+    if (!wallet || !publicClient) return;
+    if (!walletState.isTargetChain) {
+      await walletState.switchNetwork();
+      return;
+    }
+    await executeProtocolTransaction({
+      publicClient,
+      wallet,
+      chainId: deployment.descriptor.chainId,
+      deploymentId: deployment.descriptor.deploymentId,
+      kind: key,
+      label,
+      amount: reviewedAmount,
+      to: deployment.contracts.vault,
+      data,
+      value,
+      sendTransaction: walletState.sendEvmTransaction,
+      describeError: describeCreditError,
+    });
+  };
+
+  const act = async (key: string, action: () => Promise<void>) => {
+    setBusy(key);
+    setError(null);
+    try {
+      if (!publicClient || !wallet) return;
+      await verifyLaunchDeployment(publicClient, deployment);
+      await action();
+      await refresh();
+    } catch (cause) {
+      setError(describeCreditError(cause));
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (!wallet || state.isLoading) return null;
+  if (state.error || !state.data) {
+    return <p className="dapp-inline-error">{describeCreditError(state.error)}</p>;
+  }
+
+  const credit = state.data.credit;
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  const recoverable = credit.active && credit.recoverableAt !== 0 && now > credit.recoverableAt;
+
+  if (!credit.active) {
+    const unavailable = state.data.epochActive || state.data.originationsPaused;
+    return (
+      <section className="genesis-action" aria-label={`Genesis #${genesisId} secured credit`}>
+        <h3>Secured credit</h3>
+        {state.data.epochActive ? (
+          <p>Available after the Genesis Epoch. Borrow up to 171,000 STATICS without redeeming the NFT.</p>
+        ) : (
+          <>
+            <p>Borrow up to {formatEther(state.data.limit || GENESIS_MAX_CREDIT_PRINCIPAL)} STATICS against this Genesis.</p>
+            <label className="ui-field">
+              Borrow STATICS
+              <input
+                inputMode="decimal"
+                value={amount}
+                placeholder="0"
+                onChange={(event) => setAmount(event.target.value)}
+                disabled={unavailable || busy !== null}
+              />
+            </label>
+            <button
+              className="ui-button ui-button--primary ui-button--block"
+              type="button"
+              disabled={unavailable || busy !== null || !amount}
+              onClick={() =>
+                void act("open", async () => {
+                  if (!publicClient) return;
+                  const principal = parseEther(amount);
+                  if (principal <= 0n || principal > state.data.limit) {
+                    throw new Error("Choose an amount within this Genesis credit limit.");
+                  }
+                  const quote = await publicClient.readContract({
+                    address: deployment.contracts.vault,
+                    abi: staticsGenesisCreditAbi,
+                    functionName: "quoteGenesisCredit",
+                    args: [principal],
+                  });
+                  const transaction = buildOpenGenesisCreditTransaction(
+                    genesisId,
+                    principal,
+                    quote.totalNativeFee
+                  );
+                  await send(
+                    "open-genesis-credit",
+                    `Borrow against Genesis #${genesisId}`,
+                    transaction.data,
+                    `${formatEther(principal)} STATICS + ${formatEther(quote.totalNativeFee)} ETH fee`,
+                    transaction.value
+                  );
+                  setAmount("");
+                })
+              }
+            >
+              {busy === "open" ? "Borrowing…" : "Borrow STATICS"}
+            </button>
+          </>
+        )}
+        {state.data.originationsPaused && !state.data.epochActive && <p>New Genesis credit is temporarily paused.</p>}
+        {error && <p className="dapp-inline-error">{error}</p>}
+      </section>
+    );
+  }
+
+  return (
+    <section className="genesis-action" aria-label={`Genesis #${genesisId} secured credit`}>
+      <h3>Secured credit</h3>
+      <p>Borrowed: {formatEther(credit.principal)} STATICS</p>
+      <p>Maturity: {formatTimestamp(credit.maturity)}</p>
+      <p>Recovery available: {formatTimestamp(credit.recoverableAt)}</p>
+      <div className="ui-inline-actions">
+        <button
+          className="ui-button ui-button--secondary"
+          type="button"
+          disabled={busy !== null || now > credit.maturity}
+          onClick={() =>
+            void act("extend", async () => {
+              if (!publicClient) return;
+              const quote = await publicClient.readContract({
+                address: deployment.contracts.vault,
+                abi: staticsGenesisCreditAbi,
+                functionName: "quoteGenesisCreditExtension",
+                args: [genesisId],
+              });
+              const transaction = buildExtendGenesisCreditTransaction(genesisId, quote.totalNativeFee);
+              await send(
+                "extend-genesis-credit",
+                `Extend Genesis #${genesisId} credit`,
+                transaction.data,
+                `${formatEther(quote.totalNativeFee)} ETH fee`,
+                transaction.value
+              );
+            })
+          }
+        >
+          {busy === "extend" ? "Extending…" : "Extend 30 days"}
+        </button>
+        <button
+          className="ui-button ui-button--primary"
+          type="button"
+          disabled={busy !== null}
+          onClick={() =>
+            void act("repay", async () => {
+              if (!publicClient || !wallet) return;
+              const allowance = await publicClient.readContract({
+                address: deployment.contracts.statics,
+                abi: dopplerStaticsTokenAbi,
+                functionName: "allowance",
+                args: [wallet, deployment.contracts.vault],
+              });
+              if (allowance < credit.principal) {
+                await executeProtocolTransaction({
+                  publicClient,
+                  wallet,
+                  chainId: deployment.descriptor.chainId,
+                  deploymentId: deployment.descriptor.deploymentId,
+                  kind: "approve-staking-token",
+                  label: "Enable Genesis credit repayment",
+                  amount: "Maximum STATICS",
+                  to: deployment.contracts.statics,
+                  data: encodeFunctionData({
+                    abi: dopplerStaticsTokenAbi,
+                    functionName: "approve",
+                    args: [deployment.contracts.vault, MAX_ERC20_ALLOWANCE],
+                  }),
+                  sendTransaction: walletState.sendEvmTransaction,
+                  describeError: describeCreditError,
+                });
+              }
+              await send(
+                "repay-genesis-credit",
+                `Repay Genesis #${genesisId} credit`,
+                buildRepayGenesisCreditCall(genesisId),
+                `${formatEther(credit.principal)} STATICS`
+              );
+            })
+          }
+        >
+          {busy === "repay" ? "Repaying…" : "Repay"}
+        </button>
+        {recoverable && (
+          <button
+            className="ui-button ui-button--secondary"
+            type="button"
+            disabled={busy !== null}
+            onClick={() =>
+              void act("recover", async () => {
+                if (!publicClient) return;
+                const quote = await publicClient.readContract({
+                  address: deployment.contracts.vault,
+                  abi: staticsGenesisCreditAbi,
+                  functionName: "quoteGenesisCreditRecovery",
+                  args: [genesisId],
+                });
+                await send(
+                  "recover-genesis-credit",
+                  `Recover expired Genesis #${genesisId} credit`,
+                  buildRecoverGenesisCreditCall(genesisId),
+                  `${formatEther(quote.callerIncentive)} STATICS caller incentive`
+                );
+              })
+            }
+          >
+            {busy === "recover" ? "Recovering…" : "Recover expired credit"}
+          </button>
+        )}
+      </div>
+      <p>This Genesis is transfer-locked while secured credit is active.</p>
+      {error && <p className="dapp-inline-error">{error}</p>}
+    </section>
+  );
+}

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -9,12 +9,12 @@ import {
   buildRedeemGenesisCall,
   dopplerStaticsTokenAbi,
   staticsGenesisAbi,
-  staticsGenesisVaultAbi,
 } from "@statics-protocol/sdk";
 
 import { EmptyState } from "@/components/common/EmptyState";
 import { NftArtwork } from "@/components/wallet/NftArtwork";
 import type { LaunchDeployment } from "@/lib/deployments/types";
+import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import { discoverNextAvailableGenesisId, discoverWalletGenesisIds } from "@/lib/genesis/discovery";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
@@ -47,21 +47,9 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
       if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
       await verifyLaunchDeployment(publicClient, deployment);
       const [purchaseQuote, redemptionQuote, accounting, nextId, ownedIds] = await Promise.all([
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "quoteGenesisPurchase",
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "quoteGenesisRedemption",
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "vaultAccounting",
-        }),
+        publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "quoteGenesisPurchase" }),
+        publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "quoteGenesisRedemption" }),
+        publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "vaultAccounting" }),
         discoverNextAvailableGenesisId(publicClient, deployment),
         wallet ? discoverWalletGenesisIds(publicClient, deployment, wallet) : [],
       ]);
@@ -74,8 +62,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
       predicate: (query) =>
         Array.isArray(query.queryKey) &&
         query.queryKey.includes(deployment.descriptor.deploymentId) &&
-        (String(query.queryKey[0]).startsWith("genesis-vault") ||
-          String(query.queryKey[0]).startsWith("launch-genesis")),
+        (String(query.queryKey[0]).startsWith("genesis-vault") || String(query.queryKey[0]).startsWith("launch-genesis")),
     });
   };
 
@@ -95,9 +82,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     return Boolean(wallet && publicClient);
   };
 
-  const transact = async (
-    request: Omit<Parameters<typeof executeProtocolTransaction>[0], "deploymentId">
-  ) => {
+  const transact = async (request: Omit<Parameters<typeof executeProtocolTransaction>[0], "deploymentId">) => {
     await verifyLaunchDeployment(request.publicClient, deployment);
     return executeProtocolTransaction({ ...request, deploymentId: deployment.descriptor.deploymentId });
   };
@@ -109,29 +94,10 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     try {
       const id = vault.data.nextId;
       const [quote, balance, allowance, stillAvailable] = await Promise.all([
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "quoteGenesisPurchase",
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.statics,
-          abi: dopplerStaticsTokenAbi,
-          functionName: "balanceOf",
-          args: [wallet],
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.statics,
-          abi: dopplerStaticsTokenAbi,
-          functionName: "allowance",
-          args: [wallet, deployment.contracts.vault],
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "isVaultInventory",
-          args: [id],
-        }),
+        publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "quoteGenesisPurchase" }),
+        publicClient.readContract({ address: deployment.contracts.statics, abi: dopplerStaticsTokenAbi, functionName: "balanceOf", args: [wallet] }),
+        publicClient.readContract({ address: deployment.contracts.statics, abi: dopplerStaticsTokenAbi, functionName: "allowance", args: [wallet, deployment.contracts.vault] }),
+        publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "isVaultInventory", args: [id] }),
       ]);
       if (!stillAvailable) throw new Error("GenesisNotInVault");
       if (balance < quote.staticsPrice) throw new Error("Buy STATICS first, then switch back to NFT.");
@@ -144,11 +110,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           label: "Enable Genesis NFT acquisition",
           amount: "Maximum STATICS",
           to: deployment.contracts.statics,
-          data: encodeFunctionData({
-            abi: dopplerStaticsTokenAbi,
-            functionName: "approve",
-            args: [deployment.contracts.vault, MAX_ERC20_ALLOWANCE],
-          }),
+          data: encodeFunctionData({ abi: dopplerStaticsTokenAbi, functionName: "approve", args: [deployment.contracts.vault, MAX_ERC20_ALLOWANCE] }),
           sendTransaction: walletState.sendEvmTransaction,
           describeError,
         });
@@ -182,17 +144,8 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     setError(null);
     try {
       const id = BigInt(selectedOwnedId);
-      const redemptionQuote = await publicClient.readContract({
-        address: deployment.contracts.vault,
-        abi: staticsGenesisVaultAbi,
-        functionName: "quoteGenesisRedemption",
-      });
-      const approved = await publicClient.readContract({
-        address: deployment.contracts.genesis,
-        abi: staticsGenesisAbi,
-        functionName: "getApproved",
-        args: [id],
-      });
+      const redemptionQuote = await publicClient.readContract({ address: deployment.contracts.vault, abi: currentGenesisVaultAbi, functionName: "quoteGenesisRedemption" });
+      const approved = await publicClient.readContract({ address: deployment.contracts.genesis, abi: staticsGenesisAbi, functionName: "getApproved", args: [id] });
       if (getAddress(approved) !== getAddress(deployment.contracts.vault)) {
         await transact({
           publicClient,
@@ -202,11 +155,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           label: `Approve Genesis #${id} redemption`,
           amount: `Genesis #${id}`,
           to: deployment.contracts.genesis,
-          data: encodeFunctionData({
-            abi: staticsGenesisAbi,
-            functionName: "approve",
-            args: [deployment.contracts.vault, id],
-          }),
+          data: encodeFunctionData({ abi: staticsGenesisAbi, functionName: "approve", args: [deployment.contracts.vault, id] }),
           sendTransaction: walletState.sendEvmTransaction,
           describeError,
         });
@@ -259,11 +208,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         <p className="dapp-eyebrow">STATICS → Genesis NFT</p>
         <h2 id="next-genesis-title">{nextId === null ? "Vault inventory exhausted" : `Genesis #${nextId}`}</h2>
         {nextId !== null && (
-          <NftArtwork
-            chainId={deployment.descriptor.chainId}
-            expandable
-            nft={{ kind: "collection", tokenId: nextId, contract: deployment.contracts.genesis, name: `Genesis #${nextId}`, summary: "Next available Genesis NFT", carries: [], blockedReason: null }}
-          />
+          <NftArtwork chainId={deployment.descriptor.chainId} expandable nft={{ kind: "collection", tokenId: nextId, contract: deployment.contracts.genesis, name: `Genesis #${nextId}`, summary: "Next available Genesis NFT", carries: [], blockedReason: null }} />
         )}
         <dl className="portal-quote-grid">
           <div><dt>STATICS backing</dt><dd>{formatEther(purchaseQuote?.staticsPrice ?? 0n)} STATICS</dd></div>

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -24,9 +24,9 @@ import { useWalletState } from "@/providers/wallet-context";
 function describeError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   if (/rejected/i.test(message)) return "The wallet request was rejected.";
-  if (message.includes("GenesisNotInVault"))
-    return "That NFT was just acquired. Loading the next one.";
-  if (message.includes("GenesisLocked")) return "Unlink this Genesis NFT before redeeming it.";
+  if (message.includes("GenesisNotInVault")) return "That NFT was just acquired. Loading the next one.";
+  if (message.includes("CreditAlreadyActive")) return "Repay or recover this Genesis credit before redeeming.";
+  if (message.includes("GenesisLocked")) return "This Genesis is currently locked and cannot be redeemed.";
   return message || "The Genesis Vault transaction failed.";
 }
 
@@ -46,11 +46,16 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     queryFn: async () => {
       if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
       await verifyLaunchDeployment(publicClient, deployment);
-      const [quote, accounting, nextId, ownedIds] = await Promise.all([
+      const [purchaseQuote, redemptionQuote, accounting, nextId, ownedIds] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: staticsGenesisVaultAbi,
           functionName: "quoteGenesisPurchase",
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: staticsGenesisVaultAbi,
+          functionName: "quoteGenesisRedemption",
         }),
         publicClient.readContract({
           address: deployment.contracts.vault,
@@ -60,7 +65,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         discoverNextAvailableGenesisId(publicClient, deployment),
         wallet ? discoverWalletGenesisIds(publicClient, deployment, wallet) : [],
       ]);
-      return { quote, accounting, nextId, ownedIds };
+      return { purchaseQuote, redemptionQuote, accounting, nextId, ownedIds };
     },
   });
 
@@ -94,10 +99,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     request: Omit<Parameters<typeof executeProtocolTransaction>[0], "deploymentId">
   ) => {
     await verifyLaunchDeployment(request.publicClient, deployment);
-    return executeProtocolTransaction({
-      ...request,
-      deploymentId: deployment.descriptor.deploymentId,
-    });
+    return executeProtocolTransaction({ ...request, deploymentId: deployment.descriptor.deploymentId });
   };
 
   const buy = async () => {
@@ -106,7 +108,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     setError(null);
     try {
       const id = vault.data.nextId;
-      const [[price, nativeFee], balance, allowance, stillAvailable] = await Promise.all([
+      const [quote, balance, allowance, stillAvailable] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: staticsGenesisVaultAbi,
@@ -132,8 +134,8 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         }),
       ]);
       if (!stillAvailable) throw new Error("GenesisNotInVault");
-      if (balance < price) throw new Error("Buy STATICS first, then switch back to NFT.");
-      if (allowance < price) {
+      if (balance < quote.staticsPrice) throw new Error("Buy STATICS first, then switch back to NFT.");
+      if (allowance < quote.staticsPrice) {
         await transact({
           publicClient,
           wallet,
@@ -151,14 +153,14 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           describeError,
         });
       }
-      const purchase = buildBuyGenesisTransaction(id, wallet, nativeFee);
+      const purchase = buildBuyGenesisTransaction(id, wallet, quote.requiredNative);
       await transact({
         publicClient,
         wallet,
         chainId: deployment.descriptor.chainId,
         kind: "buy-genesis",
         label: `Acquire Genesis #${id}`,
-        amount: `${formatEther(price)} STATICS + ${formatEther(nativeFee)} ETH`,
+        amount: `${formatEther(quote.staticsPrice)} STATICS + ${formatEther(quote.requiredNative)} ETH`,
         to: deployment.contracts.vault,
         data: purchase.data,
         value: purchase.value,
@@ -180,6 +182,11 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     setError(null);
     try {
       const id = BigInt(selectedOwnedId);
+      const redemptionQuote = await publicClient.readContract({
+        address: deployment.contracts.vault,
+        abi: staticsGenesisVaultAbi,
+        functionName: "quoteGenesisRedemption",
+      });
       const approved = await publicClient.readContract({
         address: deployment.contracts.genesis,
         abi: staticsGenesisAbi,
@@ -210,7 +217,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         chainId: deployment.descriptor.chainId,
         kind: "redeem-genesis",
         label: `Redeem Genesis #${id}`,
-        amount: `${formatEther(vault.data?.quote[0] ?? 0n)} STATICS`,
+        amount: `${formatEther(redemptionQuote.staticsPayout)} STATICS + ${formatEther(redemptionQuote.reservePayout)} ETH`,
         to: deployment.contracts.vault,
         data: buildRedeemGenesisCall(id, wallet),
         sendTransaction: walletState.sendEvmTransaction,
@@ -227,97 +234,70 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
   };
 
   if (vault.isLoading) return <p className="dapp-loading">Loading the Genesis Vault…</p>;
-  if (vault.error) {
-    return (
-      <EmptyState title="Genesis Vault unavailable" description={describeError(vault.error)} />
-    );
-  }
+  if (vault.error) return <EmptyState title="Genesis Vault unavailable" description={describeError(vault.error)} />;
 
   const nextId = vault.data?.nextId ?? null;
+  const purchaseQuote = vault.data?.purchaseQuote;
+  const redemptionQuote = vault.data?.redemptionQuote;
+  const accounting = vault.data?.accounting;
   return (
     <div className="genesis-vault-swap">
+      <section className="portal-panel" aria-labelledby="genesis-vault-state-title">
+        <p className="dapp-eyebrow">Genesis Vault</p>
+        <h2 id="genesis-vault-state-title">Fully backed Genesis inventory</h2>
+        <dl className="portal-quote-grid">
+          <div><dt>Remaining</dt><dd>{accounting?.vaultInventory.toString() ?? "—"}</dd></div>
+          <div><dt>Circulating</dt><dd>{accounting?.circulatingGenesis.toString() ?? "—"}</dd></div>
+          <div><dt>Native reserve</dt><dd>{formatEther(accounting?.reserveETH ?? 0n)} ETH</dd></div>
+          <div><dt>Reserve / Genesis</dt><dd>{formatEther(accounting?.reserveBackingPerGenesis ?? 0n)} ETH</dd></div>
+          <div><dt>Outstanding credit</dt><dd>{formatEther(accounting?.outstandingGenesisCredit ?? 0n)} STATICS</dd></div>
+          <div><dt>Genesis Epoch</dt><dd>{accounting?.epochActive ? "Active" : "Complete"}</dd></div>
+        </dl>
+      </section>
+
       <section className="portal-panel" aria-labelledby="next-genesis-title">
         <p className="dapp-eyebrow">STATICS → Genesis NFT</p>
-        <h2 id="next-genesis-title">
-          {nextId === null ? "Vault inventory exhausted" : `Genesis #${nextId}`}
-        </h2>
+        <h2 id="next-genesis-title">{nextId === null ? "Vault inventory exhausted" : `Genesis #${nextId}`}</h2>
         {nextId !== null && (
           <NftArtwork
             chainId={deployment.descriptor.chainId}
             expandable
-            nft={{
-              kind: "collection",
-              tokenId: nextId,
-              contract: deployment.contracts.genesis,
-              name: `Genesis #${nextId}`,
-              summary: "Next available Genesis NFT",
-              carries: [],
-              blockedReason: null,
-            }}
+            nft={{ kind: "collection", tokenId: nextId, contract: deployment.contracts.genesis, name: `Genesis #${nextId}`, summary: "Next available Genesis NFT", carries: [], blockedReason: null }}
           />
         )}
         <dl className="portal-quote-grid">
-          <div>
-            <dt>Fixed backing</dt>
-            <dd>{formatEther(vault.data?.quote[0] ?? 0n)} STATICS</dd>
-          </div>
-          <div>
-            <dt>Acquisition fee</dt>
-            <dd>{formatEther(vault.data?.quote[1] ?? 0n)} ETH</dd>
-          </div>
-          <div>
-            <dt>Remaining</dt>
-            <dd>{vault.data?.accounting.vaultInventory.toString() ?? "—"}</dd>
-          </div>
+          <div><dt>STATICS backing</dt><dd>{formatEther(purchaseQuote?.staticsPrice ?? 0n)} STATICS</dd></div>
+          <div><dt>Reserve buy-in</dt><dd>{formatEther(purchaseQuote?.reserveBuyIn ?? 0n)} ETH</dd></div>
+          <div><dt>Acquisition fee</dt><dd>{formatEther(purchaseQuote?.nativeFee ?? 0n)} ETH</dd></div>
+          <div><dt>Total ETH required</dt><dd>{formatEther(purchaseQuote?.requiredNative ?? 0n)} ETH</dd></div>
         </dl>
-        <button
-          className="portal-primary-action"
-          type="button"
-          disabled={busy !== null || nextId === null}
-          onClick={() => void buy()}
-        >
-          {busy === "buy" ? "Confirming…" : "Buy Genesis NFT"}
+        <button className="portal-primary-action" type="button" disabled={busy !== null || nextId === null} onClick={() => void buy()}>
+          {busy === "buy" ? "Confirming…" : "Acquire Genesis NFT"}
         </button>
       </section>
 
       <section className="portal-panel" aria-labelledby="redeem-genesis-title">
-        <p className="dapp-eyebrow">Genesis NFT → STATICS</p>
+        <p className="dapp-eyebrow">Genesis NFT → backing</p>
         <h2 id="redeem-genesis-title">Redeem an owned NFT</h2>
         {wallet && (vault.data?.ownedIds.length ?? 0) > 0 ? (
           <>
             <label className="portal-field">
               <span>Genesis NFT</span>
-              <select
-                value={selectedOwnedId}
-                onChange={(event) => setSelectedOwnedId(event.target.value)}
-              >
+              <select value={selectedOwnedId} onChange={(event) => setSelectedOwnedId(event.target.value)}>
                 <option value="">Choose an NFT</option>
-                {vault.data!.ownedIds.map((id) => (
-                  <option key={id.toString()} value={id.toString()}>
-                    Genesis #{id.toString()}
-                  </option>
-                ))}
+                {vault.data!.ownedIds.map((id) => <option key={id.toString()} value={id.toString()}>Genesis #{id.toString()}</option>)}
               </select>
             </label>
-            <p>Receive {formatEther(vault.data?.quote[0] ?? 0n)} STATICS.</p>
-            <button
-              className="portal-primary-action"
-              type="button"
-              disabled={busy !== null || !selectedOwnedId}
-              onClick={() => void redeem()}
-            >
-              {busy === "redeem" ? "Confirming…" : "Redeem for STATICS"}
+            <p>Receive {formatEther(redemptionQuote?.staticsPayout ?? 0n)} STATICS + {formatEther(redemptionQuote?.reservePayout ?? 0n)} ETH.</p>
+            <button className="portal-primary-action" type="button" disabled={busy !== null || !selectedOwnedId} onClick={() => void redeem()}>
+              {busy === "redeem" ? "Confirming…" : "Redeem Genesis"}
             </button>
           </>
         ) : (
           <p>Connect a wallet holding a Genesis NFT to redeem it.</p>
         )}
       </section>
-      {error && (
-        <p className="portal-error" role="alert">
-          {error}
-        </p>
-      )}
+      {error && <p className="portal-error" role="alert">{error}</p>}
     </div>
   );
 }

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@statics-protocol/sdk";
 
 import { EmptyState } from "@/components/common/EmptyState";
+import { GenesisCreditPanel } from "@/components/genesis/GenesisCreditPanel";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
 import { NftArtwork } from "@/components/wallet/NftArtwork";
 import type { LaunchDeployment } from "@/lib/deployments/types";
@@ -160,7 +161,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         deploymentId: deployment.descriptor.deploymentId,
         kind: "activate-genesis",
         label: `Activate Genesis #${id} to tier ${targetTier}`,
-        amount: `${formatEther(cost)} STATICS burned`,
+        amount: `${formatEther(cost)} STATICS activation payment`,
         to: deployment.contracts.activationRegistry,
         data: buildActivateGenesisCall(id, targetTier),
         sendTransaction: walletState.sendEvmTransaction,
@@ -179,7 +180,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     return (
       <EmptyState
         title="Connect your wallet"
-        description="Connect to view and activate your Genesis NFTs."
+        description="Connect to view and manage your Genesis NFTs."
       />
     );
   }
@@ -216,7 +217,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                   <div>
                     <h2 className="ui-section-title">Genesis #{item.id.toString()}</h2>
                     <span className="ui-pill">
-                      Tier {item.tier} · {(item.multiplierBps / 10_000).toFixed(2)}×
+                      Tier {item.tier} · {(item.multiplierBps / 10_000).toFixed(2)}× reward weight
                     </span>
                   </div>
                   <NftArtwork
@@ -255,7 +256,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                           ))}
                       </select>
                     </label>
-                    <p>Burn cost: {formatEther(cost)} STATICS</p>
+                    <p>Activation cost: {formatEther(cost)} STATICS</p>
                     <button
                       className="ui-button ui-button--primary ui-button--block"
                       type="button"
@@ -264,11 +265,14 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                     >
                       {busy === item.id ? "Confirming…" : "Activate"}
                     </button>
+                    <p>Activation payments are transferred to the Statics treasury.</p>
                   </div>
                 )}
+                <GenesisCreditPanel deployment={deployment} genesisId={item.id} />
                 <p className="genesis-warning">
                   Transferring this Genesis NFT resets its activation to Tier 0. Rewards earned
-                  before transfer remain claimable by the previous owner.
+                  before transfer remain claimable by the previous owner. Active secured credit
+                  locks transfers until repayment or recovery.
                 </p>
               </article>
             );
@@ -285,6 +289,11 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
           address={deployment.contracts.activationRegistry}
           chainId={deployment.descriptor.chainId}
           label="Activation registry"
+        />
+        <AddressDisplay
+          address={deployment.contracts.vault}
+          chainId={deployment.descriptor.chainId}
+          label="Genesis Vault"
         />
       </section>
     </div>

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -92,7 +92,7 @@ const routePresentations = {
     status: "Genesis NFT",
     title: "Manage your Genesis NFTs",
     description:
-      "Activate a Genesis NFT by burning STATICS, then link it to one Position to increase that Position's reward weight.",
+      "Activate a Genesis NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
   },
   genesisRewards: {
     label: "Genesis Rewards",

--- a/lib/dollar/activity.ts
+++ b/lib/dollar/activity.ts
@@ -79,6 +79,10 @@ export type DollarActivityKind =
   | "buy-genesis"
   | "approve-genesis"
   | "redeem-genesis"
+  | "open-genesis-credit"
+  | "extend-genesis-credit"
+  | "repay-genesis-credit"
+  | "recover-genesis-credit"
   | "link-genesis"
   | "unlink-genesis"
   | "claim-creator-revenue"
@@ -182,15 +186,6 @@ export const writeProtocolActivity = writeDollarActivity;
 export const updateProtocolActivity = updateDollarActivity;
 export const subscribeProtocolActivity = subscribeDollarActivity;
 
-/**
- * Every chain this wallet has a stored record on.
- *
- * Activity is written per chain, so reading it back needs a list of chains to
- * look in. Deriving that list from the wallet's configured networks means a
- * record written on a network that was later removed -- or one the person is
- * simply not connected to right now -- silently disappears. The keys already
- * name the chain, so the honest source of that list is storage itself.
- */
 export function readActivityChainIds(
   wallet: Address,
   deploymentId = DEFAULT_ACTIVITY_DEPLOYMENT_ID

--- a/lib/genesis/current-vault.ts
+++ b/lib/genesis/current-vault.ts
@@ -1,0 +1,8 @@
+import { parseAbi } from "viem";
+
+export const currentGenesisVaultAbi = parseAbi([
+  "function quoteGenesisPurchase() view returns ((uint256 staticsPrice, uint256 reserveBuyIn, uint256 nativeFee, uint256 requiredNative, bool epochActive) quote)",
+  "function quoteGenesisRedemption() view returns ((uint256 staticsPayout, uint256 reservePayout, bool epochActive) quote)",
+  "function vaultAccounting() view returns ((uint256 vaultPrice, uint256 maximumSupply, uint256 mintedSupply, uint256 vaultInventory, uint256 circulatingGenesis, uint256 tokenBacking, uint256 grossBacking, uint256 outstandingGenesisCredit, uint256 requiredBacking, uint256 tokenCustody, uint256 reserveETH, uint256 nativeCustody, uint256 genesisEpochEnd, bool epochActive, uint256 reserveBackingPerGenesis) accounting)",
+  "function isVaultInventory(uint256 tokenId) view returns (bool)",
+]);

--- a/vendor/statics-sdk/dist/genesis-credit.d.ts
+++ b/vendor/statics-sdk/dist/genesis-credit.d.ts
@@ -1,9 +1,9 @@
-import type { Abi, Address, Hex } from "viem";
+import type { Address, Hex } from "viem";
 export declare const GENESIS_MAX_CREDIT_PRINCIPAL: bigint;
 export declare const GENESIS_RECOVERY_RESIDUAL: bigint;
 export declare const GENESIS_CREDIT_TERM: bigint;
 export declare const GENESIS_CREDIT_RECOVERY_GRACE: bigint;
-export declare const staticsGenesisCreditAbi: Abi;
+export declare const staticsGenesisCreditAbi: any;
 export type GenesisCreditTransaction = Readonly<{
     data: Hex;
     value: bigint;

--- a/vendor/statics-sdk/dist/genesis-credit.d.ts
+++ b/vendor/statics-sdk/dist/genesis-credit.d.ts
@@ -1,9 +1,9 @@
-import type { Address, Hex } from "viem";
+import type { Abi, Address, Hex } from "viem";
 export declare const GENESIS_MAX_CREDIT_PRINCIPAL: bigint;
 export declare const GENESIS_RECOVERY_RESIDUAL: bigint;
 export declare const GENESIS_CREDIT_TERM: bigint;
 export declare const GENESIS_CREDIT_RECOVERY_GRACE: bigint;
-export declare const staticsGenesisCreditAbi: readonly unknown[];
+export declare const staticsGenesisCreditAbi: Abi;
 export type GenesisCreditTransaction = Readonly<{
     data: Hex;
     value: bigint;

--- a/vendor/statics-sdk/dist/genesis-credit.d.ts
+++ b/vendor/statics-sdk/dist/genesis-credit.d.ts
@@ -1,0 +1,15 @@
+import type { Address, Hex } from "viem";
+export declare const GENESIS_MAX_CREDIT_PRINCIPAL: bigint;
+export declare const GENESIS_RECOVERY_RESIDUAL: bigint;
+export declare const GENESIS_CREDIT_TERM: bigint;
+export declare const GENESIS_CREDIT_RECOVERY_GRACE: bigint;
+export declare const staticsGenesisCreditAbi: readonly unknown[];
+export type GenesisCreditTransaction = Readonly<{
+    data: Hex;
+    value: bigint;
+}>;
+export declare function buildOpenGenesisCreditTransaction(genesisId: bigint, principal: bigint, nativeFee: bigint): GenesisCreditTransaction;
+export declare function buildExtendGenesisCreditTransaction(genesisId: bigint, nativeFee: bigint): GenesisCreditTransaction;
+export declare function buildRepayGenesisCreditCall(genesisId: bigint): Hex;
+export declare function buildRecoverGenesisCreditCall(genesisId: bigint): Hex;
+export type GenesisCreditContract = Address;

--- a/vendor/statics-sdk/dist/genesis-credit.js
+++ b/vendor/statics-sdk/dist/genesis-credit.js
@@ -1,0 +1,47 @@
+import { encodeFunctionData, parseAbi } from "viem";
+export const GENESIS_MAX_CREDIT_PRINCIPAL = 171_000n * 10n ** 18n;
+export const GENESIS_RECOVERY_RESIDUAL = 9_000n * 10n ** 18n;
+export const GENESIS_CREDIT_TERM = 30n * 24n * 60n * 60n;
+export const GENESIS_CREDIT_RECOVERY_GRACE = 60n * 60n;
+export const staticsGenesisCreditAbi = parseAbi([
+    "function openGenesisCredit(uint256 genesisId, uint256 principal) payable",
+    "function extendGenesisCredit(uint256 genesisId) payable",
+    "function repayGenesisCredit(uint256 genesisId)",
+    "function recoverGenesisCredit(uint256 genesisId)",
+    "function creditLimit(uint256 genesisId) view returns (uint256)",
+    "function credit(uint256 genesisId) view returns ((address owner, uint256 principal, uint40 maturity, uint40 recoverableAt, bool active) state)",
+    "function creditActive(uint256 genesisId) view returns (bool)",
+    "function creditRecoverableAt(uint256 genesisId) view returns (uint40)",
+    "function quoteGenesisCredit(uint256 principal) view returns ((uint256 totalNativeFee, uint16 reserveShareBps, uint16 treasuryShareBps, uint256 reservePortion, uint256 treasuryPortion) quote)",
+    "function quoteGenesisCreditExtension(uint256 genesisId) view returns ((uint256 totalNativeFee, uint16 reserveShareBps, uint16 treasuryShareBps, uint256 reservePortion, uint256 treasuryPortion) quote)",
+    "function quoteGenesisCreditRecovery(uint256 genesisId) view returns ((uint256 unusedCredit, uint256 recoveryResidual, uint256 callerIncentive, uint256 genesisDistribution, uint40 recoverableAt) quote)",
+    "function totalOutstandingGenesisCredit() view returns (uint256)",
+    "function creditOriginationFee() view returns (uint256)",
+    "function creditExtensionFee() view returns (uint256)",
+    "function recoveryCallerShareBps() view returns (uint16)",
+    "function creditServiceReserveShareBps() view returns (uint16)",
+    "function creditServiceTreasuryShareBps() view returns (uint16)",
+    "function creditOriginationsPaused() view returns (bool)",
+    "event GenesisCreditOpened(uint256 indexed genesisId, address indexed owner, uint256 principal, uint40 maturity, uint256 nativeFee)",
+    "event GenesisCreditExtended(uint256 indexed genesisId, address indexed owner, uint40 previousMaturity, uint40 newMaturity, uint256 nativeFee)",
+    "event GenesisCreditRepaid(uint256 indexed genesisId, address indexed payer, address indexed owner, uint256 principal)",
+    "event GenesisCreditRecovered(uint256 indexed genesisId, address indexed formerOwner, address indexed caller, uint256 principal, uint256 unusedCredit, uint256 callerIncentive, uint256 genesisDistribution)",
+]);
+export function buildOpenGenesisCreditTransaction(genesisId, principal, nativeFee) {
+    return {
+        data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "openGenesisCredit", args: [genesisId, principal] }),
+        value: nativeFee,
+    };
+}
+export function buildExtendGenesisCreditTransaction(genesisId, nativeFee) {
+    return {
+        data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "extendGenesisCredit", args: [genesisId] }),
+        value: nativeFee,
+    };
+}
+export function buildRepayGenesisCreditCall(genesisId) {
+    return encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "repayGenesisCredit", args: [genesisId] });
+}
+export function buildRecoverGenesisCreditCall(genesisId) {
+    return encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "recoverGenesisCredit", args: [genesisId] });
+}

--- a/vendor/statics-sdk/dist/genesis-credit.js
+++ b/vendor/statics-sdk/dist/genesis-credit.js
@@ -8,6 +8,7 @@ export const staticsGenesisCreditAbi = parseAbi([
     "function extendGenesisCredit(uint256 genesisId) payable",
     "function repayGenesisCredit(uint256 genesisId)",
     "function recoverGenesisCredit(uint256 genesisId)",
+    "function epochActive() view returns (bool)",
     "function creditLimit(uint256 genesisId) view returns (uint256)",
     "function credit(uint256 genesisId) view returns ((address owner, uint256 principal, uint40 maturity, uint40 recoverableAt, bool active) state)",
     "function creditActive(uint256 genesisId) view returns (bool)",
@@ -28,16 +29,10 @@ export const staticsGenesisCreditAbi = parseAbi([
     "event GenesisCreditRecovered(uint256 indexed genesisId, address indexed formerOwner, address indexed caller, uint256 principal, uint256 unusedCredit, uint256 callerIncentive, uint256 genesisDistribution)",
 ]);
 export function buildOpenGenesisCreditTransaction(genesisId, principal, nativeFee) {
-    return {
-        data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "openGenesisCredit", args: [genesisId, principal] }),
-        value: nativeFee,
-    };
+    return { data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "openGenesisCredit", args: [genesisId, principal] }), value: nativeFee };
 }
 export function buildExtendGenesisCreditTransaction(genesisId, nativeFee) {
-    return {
-        data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "extendGenesisCredit", args: [genesisId] }),
-        value: nativeFee,
-    };
+    return { data: encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "extendGenesisCredit", args: [genesisId] }), value: nativeFee };
 }
 export function buildRepayGenesisCreditCall(genesisId) {
     return encodeFunctionData({ abi: staticsGenesisCreditAbi, functionName: "repayGenesisCredit", args: [genesisId] });

--- a/vendor/statics-sdk/package.json
+++ b/vendor/statics-sdk/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./genesis-credit": {
+      "types": "./dist/genesis-credit.d.ts",
+      "import": "./dist/genesis-credit.js"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary  
Align the standalone Genesis launch application with the current Statics Genesis Vault and expose the complete user lifecycle required for launch.

## Changes  
- Fix Genesis acquisition to use the current reserve-backed purchase quote and send `requiredNative`
- Show STATICS backing, reserve buy-in, acquisition fee, and total ETH required separately
- Use the current redemption quote and surface both STATICS and native reserve payouts
- Add a compact Vault state panel with inventory, circulation, native reserve, reserve-per-Genesis, outstanding credit, and Epoch state
- Replace obsolete activation-burn language with the actual treasury activation payment semantics
- Add per-Genesis secured credit origination, extension, repayment, maturity, lock, and permissionless recovery controls
- Gate new credit during the Genesis Epoch and when originations are paused
- Add Genesis credit transaction activity kinds
- Vendor the secured-credit subpath from EqualFiLabs/statics-sdk#11
- Pin the current reserve-backed Vault read ABI locally while this stacked SDK/app series is landing

## Motivation  
App PR #27 predates the final reserve-backed Genesis Vault and secured-credit stack. Its acquisition flow decodes the old purchase tuple and can underpay native value against the current Vault. The launch UI also lacked post-Epoch Genesis secured credit and still described activation payments as token burns. This PR makes the standalone launch surface match the current protocol behavior without pulling future Basket, Dollar, Position, or protocol-liquidity workflows into Genesis launch scope.

## Testing  
- Added SDK-side focused secured-credit builder tests in EqualFiLabs/statics-sdk#11
- App CI should run lint, formatting, TypeScript, unit tests, production build, and Playwright against this branch
- Live deployment/fork validation remains dependent on a current Genesis deployment manifest

## Checklist  
- [x] Tests  
- [ ] Docs  
- [ ] Lint  
- [x] Ready for review  

Depends on EqualFiLabs/statics-sdk#11. Stacked on #27.