### PR TITLE
feat(genesis): rebuild My Genesis around the asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ against that manifest.
 - `/app/dollar?profile=USDG` — pegged Statics Dollar profile.
 - `/app/baskets` — basket discovery, creation, conversion, and protocol swaps.
 - `/app/positions` — PositionNFT custody and collateral management.
-- `/app/genesis` — inspect and activate Genesis NFTs owned by the connected wallet, register them for launch rewards, and claim accrued rewards.
+- `/app/genesis` — inspect and activate Genesis NFTs owned by the connected wallet, register them for launch rewards, claim accrued rewards, and borrow against a Genesis after the Epoch.
+- `/app/genesis/recoveries` — recover Genesis NFTs whose secured credit has matured, for the caller incentive.
 - `/app/create` — permissionlessly configure, fund, and launch an index basket.
 - `/app/rewards` — claim Position, Basket, creator, and permissionless partner-distribution rewards.
 - `/app/loans` — proportional self-backed lending.

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -1433,6 +1433,18 @@
   display: block;
 }
 
+.wallet-nft-art.is-lg,
+.wallet-nft-art-trigger.is-lg {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+}
+
+.wallet-nft-art-trigger.is-lg .wallet-nft-art {
+  width: 100%;
+  height: 100%;
+}
+
 .wallet-nft-art.is-placeholder {
   display: flex;
   align-items: center;
@@ -5794,35 +5806,35 @@
     width: 100%;
   }
 }
-.genesis-page,
+
+/* ---- Genesis ------------------------------------------------------- */
+
+.genesis-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .genesis-grid,
 .genesis-action {
   display: grid;
   gap: 1rem;
 }
 
+.genesis-grid {
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+/* The wallet before the NFT: how many, what they are worth, what is owed. */
 .genesis-summary {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto;
+  gap: 1.5rem;
+  align-items: center;
 }
 
-.genesis-card-heading {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.genesis-card {
-  display: grid;
-  gap: 1rem;
-}
-
-.genesis-card-heading > div {
-  display: grid;
-  gap: 0.65rem;
-  align-content: start;
+.genesis-summary .ui-stat {
+  gap: 0.25rem;
+  min-width: 0;
 }
 
 .genesis-summary .ui-stat__value {
@@ -5830,10 +5842,811 @@
   overflow-wrap: anywhere;
 }
 
-.genesis-action > p {
-  margin: 0;
+.genesis-summary .ui-stat__value.is-accent {
+  color: var(--accent);
+}
+
+.genesis-summary .ui-stat__value.is-warning {
+  color: var(--warning);
+}
+
+.genesis-summary .ui-stat small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-recoveries-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  justify-self: start;
+  min-height: var(--control-height-sm);
+  padding: 0 0.875rem;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--app-surface);
   color: var(--app-text-secondary);
   font-size: var(--text-sm);
+}
+
+.genesis-recoveries-link:hover {
+  background: var(--app-raised);
+  color: var(--app-text);
+}
+
+/* ---- Owned carousel ------------------------------------------------- */
+
+.genesis-carousel {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.genesis-carousel-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.genesis-carousel-count {
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-carousel-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.genesis-carousel-pager {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.genesis-carousel-pager button {
+  display: grid;
+  place-items: center;
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  padding: 0;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--app-surface);
+  color: var(--app-text-secondary);
+  cursor: pointer;
+}
+
+.genesis-carousel-pager button:hover:not(:disabled) {
+  background: var(--app-raised);
+  color: var(--app-text);
+}
+
+.genesis-carousel-pager button:disabled {
+  cursor: default;
+  opacity: 0.3;
+}
+
+.genesis-carousel-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.genesis-carousel-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: var(--control-height-sm);
+  padding: 0 0.7rem;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--app-surface);
+  color: var(--app-text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.genesis-carousel-filter:hover {
+  background: var(--app-raised);
+  color: var(--app-text);
+}
+
+.genesis-carousel-filter[aria-pressed="true"] {
+  border-color: var(--accent);
+  background: var(--accent-wash);
+  color: var(--accent);
+}
+
+/* Six across at full width, and never a second row. The card width derives
+ * from the count so a card cannot land half-cut at the right edge. */
+.genesis-carousel-rail {
+  --genesis-cards: 6;
+
+  position: relative;
+  display: flex;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+}
+
+.genesis-carousel-rail::-webkit-scrollbar {
+  height: 6px;
+}
+
+.genesis-carousel-rail::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-pill);
+  background: var(--app-border-strong);
+}
+
+.genesis-carousel-rail.is-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  max-height: 26rem;
+  overflow-x: visible;
+  overflow-y: auto;
+}
+
+.genesis-carousel-card {
+  flex: 0 0 calc((100% - (var(--genesis-cards) - 1) * 0.75rem) / var(--genesis-cards));
+  min-width: 8rem;
+  padding: 0.625rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+  background: var(--app-surface);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  scroll-snap-align: start;
+  cursor: pointer;
+}
+
+.genesis-carousel-rail.is-grid .genesis-carousel-card {
+  flex: none;
+  min-width: 0;
+}
+
+.genesis-carousel-card:hover {
+  background: var(--app-raised);
+}
+
+.genesis-carousel-card[aria-selected="true"] {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.genesis-carousel-id {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.genesis-carousel-id b {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-carousel-flags {
+  display: flex;
+  gap: 0.3rem;
+  min-height: 7px;
+  margin-top: 0.4rem;
+}
+
+.genesis-flag {
+  display: block;
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--app-border-strong);
+}
+
+.genesis-flag.is-unregistered {
+  background: var(--warning);
+}
+
+.genesis-flag.is-pending {
+  background: var(--accent);
+}
+
+.genesis-flag.is-credit {
+  background: var(--negative);
+}
+
+.genesis-carousel-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-carousel-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* ---- Detail: identity beside actions --------------------------------- */
+
+.genesis-detail {
+  display: grid;
+  grid-template-columns: minmax(0, 22rem) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.genesis-identity {
+  position: sticky;
+  top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.genesis-identity-art .wallet-nft-art,
+.genesis-identity-art .wallet-nft-art-trigger {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+}
+
+.genesis-identity-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.genesis-identity-sub {
+  margin: 0.15rem 0 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+}
+
+.genesis-tier-badge {
+  display: grid;
+  place-items: center;
+  width: 3.4rem;
+  height: 3.4rem;
+  flex: none;
+  margin-left: auto;
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  background: var(--app-raised);
+  line-height: var(--leading-tight);
+  text-align: center;
+}
+
+.genesis-tier-badge b {
+  color: var(--accent);
+  font-size: var(--text-base);
+  font-weight: 650;
+}
+
+.genesis-tier-badge span {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-tier-badge[data-tier="0"] {
+  border-color: var(--app-border-strong);
+}
+
+.genesis-tier-badge[data-tier="0"] b {
+  color: var(--app-text-muted);
+}
+
+.genesis-identity-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.genesis-identity-backing,
+.genesis-identity-traits dl {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.genesis-identity-backing > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: var(--text-sm);
+}
+
+.genesis-identity-backing dt {
+  color: var(--app-text-muted);
+}
+
+.genesis-identity-backing dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-identity-traits {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.genesis-identity-traits dl {
+  grid-template-columns: 1fr 1fr;
+  gap: 0.375rem;
+  padding: 0;
+  background: transparent;
+}
+
+.genesis-identity-traits dl > div {
+  padding: 0.45rem 0.55rem;
+  border-radius: var(--radius-sm);
+  background: var(--app-sunken);
+}
+
+.genesis-identity-traits dt {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-identity-traits dd {
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+/* ---- Action panels ---------------------------------------------------- */
+
+.genesis-actions {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  align-content: start;
+}
+
+.genesis-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+  background: var(--app-surface);
+}
+
+.genesis-tabs button {
+  display: grid;
+  gap: 0.1rem;
+  min-height: var(--control-height);
+  padding: 0.5rem 0.75rem;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.genesis-tabs button:hover {
+  background: var(--app-raised);
+}
+
+.genesis-tabs button[aria-selected="true"] {
+  background: var(--app-raised);
+  box-shadow: inset 0 0 0 1px var(--app-border-strong);
+}
+
+.genesis-tabs button b {
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.genesis-tabs button[aria-selected="true"] b {
+  color: var(--app-text);
+}
+
+.genesis-tabs button small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-tabs button[data-alert="true"] b::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 0.4rem;
+  border-radius: 50%;
+  background: var(--accent);
+  vertical-align: middle;
+}
+
+.genesis-panel {
+  display: grid;
+  gap: 1.125rem;
+}
+
+.genesis-panel-head {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.genesis-panel-head h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 620;
+}
+
+.genesis-panel-head p {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+/* ---- Tier ladder ------------------------------------------------------ */
+
+.genesis-ladder {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.genesis-ladder-rung {
+  display: grid;
+  grid-template-columns: 4rem 1fr auto auto;
+  gap: 1rem;
+  align-items: center;
+  width: 100%;
+  min-height: var(--control-height);
+  padding: 0.7rem 0.875rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.genesis-ladder-rung:hover:not(:disabled) {
+  background: var(--app-raised);
+}
+
+.genesis-ladder-rung:disabled {
+  cursor: default;
+}
+
+.genesis-ladder-rung[data-state="reached"] {
+  opacity: 0.5;
+}
+
+.genesis-ladder-rung[data-state="current"] {
+  border-color: var(--app-border-strong);
+  background: var(--app-raised);
+}
+
+.genesis-ladder-rung[data-state="target"] {
+  border-color: var(--accent);
+  background: var(--accent-wash);
+}
+
+.genesis-ladder-tier {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.genesis-ladder-multiplier {
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-ladder-rung[data-state="target"] .genesis-ladder-multiplier {
+  color: var(--app-text);
+}
+
+.genesis-ladder-cost {
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.genesis-ladder-mark {
+  min-width: 6rem;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  text-align: right;
+}
+
+.genesis-ladder-rung[data-state="current"] .genesis-ladder-mark {
+  color: var(--app-text);
+}
+
+.genesis-ladder-rung[data-state="target"] .genesis-ladder-mark {
+  color: var(--accent);
+}
+
+/* ---- Figures, notes, claims -------------------------------------------- */
+
+.genesis-figures {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.genesis-figures > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--app-sunken);
+  font-size: var(--text-sm);
+}
+
+.genesis-figures dt {
+  color: var(--app-text-secondary);
+}
+
+.genesis-figures dd {
+  margin: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-figures > div.is-total {
+  background: var(--app-raised);
+}
+
+.genesis-figures > div.is-total dd {
+  color: var(--accent);
+  font-size: var(--text-base);
+}
+
+.genesis-note {
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+.genesis-note b {
+  color: var(--app-text);
+}
+
+.genesis-note.is-warning {
+  background: var(--warning-wash);
+  color: var(--warning);
+}
+
+.genesis-note.is-warning b,
+.genesis-note.is-error b {
+  color: inherit;
+}
+
+.genesis-note.is-error {
+  background: var(--negative-wash);
+  color: var(--negative);
+}
+
+.genesis-claims {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.genesis-claims li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.genesis-claims li > div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.genesis-claims span {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-claims strong {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-claims strong.is-muted {
+  color: var(--app-text-muted);
+}
+
+.genesis-maintenance {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.genesis-maintenance span {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+/* ---- Credit ------------------------------------------------------------ */
+
+.genesis-borrow {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.genesis-borrow-amount {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-borrow-amount b {
+  font-size: var(--text-3xl);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.genesis-borrow-amount span {
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
+}
+
+.genesis-borrow-scale {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The term, the grace hour, and the open recovery window that follows --
+ * the whole risk of borrowing here, which a pair of timestamps cannot say. */
+.genesis-timeline {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.genesis-timeline-track {
+  position: relative;
+  height: 2.125rem;
+  border-radius: var(--radius-sm);
+  background: var(--app-sunken);
+  overflow: hidden;
+}
+
+.genesis-timeline-segment {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: grid;
+  place-items: center;
+  font-size: var(--text-caption);
+  white-space: nowrap;
+}
+
+.genesis-timeline-segment.is-safe {
+  background: var(--accent-wash);
+  color: var(--accent);
+}
+
+.genesis-timeline-segment.is-grace {
+  background: var(--warning-wash);
+  color: var(--warning);
+}
+
+.genesis-timeline-segment.is-danger {
+  background: var(--negative-wash);
+  color: var(--negative);
+}
+
+.genesis-timeline-now {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--app-text);
+}
+
+.genesis-timeline-marks {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.genesis-locked {
+  display: grid;
+  gap: 0.75rem;
+  place-items: center;
+  padding: 2rem 1.25rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+  text-align: center;
+}
+
+.genesis-locked strong {
+  font-size: var(--text-2xl);
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-locked p {
+  margin: 0;
+  max-width: 44ch;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.genesis-recovery-figures {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.genesis-recovery-figures > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: var(--text-sm);
+}
+
+.genesis-recovery-figures dt {
+  color: var(--app-text-muted);
+}
+
+.genesis-recovery-figures dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.genesis-recovery-figures dd.is-accent {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.genesis-card,
+.genesis-card-heading {
+  display: grid;
+  gap: 1rem;
 }
 
 .genesis-warning {
@@ -5842,12 +6655,78 @@
   font-size: var(--text-sm);
 }
 
-.genesis-grid {
-  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-}
-
 .genesis-contracts {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+}
+
+/* ---- Genesis responsive ------------------------------------------------- */
+
+@media (max-width: 1180px) {
+  .genesis-carousel-rail {
+    --genesis-cards: 5;
+  }
+}
+
+@media (max-width: 1024px) {
+  .genesis-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .genesis-identity {
+    position: static;
+  }
+
+  .genesis-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .genesis-summary > .ui-button {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 900px) {
+  .genesis-carousel-rail {
+    --genesis-cards: 4;
+  }
+}
+
+@media (max-width: 700px) {
+  .genesis-carousel-rail {
+    --genesis-cards: 3;
+  }
+
+  .genesis-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .genesis-ladder-rung {
+    grid-template-columns: 3.5rem 1fr auto;
+  }
+
+  .genesis-ladder-mark {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .genesis-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .genesis-carousel-rail {
+    --genesis-cards: 2;
+  }
+
+  .genesis-identity-traits dl {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .genesis-carousel-rail {
+    scroll-behavior: auto;
+  }
 }

--- a/app/(dapp)/app/genesis/recoveries/page.tsx
+++ b/app/(dapp)/app/genesis/recoveries/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { GenesisRecoveriesPage } from "@/components/genesis/GenesisRecoveriesPage";
+
+export const metadata: Metadata = {
+  title: "Genesis recoveries | Statics",
+  description:
+    "Discover Genesis NFTs whose secured credit has matured and recover them permissionlessly for the caller incentive.",
+};
+
+export default function GenesisRecoveriesRoute() {
+  return <GenesisRecoveriesPage />;
+}

--- a/components/app-shell/AppShell.tsx
+++ b/components/app-shell/AppShell.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { AccountDialog } from "@/components/app-shell/AccountDialog";
 import { LocaleSwitcher } from "@/components/common/LocaleSwitcher";
-import { getDappRouteId, isDappOverviewPath } from "@/lib/dapp-navigation";
+import { getDappRouteId } from "@/lib/dapp-navigation";
 import { appNavigationGroupsForStage, appTabNavigationForStage } from "@/lib/site-config";
 import { useDeployment } from "@/providers/deployment-context";
 import { useWalletState } from "@/providers/wallet-context";
@@ -249,12 +249,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const tLaunchRoutes = useTranslations("launchRoutes");
   const routeCopy = {
     label: useLaunchRouteCopy ? tLaunchRoutes(`${routeId}.label`) : tRoutes(`${routeId}.label`),
+    status: useLaunchRouteCopy ? tLaunchRoutes(`${routeId}.status`) : tRoutes(`${routeId}.status`),
     title: useLaunchRouteCopy ? tLaunchRoutes(`${routeId}.title`) : tRoutes(`${routeId}.title`),
     description: useLaunchRouteCopy
       ? tLaunchRoutes(`${routeId}.description`)
       : tRoutes(`${routeId}.description`),
   };
-  const showOverviewSummary = isDappOverviewPath(currentPath);
   const showApprovalDisclosure = approvalDisclosureRoutes.some(
     (route) => currentPath === route || currentPath.startsWith(`${route}/`)
   );
@@ -381,13 +381,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <main id="dapp-content" className="dapp-content">
           <WrongNetworkBar />
 
-          {showOverviewSummary && (
-            <section className="dapp-intro">
-              <p className="dapp-eyebrow">{tShell("application")}</p>
-              <h1>{routeCopy.title}</h1>
-              <p>{routeCopy.description}</p>
-            </section>
-          )}
+          {/* Every route names itself. This used to be gated to /app, which left
+              every other destination -- Genesis included -- with no <h1> at all
+              and no statement of what the page is for. */}
+          <section className="dapp-intro">
+            <p className="dapp-eyebrow">{routeCopy.status}</p>
+            <h1>{routeCopy.title}</h1>
+            <p>{routeCopy.description}</p>
+          </section>
 
           {wallet.error && (
             <p className="dapp-inline-error" role="alert">

--- a/components/genesis/GenesisCarousel.tsx
+++ b/components/genesis/GenesisCarousel.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { NftArtwork } from "@/components/wallet/NftArtwork";
+
+export type GenesisCarouselItem = Readonly<{
+  id: bigint;
+  tier: number;
+  registered: boolean;
+  hasPendingRewards: boolean;
+  creditActive: boolean;
+}>;
+
+type Filter = "all" | "unregistered" | "pending" | "credit";
+
+const FILTERS: readonly Readonly<{ key: Filter; label: string; flag: string | null }>[] = [
+  { key: "all", label: "All", flag: null },
+  { key: "unregistered", label: "Not registered", flag: "unregistered" },
+  { key: "pending", label: "Rewards pending", flag: "pending" },
+  { key: "credit", label: "Credit active", flag: "credit" },
+];
+
+function matches(item: GenesisCarouselItem, filter: Filter): boolean {
+  if (filter === "unregistered") return !item.registered;
+  if (filter === "pending") return item.hasPendingRewards;
+  if (filter === "credit") return item.creditActive;
+  return true;
+}
+
+/**
+ * The wallet's Genesis NFTs, as a paged rail rather than a wrapping chip row.
+ *
+ * A wrapping row is fine at three NFTs and unusable at thirty: it grows a new
+ * line for every few tokens, pushes the NFT you are managing below the fold,
+ * and reflows whenever a badge appears or clears. This rail is fixed at one
+ * line and pages horizontally instead.
+ *
+ * Past `GRID_THRESHOLD` the rail stops being the right tool -- paging six at a
+ * time through sixty is worse than the wrap it replaced -- so a grid view with
+ * status filters takes over.
+ */
+const GRID_THRESHOLD = 12;
+
+export function GenesisCarousel({
+  items,
+  selectedId,
+  onSelect,
+  chainId,
+  collection,
+}: Readonly<{
+  items: readonly GenesisCarouselItem[];
+  selectedId: bigint | null;
+  onSelect: (id: bigint) => void;
+  chainId: number;
+  collection: `0x${string}`;
+}>) {
+  const railRef = useRef<HTMLDivElement>(null);
+  const [view, setView] = useState<"carousel" | "grid">("carousel");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [overflow, setOverflow] = useState({ start: false, end: false });
+
+  const visible = view === "grid" ? items.filter((item) => matches(item, filter)) : items;
+
+  const syncOverflow = useCallback(() => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const scrollable = rail.scrollWidth > rail.clientWidth + 1;
+    setOverflow({
+      start: scrollable && rail.scrollLeft > 1,
+      end: scrollable && rail.scrollLeft + rail.clientWidth < rail.scrollWidth - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    syncOverflow();
+    const rail = railRef.current;
+    if (!rail) return;
+    const observer = new ResizeObserver(syncOverflow);
+    observer.observe(rail);
+    return () => observer.disconnect();
+  }, [syncOverflow, visible.length, view]);
+
+  // Selecting through the keyboard, or from anywhere else on the page, has to
+  // bring the card back into view or the selection becomes invisible.
+  useEffect(() => {
+    if (view === "grid") return;
+    const rail = railRef.current;
+    const card = rail?.querySelector<HTMLElement>('[aria-selected="true"]');
+    if (!rail || !card) return;
+    const cardBox = card.getBoundingClientRect();
+    const railBox = rail.getBoundingClientRect();
+    if (cardBox.left < railBox.left) {
+      rail.scrollLeft -= railBox.left - cardBox.left + 12;
+    } else if (cardBox.right > railBox.right) {
+      rail.scrollLeft += cardBox.right - railBox.right + 12;
+    }
+  }, [selectedId, view]);
+
+  const page = (direction: 1 | -1) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const card = rail.querySelector<HTMLElement>(".genesis-carousel-card");
+    const step = card ? card.getBoundingClientRect().width + 12 : rail.clientWidth * 0.8;
+    // Advance by a whole page less one card, so the card at the edge stays
+    // visible as an anchor rather than jumping out of sight.
+    const perPage = Math.max(1, Math.floor(rail.clientWidth / step) - 1);
+    rail.scrollLeft += direction * step * perPage;
+  };
+
+  const move = (from: bigint, delta: 1 | -1) => {
+    const order = visible;
+    const index = order.findIndex((item) => item.id === from);
+    const next = order[index + delta];
+    if (next) onSelect(next.id);
+  };
+
+  const showGridToggle = items.length > GRID_THRESHOLD;
+  const selected = items.find((item) => item.id === selectedId) ?? null;
+
+  return (
+    <section className="genesis-carousel" aria-label="Your Genesis NFTs">
+      <div className="genesis-carousel-head">
+        <h2 className="ui-section-title">Your Genesis</h2>
+        <span className="genesis-carousel-count">
+          {items.length} held{selected ? ` · #${selected.id} selected` : ""}
+        </span>
+        <div className="genesis-carousel-controls">
+          {showGridToggle && (
+            <button
+              className="ui-button ui-button--ghost ui-button--sm"
+              type="button"
+              onClick={() => {
+                setView(view === "carousel" ? "grid" : "carousel");
+                setFilter("all");
+              }}
+            >
+              {view === "carousel" ? "View all" : "Back to carousel"}
+            </button>
+          )}
+          {view === "carousel" && (overflow.start || overflow.end) && (
+            <div className="genesis-carousel-pager">
+              <button
+                type="button"
+                onClick={() => page(-1)}
+                disabled={!overflow.start}
+                aria-label="Previous Genesis NFTs"
+              >
+                <span aria-hidden="true">‹</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => page(1)}
+                disabled={!overflow.end}
+                aria-label="More Genesis NFTs"
+              >
+                <span aria-hidden="true">›</span>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {view === "grid" && (
+        <div className="genesis-carousel-filters">
+          {FILTERS.map((entry) => {
+            const count =
+              entry.key === "all"
+                ? items.length
+                : items.filter((item) => matches(item, entry.key)).length;
+            return (
+              <button
+                key={entry.key}
+                className="genesis-carousel-filter"
+                type="button"
+                aria-pressed={filter === entry.key}
+                onClick={() => setFilter(entry.key)}
+              >
+                {entry.flag && <i className={`genesis-flag is-${entry.flag}`} aria-hidden="true" />}
+                {entry.label} {count}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div
+        className={`genesis-carousel-rail${view === "grid" ? " is-grid" : ""}`}
+        data-overflow-end={overflow.end && view === "carousel" ? "true" : undefined}
+        ref={railRef}
+        onScroll={syncOverflow}
+        role="tablist"
+        aria-label="Select a Genesis NFT"
+      >
+        {visible.map((item) => {
+          const isSelected = item.id === selectedId;
+          return (
+            <button
+              key={item.id.toString()}
+              className="genesis-carousel-card"
+              type="button"
+              role="tab"
+              aria-selected={isSelected}
+              tabIndex={isSelected ? 0 : -1}
+              onClick={() => onSelect(item.id)}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowRight") {
+                  event.preventDefault();
+                  move(item.id, 1);
+                } else if (event.key === "ArrowLeft") {
+                  event.preventDefault();
+                  move(item.id, -1);
+                } else if (event.key === "Home" && visible[0]) {
+                  event.preventDefault();
+                  onSelect(visible[0].id);
+                } else if (event.key === "End" && visible.length) {
+                  event.preventDefault();
+                  onSelect(visible[visible.length - 1].id);
+                }
+              }}
+            >
+              <NftArtwork
+                chainId={chainId}
+                size="lg"
+                nft={{
+                  kind: "collection",
+                  tokenId: item.id,
+                  contract: collection,
+                  name: `Genesis #${item.id}`,
+                  summary: `Tier ${item.tier}`,
+                  carries: [],
+                  blockedReason: null,
+                }}
+              />
+              <span className="genesis-carousel-id">
+                Genesis #{item.id.toString()}
+                <b>T{item.tier}</b>
+              </span>
+              <span className="genesis-carousel-flags">
+                {!item.registered && (
+                  <i className="genesis-flag is-unregistered" title="Not registered" />
+                )}
+                {item.hasPendingRewards && (
+                  <i className="genesis-flag is-pending" title="Rewards pending" />
+                )}
+                {item.creditActive && (
+                  <i className="genesis-flag is-credit" title="Credit active" />
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {view === "carousel" && (
+        <p className="genesis-carousel-legend">
+          <span>
+            <i className="genesis-flag is-unregistered" aria-hidden="true" /> Not registered
+          </span>
+          <span>
+            <i className="genesis-flag is-pending" aria-hidden="true" /> Rewards pending
+          </span>
+          <span>
+            <i className="genesis-flag is-credit" aria-hidden="true" /> Credit active — transfer
+            locked
+          </span>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -17,8 +17,14 @@ import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import type { LaunchDeployment } from "@/lib/deployments/types";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
 import { useWalletState } from "@/providers/wallet-context";
+
+/** StaticsGenesisVault.RECOVERY_GRACE. */
+const RECOVERY_GRACE_SECONDS = 3_600;
+/** StaticsGenesisVault.CREDIT_TERM. */
+const CREDIT_TERM_SECONDS = 30 * 24 * 60 * 60;
 
 function describeCreditError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -38,6 +44,17 @@ function formatTimestamp(timestamp: number): string {
   return new Date(timestamp * 1000).toLocaleString();
 }
 
+/** "6d 04h", or "1h 12m" once it is close enough that days stop being useful. */
+function formatCountdown(seconds: number): string {
+  if (seconds <= 0) return "now";
+  const days = Math.floor(seconds / 86_400);
+  const hours = Math.floor((seconds % 86_400) / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+  if (days > 0) return `${days}d ${String(hours).padStart(2, "0")}h`;
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+  return `${minutes}m`;
+}
+
 type GenesisCreditState = {
   owner: `0x${string}`;
   principal: bigint;
@@ -52,6 +69,79 @@ type GenesisCreditQuote = {
   reservePortion: bigint;
   treasuryPortion: bigint;
 };
+
+/**
+ * What happens to this NFT if the credit is not repaid, drawn to scale.
+ *
+ * The term, the grace hour, and the open-ended recoverable window after it are
+ * the whole risk of borrowing here, and a pair of locale timestamps does not
+ * convey them. `now` moves along the track once a credit is live.
+ */
+function RecoveryTimeline({
+  openedAt,
+  maturity,
+  recoverableAt,
+  now,
+}: Readonly<{
+  openedAt: number;
+  maturity: number;
+  recoverableAt: number;
+  now: number | null;
+}>) {
+  // A tail past the recovery point keeps the danger band visible rather than
+  // collapsing it to a hairline at the right edge.
+  const tail = Math.round(CREDIT_TERM_SECONDS * 0.18);
+  const span = Math.max(1, recoverableAt + tail - openedAt);
+  const pct = (from: number, to: number) => ((to - from) / span) * 100;
+  const nowPct =
+    now === null ? null : Math.min(99.6, Math.max(0, pct(openedAt, Math.max(now, openedAt))));
+
+  return (
+    <div className="genesis-timeline">
+      <p className="dapp-eyebrow">
+        {now === null ? "Before you borrow, know the shape of it" : "If this is not repaid"}
+      </p>
+      <div className="genesis-timeline-track">
+        <span
+          className="genesis-timeline-segment is-safe"
+          style={{ left: 0, width: `${pct(openedAt, maturity)}%` }}
+        >
+          30-day term
+        </span>
+        <span
+          className="genesis-timeline-segment is-grace"
+          style={{
+            left: `${pct(openedAt, maturity)}%`,
+            width: `${pct(maturity, recoverableAt)}%`,
+          }}
+        >
+          1h grace
+        </span>
+        <span
+          className="genesis-timeline-segment is-danger"
+          style={{
+            left: `${pct(openedAt, recoverableAt)}%`,
+            width: `${100 - pct(openedAt, recoverableAt)}%`,
+          }}
+        >
+          Recoverable
+        </span>
+        {nowPct !== null && (
+          <span
+            className="genesis-timeline-now"
+            style={{ left: `${nowPct}%` }}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+      <div className="genesis-timeline-marks">
+        <span>{now === null ? "Today" : "Opened"}</span>
+        <span>Matures {new Date(maturity * 1_000).toLocaleDateString()}</span>
+        <span>Anyone can recover</span>
+      </div>
+    </div>
+  );
+}
 
 export function GenesisCreditPanel({
   deployment,
@@ -114,6 +204,7 @@ export function GenesisCreditPanel({
       return {
         epochActive: vault.epochActive,
         genesisEpochEnd: Number(vault.genesisEpochEnd),
+        vaultPrice: vault.vaultPrice,
         originationsPaused,
         credit,
         limit,
@@ -176,166 +267,312 @@ export function GenesisCreditPanel({
     }
   };
 
-  if (!wallet || state.isLoading) return null;
+  if (!wallet || state.isLoading) {
+    return <p className="dapp-loading">Loading secured credit…</p>;
+  }
   if (state.error || !state.data) {
     return <p className="dapp-inline-error">{describeCreditError(state.error)}</p>;
   }
 
   const credit = state.data.credit;
+  const maxPrincipal = state.data.limit > 0n ? state.data.limit : GENESIS_MAX_CREDIT_PRINCIPAL;
+  const backing = state.data.vaultPrice;
 
-  if (!credit.active) {
+  if (credit.active) {
+    const openedAt = credit.maturity - CREDIT_TERM_SECONDS;
+    const untilMaturity = credit.maturity - now;
+    const untilRecoverable = credit.recoverableAt - now;
+    const overdue = untilMaturity <= 0;
+
     return (
-      <section className="genesis-action" aria-label={`Genesis #${genesisId} secured credit`}>
-        <h3>Secured credit</h3>
-        {state.data.epochActive ? (
+      <section
+        className="ui-card genesis-panel"
+        aria-label={`Genesis #${genesisId} secured credit`}
+      >
+        <div className="genesis-panel-head">
+          <h3>Secured credit — active</h3>
           <p>
-            Genesis credit opens after the Epoch ends at{" "}
-            {formatTimestamp(state.data.genesisEpochEnd)}. The maximum principal is{" "}
-            {formatEther(GENESIS_MAX_CREDIT_PRINCIPAL)} STATICS.
+            You borrowed against this NFT&apos;s backing. It cannot be transferred until the credit
+            is repaid.
           </p>
-        ) : state.data.originationsPaused ? (
-          <p>New Genesis credit is temporarily paused.</p>
-        ) : (
-          <>
-            <p>
-              Borrow up to {formatEther(state.data.limit || GENESIS_MAX_CREDIT_PRINCIPAL)} STATICS
-              against this Genesis.
-            </p>
-            <label className="ui-field">
-              Borrow STATICS
-              <input
-                inputMode="decimal"
-                value={amount}
-                placeholder="0"
-                onChange={(event) => setAmount(event.target.value)}
-                disabled={busy !== null}
-              />
-            </label>
-            <button
-              className="ui-button ui-button--primary ui-button--block"
-              type="button"
-              disabled={busy !== null || !amount}
-              onClick={() =>
-                void act("open", async () => {
-                  if (!publicClient) return;
-                  const principal = parseEther(amount);
-                  if (principal <= 0n || principal > state.data.limit) {
-                    throw new Error("Choose an amount within this Genesis credit limit.");
-                  }
-                  const quote = (await publicClient.readContract({
-                    address: deployment.contracts.vault,
-                    abi: staticsGenesisCreditAbi,
-                    functionName: "quoteGenesisCredit",
-                    args: [principal],
-                  })) as GenesisCreditQuote;
-                  const transaction = buildOpenGenesisCreditTransaction(
-                    genesisId,
-                    principal,
-                    quote.totalNativeFee
-                  );
-                  await send(
-                    "open-genesis-credit",
-                    `Borrow against Genesis #${genesisId}`,
-                    transaction.data,
-                    `${formatEther(principal)} STATICS + ${formatEther(quote.totalNativeFee)} ETH fee`,
-                    transaction.value
-                  );
-                  setAmount("");
-                })
-              }
-            >
-              {busy === "open" ? "Borrowing…" : "Borrow STATICS"}
-            </button>
-          </>
-        )}
+        </div>
 
-        {error && <p className="dapp-inline-error">{error}</p>}
+        <dl className="genesis-figures">
+          <div>
+            <dt>Principal owed</dt>
+            <dd>{formatTokenAmountGrouped(credit.principal, 18, 0)} STATICS</dd>
+          </div>
+          <div>
+            <dt>Against backing of</dt>
+            <dd>
+              {formatTokenAmountGrouped(backing, 18, 0)} STATICS
+              {backing > 0n ? ` · ${Number((credit.principal * 100n) / backing)}% LTV` : ""}
+            </dd>
+          </div>
+          <div className="is-total">
+            <dt>{overdue ? "Recoverable in" : "Repay within"}</dt>
+            <dd>{formatCountdown(overdue ? untilRecoverable : untilMaturity)}</dd>
+          </div>
+        </dl>
+
+        <RecoveryTimeline
+          openedAt={openedAt}
+          maturity={credit.maturity}
+          recoverableAt={credit.recoverableAt}
+          now={now}
+        />
+
+        <p className={`genesis-note ${overdue ? "is-error" : "is-warning"}`}>
+          <b>After the grace hour, anyone can recover this Genesis.</b> They take the caller
+          incentive, the NFT leaves your wallet, and you keep the residual value rather than the
+          full backing.
+        </p>
+
+        <dl className="genesis-figures">
+          <div>
+            <dt>Matures</dt>
+            <dd>{formatTimestamp(credit.maturity)}</dd>
+          </div>
+          <div>
+            <dt>Recoverable from</dt>
+            <dd>{formatTimestamp(credit.recoverableAt)}</dd>
+          </div>
+        </dl>
+
+        <div className="ui-inline-actions">
+          <button
+            className="ui-button ui-button--secondary"
+            type="button"
+            disabled={busy !== null || overdue}
+            onClick={() =>
+              void act("extend", async () => {
+                if (!publicClient) return;
+                const quote = (await publicClient.readContract({
+                  address: deployment.contracts.vault,
+                  abi: staticsGenesisCreditAbi,
+                  functionName: "quoteGenesisCreditExtension",
+                  args: [genesisId],
+                })) as GenesisCreditQuote;
+                const transaction = buildExtendGenesisCreditTransaction(
+                  genesisId,
+                  quote.totalNativeFee
+                );
+                await send(
+                  "extend-genesis-credit",
+                  `Extend Genesis #${genesisId} credit`,
+                  transaction.data,
+                  `${formatEther(quote.totalNativeFee)} ETH fee`,
+                  transaction.value
+                );
+              })
+            }
+          >
+            {busy === "extend" ? "Extending…" : "Extend the term"}
+          </button>
+          <button
+            className="ui-button ui-button--primary"
+            type="button"
+            disabled={busy !== null}
+            onClick={() =>
+              void act("repay", async () => {
+                if (!publicClient || !wallet) return;
+                const allowance = await publicClient.readContract({
+                  address: deployment.contracts.statics,
+                  abi: dopplerStaticsTokenAbi,
+                  functionName: "allowance",
+                  args: [wallet, deployment.contracts.vault],
+                });
+                if (allowance < credit.principal) {
+                  await executeProtocolTransaction({
+                    publicClient,
+                    wallet,
+                    chainId: deployment.descriptor.chainId,
+                    deploymentId: deployment.descriptor.deploymentId,
+                    kind: "approve-staking-token",
+                    label: "Enable Genesis credit repayment",
+                    amount: "Maximum STATICS",
+                    to: deployment.contracts.statics,
+                    data: encodeFunctionData({
+                      abi: dopplerStaticsTokenAbi,
+                      functionName: "approve",
+                      args: [deployment.contracts.vault, MAX_ERC20_ALLOWANCE],
+                    }),
+                    sendTransaction: walletState.sendEvmTransaction,
+                    describeError: describeCreditError,
+                  });
+                }
+                await send(
+                  "repay-genesis-credit",
+                  `Repay Genesis #${genesisId} credit`,
+                  buildRepayGenesisCreditCall(genesisId),
+                  `${formatEther(credit.principal)} STATICS`
+                );
+              })
+            }
+          >
+            {busy === "repay"
+              ? "Repaying…"
+              : `Repay ${formatTokenAmountGrouped(credit.principal, 18, 0)} STATICS`}
+          </button>
+        </div>
+
+        {error && (
+          <p className="dapp-inline-error" role="alert">
+            {error}
+          </p>
+        )}
       </section>
     );
   }
 
+  if (state.data.epochActive) {
+    return (
+      <section
+        className="ui-card genesis-panel"
+        aria-label={`Genesis #${genesisId} secured credit`}
+      >
+        <div className="genesis-panel-head">
+          <h3>Secured credit</h3>
+          <p>Borrowing against a Genesis NFT opens once the Genesis Epoch ends.</p>
+        </div>
+        <div className="genesis-locked">
+          <strong>{formatCountdown(state.data.genesisEpochEnd - now)}</strong>
+          <p>
+            The Epoch ends {formatTimestamp(state.data.genesisEpochEnd)}. You will then be able to
+            borrow up to {formatTokenAmountGrouped(GENESIS_MAX_CREDIT_PRINCIPAL, 18, 0)} STATICS
+            against this NFT.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (state.data.originationsPaused) {
+    return (
+      <section
+        className="ui-card genesis-panel"
+        aria-label={`Genesis #${genesisId} secured credit`}
+      >
+        <div className="genesis-panel-head">
+          <h3>Secured credit</h3>
+          <p>New Genesis credit is temporarily paused. Existing credit is unaffected.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const parsed = (() => {
+    if (!amount.trim()) return 0n;
+    try {
+      return parseEther(amount);
+    } catch {
+      return 0n;
+    }
+  })();
+  const clamped = parsed > maxPrincipal ? maxPrincipal : parsed;
+  const ltv = backing > 0n ? Number((clamped * 10_000n) / backing) / 100 : 0;
+  const maxLtv = backing > 0n ? Number((maxPrincipal * 10_000n) / backing) / 100 : 0;
+
   return (
-    <section className="genesis-action" aria-label={`Genesis #${genesisId} secured credit`}>
-      <h3>Secured credit</h3>
-      <p>Borrowed: {formatEther(credit.principal)} STATICS</p>
-      <p>Maturity: {formatTimestamp(credit.maturity)}</p>
-      <p>Recovery available: {formatTimestamp(credit.recoverableAt)}</p>
-      <div className="ui-inline-actions">
-        <button
-          className="ui-button ui-button--secondary"
-          type="button"
-          disabled={busy !== null || now > credit.maturity}
-          onClick={() =>
-            void act("extend", async () => {
-              if (!publicClient) return;
-              const quote = (await publicClient.readContract({
-                address: deployment.contracts.vault,
-                abi: staticsGenesisCreditAbi,
-                functionName: "quoteGenesisCreditExtension",
-                args: [genesisId],
-              })) as GenesisCreditQuote;
-              const transaction = buildExtendGenesisCreditTransaction(
-                genesisId,
-                quote.totalNativeFee
-              );
-              await send(
-                "extend-genesis-credit",
-                `Extend Genesis #${genesisId} credit`,
-                transaction.data,
-                `${formatEther(quote.totalNativeFee)} ETH fee`,
-                transaction.value
-              );
-            })
-          }
-        >
-          {busy === "extend" ? "Extending…" : "Extend until maturity"}
-        </button>
-        <button
-          className="ui-button ui-button--primary"
-          type="button"
-          disabled={busy !== null}
-          onClick={() =>
-            void act("repay", async () => {
-              if (!publicClient || !wallet) return;
-              const allowance = await publicClient.readContract({
-                address: deployment.contracts.statics,
-                abi: dopplerStaticsTokenAbi,
-                functionName: "allowance",
-                args: [wallet, deployment.contracts.vault],
-              });
-              if (allowance < credit.principal) {
-                await executeProtocolTransaction({
-                  publicClient,
-                  wallet,
-                  chainId: deployment.descriptor.chainId,
-                  deploymentId: deployment.descriptor.deploymentId,
-                  kind: "approve-staking-token",
-                  label: "Enable Genesis credit repayment",
-                  amount: "Maximum STATICS",
-                  to: deployment.contracts.statics,
-                  data: encodeFunctionData({
-                    abi: dopplerStaticsTokenAbi,
-                    functionName: "approve",
-                    args: [deployment.contracts.vault, MAX_ERC20_ALLOWANCE],
-                  }),
-                  sendTransaction: walletState.sendEvmTransaction,
-                  describeError: describeCreditError,
-                });
-              }
-              await send(
-                "repay-genesis-credit",
-                `Repay Genesis #${genesisId} credit`,
-                buildRepayGenesisCreditCall(genesisId),
-                `${formatEther(credit.principal)} STATICS`
-              );
-            })
-          }
-        >
-          {busy === "repay" ? "Repaying…" : "Repay"}
-        </button>
+    <section className="ui-card genesis-panel" aria-label={`Genesis #${genesisId} secured credit`}>
+      <div className="genesis-panel-head">
+        <h3>Borrow against this Genesis</h3>
+        <p>
+          Take STATICS out of this NFT&apos;s backing for 30 days. The NFT stays in your wallet but
+          cannot be transferred until you repay.
+        </p>
       </div>
-      <p>This Genesis is transfer-locked while secured credit is active.</p>
-      {error && <p className="dapp-inline-error">{error}</p>}
+
+      <div className="genesis-borrow">
+        <p className="genesis-borrow-amount">
+          <b>{formatTokenAmountGrouped(clamped, 18, 0)}</b>
+          <span>STATICS · {ltv.toFixed(0)}% of backing</span>
+        </p>
+        <label className="ui-field">
+          <span className="sr-only">Amount to borrow</span>
+          <input
+            type="range"
+            min={0}
+            max={Number(formatEther(maxPrincipal))}
+            step={1_000}
+            value={Number(formatEther(clamped))}
+            disabled={busy !== null}
+            onChange={(event) => setAmount(event.target.value)}
+          />
+        </label>
+        <p className="genesis-borrow-scale">
+          <span>0</span>
+          <span>
+            {formatTokenAmountGrouped(maxPrincipal, 18, 0)} · {maxLtv.toFixed(0)}% max
+          </span>
+        </p>
+        <label className="ui-field">
+          Or enter an exact amount
+          <input
+            inputMode="decimal"
+            value={amount}
+            placeholder="0"
+            disabled={busy !== null}
+            onChange={(event) => setAmount(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <RecoveryTimeline
+        openedAt={now}
+        maturity={now + CREDIT_TERM_SECONDS}
+        recoverableAt={now + CREDIT_TERM_SECONDS + RECOVERY_GRACE_SECONDS}
+        now={null}
+      />
+
+      <p className="genesis-note is-warning">
+        <b>Miss the deadline and you lose the NFT.</b> One hour after maturity anyone can recover it
+        for an incentive. You would keep the residual value rather than the{" "}
+        {formatTokenAmountGrouped(backing, 18, 0)} STATICS backing.
+      </p>
+
+      <button
+        className="ui-button ui-button--primary ui-button--block"
+        type="button"
+        disabled={busy !== null || clamped <= 0n}
+        onClick={() =>
+          void act("open", async () => {
+            if (!publicClient) return;
+            if (clamped <= 0n || clamped > maxPrincipal) {
+              throw new Error("Choose an amount within this Genesis credit limit.");
+            }
+            const quote = (await publicClient.readContract({
+              address: deployment.contracts.vault,
+              abi: staticsGenesisCreditAbi,
+              functionName: "quoteGenesisCredit",
+              args: [clamped],
+            })) as GenesisCreditQuote;
+            const transaction = buildOpenGenesisCreditTransaction(
+              genesisId,
+              clamped,
+              quote.totalNativeFee
+            );
+            await send(
+              "open-genesis-credit",
+              `Borrow against Genesis #${genesisId}`,
+              transaction.data,
+              `${formatEther(clamped)} STATICS + ${formatEther(quote.totalNativeFee)} ETH fee`,
+              transaction.value
+            );
+            setAmount("");
+          })
+        }
+      >
+        {busy === "open"
+          ? "Borrowing…"
+          : `Borrow ${formatTokenAmountGrouped(clamped, 18, 0)} STATICS`}
+      </button>
+
+      {error && (
+        <p className="dapp-inline-error" role="alert">
+          {error}
+        </p>
+      )}
     </section>
   );
 }

--- a/components/genesis/GenesisIdentityPanel.tsx
+++ b/components/genesis/GenesisIdentityPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { usePublicClient } from "wagmi";
+
+import { NftArtwork } from "@/components/wallet/NftArtwork";
+import { genesisTierMultiplier } from "@/components/genesis/GenesisTierLadder";
+import { resolveNftMetadata } from "@/lib/wallet/nft-image";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+
+/**
+ * What this NFT *is*, as opposed to what you can do with it.
+ *
+ * Artwork, identity, traits, and backing live together on one side of the page
+ * so the action panels opposite stay about a single decision each.
+ */
+export function GenesisIdentityPanel({
+  id,
+  tier,
+  registered,
+  rewardWeight,
+  creditActive,
+  chainId,
+  collection,
+  vaultPrice,
+  maximumSupply,
+}: Readonly<{
+  id: bigint;
+  tier: number;
+  registered: boolean;
+  rewardWeight: bigint;
+  creditActive: boolean;
+  chainId: number;
+  collection: `0x${string}`;
+  vaultPrice: bigint;
+  maximumSupply: bigint;
+}>) {
+  const publicClient = usePublicClient({ chainId });
+
+  // The traits ride along with the artwork request the card already makes: the
+  // tokenURI document is decoded either way, so this costs no extra RPC.
+  const metadata = useQuery({
+    queryKey: ["genesis-traits", chainId, collection, id.toString()],
+    enabled: Boolean(publicClient),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+    queryFn: ({ signal }) => {
+      if (!publicClient) return null;
+      return resolveNftMetadata(publicClient, collection, id, signal);
+    },
+  });
+
+  // The tier is already stated by the badge above, and the registry is a more
+  // current source for it than cached metadata.
+  const traits = (metadata.data?.traits ?? []).filter(
+    (trait) => trait.label.toLowerCase() !== "activation tier"
+  );
+
+  return (
+    <aside className="genesis-identity ui-card" aria-label={`Genesis #${id} details`}>
+      <div className="genesis-identity-art">
+        <NftArtwork
+          chainId={chainId}
+          expandable
+          size="lg"
+          nft={{
+            kind: "collection",
+            tokenId: id,
+            contract: collection,
+            name: `Genesis #${id}`,
+            summary: `Tier ${tier}`,
+            carries: [],
+            blockedReason: creditActive ? "Repay secured credit before transfer." : null,
+          }}
+        />
+      </div>
+
+      <div className="genesis-identity-heading">
+        <div>
+          <h2 className="ui-section-title">Genesis #{id.toString()}</h2>
+          <p className="genesis-identity-sub">1 of {maximumSupply.toString()} · fully backed</p>
+        </div>
+        <span className="genesis-tier-badge" data-tier={tier}>
+          <b>T{tier}</b>
+          <span>{genesisTierMultiplier(tier).toFixed(2)}×</span>
+        </span>
+      </div>
+
+      <div className="genesis-identity-chips">
+        <span className={`ui-pill${registered ? " is-ready" : " is-warning"}`}>
+          {registered ? "Registered for rewards" : "Not registered"}
+        </span>
+        <span className={`ui-pill${creditActive ? " is-error" : ""}`}>
+          {creditActive ? "Transfer locked · credit active" : "Transferable"}
+        </span>
+      </div>
+
+      <dl className="genesis-identity-backing">
+        <div>
+          <dt>Redeemable for</dt>
+          <dd>{formatTokenAmountGrouped(vaultPrice, 18, 0)} STATICS</dd>
+        </div>
+        <div>
+          <dt>Reserve share</dt>
+          <dd>1 / {maximumSupply.toString()} of ETH reserve</dd>
+        </div>
+        <div>
+          <dt>Reward weight</dt>
+          <dd>{registered ? rewardWeight.toString() : "—"}</dd>
+        </div>
+      </dl>
+
+      {traits.length > 0 && (
+        <div className="genesis-identity-traits">
+          <p className="dapp-eyebrow">Onchain traits</p>
+          <dl>
+            {traits.map((trait) => (
+              <div key={trait.label}>
+                <dt>{trait.label}</dt>
+                <dd>{trait.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -238,7 +238,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
         </div>
         <div className="ui-stat">
           <span className="ui-stat__label">Activation</span>
-          <strong className="ui-stat__value">Burned STATICS; resets on transfer</strong>
+          <strong className="ui-stat__value">Paid to the treasury; resets on transfer</strong>
         </div>
       </div>
       {error && (
@@ -307,7 +307,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                         ))}
                     </select>
                   </label>
-                  <p>Burn cost: {formatEther(cost)} STATICS</p>
+                  <p>Activation cost: {formatEther(cost)} STATICS</p>
                   {needsApproval ? (
                     <button
                       className="ui-button ui-button--primary ui-button--block"
@@ -346,7 +346,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                             "activate-genesis",
                             `Activate Genesis #${actionKey} to tier ${target}`,
                             buildActivateGenesisCall(id, target, cost),
-                            `${formatEther(cost)} STATICS burned`
+                            `${formatEther(cost)} STATICS activation payment`
                           );
                         })
                       }

--- a/components/genesis/GenesisRecoveriesPage.tsx
+++ b/components/genesis/GenesisRecoveriesPage.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { formatEther, getAddress } from "viem";
+import { usePublicClient } from "wagmi";
+import {
+  buildRecoverGenesisCreditCall,
+  staticsGenesisCreditAbi,
+} from "@statics-protocol/sdk/genesis-credit";
+
+import { EmptyState, UnconfiguredSurface } from "@/components/common/EmptyState";
+import { AddressDisplay } from "@/components/protocol/AddressDisplay";
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
+import { loadRecoverableGenesisCredits } from "@/lib/indexer/statics";
+import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+import { useDeployment } from "@/providers/deployment-context";
+import { useWalletState } from "@/providers/wallet-context";
+
+type RecoveryCredit = Readonly<{
+  genesisId: bigint;
+  owner: `0x${string}`;
+  principal: bigint;
+  maturity: bigint;
+  recoverableAt: bigint;
+  unusedCredit: bigint;
+  callerIncentive: bigint;
+  genesisDistribution: bigint;
+}>;
+
+function describeRecoveryError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/rejected/i.test(message)) return "The wallet request was rejected.";
+  if (message.includes("CreditNotRecoverable")) return "This credit is not recoverable yet.";
+  if (message.includes("CreditNotActive")) return "This Genesis credit is no longer active.";
+  return message || "The recovery transaction failed.";
+}
+
+function displayTimestamp(timestamp: bigint): string {
+  return new Date(Number(timestamp) * 1_000).toLocaleString();
+}
+
+export function GenesisRecoveriesPage() {
+  const { active } = useDeployment();
+  if (!active.launch) return <UnconfiguredSurface subject="Genesis recoveries" />;
+  return <LaunchGenesisRecoveries deployment={active.launch} />;
+}
+
+/**
+ * Permissionless recovery of other people's defaulted Genesis credit.
+ *
+ * This is keeper work, not Genesis ownership, which is why it has its own
+ * destination: it used to sit as the first tab on My Genesis, so every holder
+ * had to step past somebody else's liquidations to reach their own NFTs.
+ */
+function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment }) {
+  const walletState = useWalletState();
+  const publicClient = usePublicClient({ chainId: deployment.descriptor.chainId });
+  const queryClient = useQueryClient();
+  const wallet =
+    walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
+  const [busy, setBusy] = useState<bigint | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const epoch = useQuery({
+    queryKey: ["genesis-vault-epoch", deployment.descriptor.deploymentId],
+    enabled: Boolean(publicClient),
+    queryFn: async () => {
+      if (!publicClient) throw new Error("The deployment RPC is unavailable.");
+      const accounting = await publicClient.readContract({
+        address: deployment.contracts.vault,
+        abi: currentGenesisVaultAbi,
+        functionName: "vaultAccounting",
+      });
+      return accounting.epochActive;
+    },
+  });
+
+  const recoveries = useQuery({
+    queryKey: ["launch-genesis-recoveries", deployment.descriptor.deploymentId],
+    enabled: Boolean(publicClient && epoch.data === false),
+    queryFn: async (): Promise<readonly RecoveryCredit[]> => {
+      if (!publicClient) return [];
+      await verifyLaunchDeployment(publicClient, deployment);
+      const block = await publicClient.getBlock({ blockTag: "latest" });
+      const indexed = await loadRecoverableGenesisCredits(
+        block.timestamp,
+        deployment.descriptor.deploymentId
+      );
+      const checked = await Promise.all(
+        indexed.map(async (candidate): Promise<RecoveryCredit | null> => {
+          const [credit, quote] = await Promise.all([
+            publicClient.readContract({
+              address: deployment.contracts.vault,
+              abi: staticsGenesisCreditAbi,
+              functionName: "credit",
+              args: [candidate.genesisId],
+            }),
+            publicClient
+              .readContract({
+                address: deployment.contracts.vault,
+                abi: staticsGenesisCreditAbi,
+                functionName: "quoteGenesisCreditRecovery",
+                args: [candidate.genesisId],
+              })
+              .catch(() => null),
+          ]);
+          if (!credit.active || !quote || BigInt(credit.recoverableAt) >= block.timestamp)
+            return null;
+          return {
+            genesisId: candidate.genesisId,
+            owner: getAddress(credit.owner),
+            principal: credit.principal,
+            maturity: BigInt(credit.maturity),
+            recoverableAt: BigInt(credit.recoverableAt),
+            unusedCredit: quote.unusedCredit,
+            callerIncentive: quote.callerIncentive,
+            genesisDistribution: quote.genesisDistribution,
+          };
+        })
+      );
+      return checked.filter((item): item is RecoveryCredit => item !== null);
+    },
+  });
+
+  const recover = async (credit: RecoveryCredit) => {
+    if (!publicClient) return;
+    if (!wallet) {
+      if (walletState.status === "wallet-missing") void walletState.createWallet();
+      else walletState.connectWallet();
+      return;
+    }
+    if (!walletState.isTargetChain) {
+      await walletState.switchNetwork();
+      return;
+    }
+    setBusy(credit.genesisId);
+    setError(null);
+    try {
+      await verifyLaunchDeployment(publicClient, deployment);
+      await executeProtocolTransaction({
+        publicClient,
+        wallet,
+        chainId: deployment.descriptor.chainId,
+        deploymentId: deployment.descriptor.deploymentId,
+        kind: "recover-genesis-credit",
+        label: `Recover Genesis #${credit.genesisId}`,
+        amount: `${formatEther(credit.callerIncentive)} STATICS caller incentive`,
+        to: deployment.contracts.vault,
+        data: buildRecoverGenesisCreditCall(credit.genesisId),
+        sendTransaction: walletState.sendEvmTransaction,
+        describeError: describeRecoveryError,
+        verifyConfirmation: async () => {
+          const current = await publicClient.readContract({
+            address: deployment.contracts.vault,
+            abi: staticsGenesisCreditAbi,
+            functionName: "credit",
+            args: [credit.genesisId],
+          });
+          if (current.active) throw new Error("Recovery is not reflected onchain yet.");
+        },
+      });
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          Array.isArray(query.queryKey) &&
+          query.queryKey.includes(deployment.descriptor.deploymentId) &&
+          ["launch-genesis", "genesis-vault"].some((prefix) =>
+            String(query.queryKey[0]).startsWith(prefix)
+          ),
+      });
+    } catch (cause) {
+      setError(describeRecoveryError(cause));
+      await recoveries.refetch();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (epoch.data !== false) {
+    return (
+      <EmptyState
+        title="Recovery opens after the Genesis Epoch"
+        description="Genesis credit cannot be opened, and so cannot default, while the Epoch is running."
+        secondary={{ label: "Back to My Genesis", href: "/app/genesis" }}
+      />
+    );
+  }
+
+  return (
+    <div className="genesis-page">
+      {error && (
+        <p className="dapp-inline-error" role="alert">
+          {error}
+        </p>
+      )}
+      {recoveries.isLoading ? (
+        <p className="dapp-loading">Loading recoverable Genesis credits…</p>
+      ) : recoveries.error ? (
+        <p className="dapp-inline-error" role="alert">
+          Recovery discovery is temporarily unavailable because the deployment indexer could not be
+          reached. Owned Genesis management remains available.
+        </p>
+      ) : !recoveries.data?.length ? (
+        <EmptyState
+          title="No recoverable Genesis credits"
+          description="No indexed credit is currently eligible for permissionless recovery."
+          secondary={{ label: "Back to My Genesis", href: "/app/genesis" }}
+        />
+      ) : (
+        <div className="genesis-grid">
+          {recoveries.data.map((credit) => (
+            <article className="ui-card genesis-card" key={credit.genesisId.toString()}>
+              <h2 className="ui-section-title">Genesis #{credit.genesisId.toString()}</h2>
+              <AddressDisplay
+                address={credit.owner}
+                chainId={deployment.descriptor.chainId}
+                label="Current owner"
+              />
+              <dl className="genesis-recovery-figures">
+                <div>
+                  <dt>Principal</dt>
+                  <dd>{formatTokenAmountGrouped(credit.principal, 18, 0)} STATICS</dd>
+                </div>
+                <div>
+                  <dt>Unused credit</dt>
+                  <dd>{formatTokenAmountGrouped(credit.unusedCredit, 18, 2)} STATICS</dd>
+                </div>
+                <div>
+                  <dt>Your incentive</dt>
+                  <dd className="is-accent">
+                    {formatTokenAmountGrouped(credit.callerIncentive, 18, 2)} STATICS
+                  </dd>
+                </div>
+                <div>
+                  <dt>To the Genesis holder</dt>
+                  <dd>{formatTokenAmountGrouped(credit.genesisDistribution, 18, 2)} STATICS</dd>
+                </div>
+                <div>
+                  <dt>Matured</dt>
+                  <dd>{displayTimestamp(credit.maturity)}</dd>
+                </div>
+                <div>
+                  <dt>Recoverable since</dt>
+                  <dd>{displayTimestamp(credit.recoverableAt)}</dd>
+                </div>
+              </dl>
+              <button
+                className="ui-button ui-button--primary ui-button--block"
+                type="button"
+                disabled={busy !== null && busy !== credit.genesisId}
+                onClick={() => void recover(credit)}
+              >
+                {busy === credit.genesisId ? "Recovering…" : `Recover Genesis #${credit.genesisId}`}
+              </button>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/genesis/GenesisTierLadder.tsx
+++ b/components/genesis/GenesisTierLadder.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+
+/**
+ * Mirrors GenesisActivationRegistry.multiplierForTier. Kept as a pure local
+ * table rather than a contract read: it is `pure` onchain, five constant
+ * values, and every rung of the ladder needs it at once.
+ */
+export const GENESIS_TIER_MULTIPLIER_BPS: readonly number[] = [
+  10_000, 11_000, 11_500, 12_000, 12_500,
+];
+
+export const GENESIS_MAX_TIER = 4;
+
+export function genesisTierMultiplier(tier: number): number {
+  return (GENESIS_TIER_MULTIPLIER_BPS[tier] ?? 10_000) / 10_000;
+}
+
+/** Cumulative cost of moving from `currentTier` up to `targetTier`. */
+export function cumulativeTierCost(
+  tierCosts: readonly bigint[],
+  currentTier: number,
+  targetTier: number
+): bigint {
+  let total = 0n;
+  for (let tier = currentTier + 1; tier <= targetTier; tier += 1) {
+    total += tierCosts[tier] ?? 0n;
+  }
+  return total;
+}
+
+/**
+ * The activation ladder, drawn in full.
+ *
+ * A <select> of remaining tiers hides the shape of the decision: the
+ * multiplier curve flattens hard after Tier 1, so the last 0.05x costs
+ * 40,000 STATICS. That is only weighable when every rung is visible at once.
+ */
+export function GenesisTierLadder({
+  currentTier,
+  targetTier,
+  tierCosts,
+  onSelect,
+  disabled,
+}: Readonly<{
+  currentTier: number;
+  targetTier: number;
+  tierCosts: readonly bigint[];
+  onSelect: (tier: number) => void;
+  disabled: boolean;
+}>) {
+  return (
+    <ol className="genesis-ladder" aria-label="Activation tiers">
+      {Array.from({ length: GENESIS_MAX_TIER + 1 }, (_, tier) => {
+        const reached = tier < currentTier;
+        const isCurrent = tier === currentTier;
+        const isTarget = tier === targetTier && tier > currentTier;
+        const state = reached ? "reached" : isCurrent ? "current" : isTarget ? "target" : "ahead";
+        const selectable = tier > currentTier && !disabled;
+        return (
+          <li key={tier}>
+            <button
+              className="genesis-ladder-rung"
+              type="button"
+              data-state={state}
+              disabled={!selectable}
+              aria-current={isCurrent ? "step" : undefined}
+              onClick={() => onSelect(tier)}
+            >
+              <span className="genesis-ladder-tier">Tier {tier}</span>
+              <span className="genesis-ladder-multiplier">
+                {genesisTierMultiplier(tier).toFixed(2)}× reward weight
+              </span>
+              <span className="genesis-ladder-cost">
+                {tier === 0
+                  ? "—"
+                  : `${formatTokenAmountGrouped(tierCosts[tier] ?? 0n, 18, 0)} STATICS`}
+              </span>
+              <span className="genesis-ladder-mark">
+                {reached ? "Reached" : isCurrent ? "You are here" : isTarget ? "Target" : ""}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
 import { encodeFunctionData, formatEther, getAddress } from "viem";
 import { usePublicClient } from "wagmi";
 import {
@@ -15,23 +16,26 @@ import {
   genesisActivationRegistryAbi,
   genesisLaunchDistributorAbi,
 } from "@statics-protocol/sdk";
-import {
-  buildRecoverGenesisCreditCall,
-  staticsGenesisCreditAbi,
-} from "@statics-protocol/sdk/genesis-credit";
+import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
 
 import { EmptyState } from "@/components/common/EmptyState";
+import { GenesisCarousel } from "@/components/genesis/GenesisCarousel";
 import { GenesisCreditPanel } from "@/components/genesis/GenesisCreditPanel";
+import { GenesisIdentityPanel } from "@/components/genesis/GenesisIdentityPanel";
+import {
+  GENESIS_MAX_TIER,
+  GenesisTierLadder,
+  genesisTierMultiplier,
+} from "@/components/genesis/GenesisTierLadder";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
-import { NftArtwork } from "@/components/wallet/NftArtwork";
 import type { LaunchDeployment } from "@/lib/deployments/types";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
 import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
-import { loadRecoverableGenesisCredits } from "@/lib/indexer/statics";
 import { discoverWalletGenesisIds } from "@/lib/genesis/discovery";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
 import { useWalletState } from "@/providers/wallet-context";
 
 function describeGenesisError(error: unknown): string {
@@ -40,21 +44,9 @@ function describeGenesisError(error: unknown): string {
   if (message.includes("NotGenesisOwner")) return "This wallet no longer owns that Genesis NFT.";
   if (message.includes("GenesisAlreadyRegistered"))
     return "That Genesis NFT is already registered for rewards.";
-  if (message.includes("CreditNotRecoverable")) return "This credit is not recoverable yet.";
-  if (message.includes("CreditNotActive")) return "This Genesis credit is no longer active.";
+  if (message.includes("NoRewards")) return "There is nothing to claim for that asset yet.";
   return message || "The Genesis transaction failed.";
 }
-
-type RecoveryCredit = Readonly<{
-  genesisId: bigint;
-  owner: `0x${string}`;
-  principal: bigint;
-  maturity: bigint;
-  recoverableAt: bigint;
-  unusedCredit: bigint;
-  callerIncentive: bigint;
-  genesisDistribution: bigint;
-}>;
 
 type OwnedGenesis = Readonly<{
   id: bigint;
@@ -64,11 +56,12 @@ type OwnedGenesis = Readonly<{
   rewardWeight: bigint;
   pendingStatics: bigint;
   pendingWeth: bigint;
+  creditActive: boolean;
+  creditPrincipal: bigint;
+  creditMaturity: number;
 }>;
 
-function displayTimestamp(timestamp: bigint): string {
-  return new Date(Number(timestamp) * 1_000).toLocaleString();
-}
+type ActionTab = "activate" | "rewards" | "credit";
 
 export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeployment }) {
   const walletState = useWalletState();
@@ -76,74 +69,31 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
   const queryClient = useQueryClient();
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
-  const [targetTiers, setTargetTiers] = useState<Record<string, number>>({});
-  const [busy, setBusy] = useState<bigint | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [view, setView] = useState<"owned" | "recoveries">("owned");
-  const [recoveryBusy, setRecoveryBusy] = useState<bigint | null>(null);
-  const [recoveryError, setRecoveryError] = useState<string | null>(null);
-  const [rewardsBusy, setRewardsBusy] = useState<string | null>(null);
-  const [rewardsError, setRewardsError] = useState<string | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
-  const epoch = useQuery({
+  const [selectedId, setSelectedId] = useState<bigint | null>(null);
+  const [tab, setTab] = useState<ActionTab>("activate");
+  const [targetTiers, setTargetTiers] = useState<Record<string, number>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [claimProgress, setClaimProgress] = useState<string | null>(null);
+
+  const vault = useQuery({
     queryKey: ["genesis-vault-epoch", deployment.descriptor.deploymentId],
     enabled: Boolean(publicClient),
     queryFn: async () => {
-      if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
+      if (!publicClient) throw new Error("The deployment RPC is unavailable.");
       const accounting = await publicClient.readContract({
         address: deployment.contracts.vault,
         abi: currentGenesisVaultAbi,
         functionName: "vaultAccounting",
       });
-      return accounting.epochActive;
-    },
-  });
-
-  const recoveries = useQuery({
-    queryKey: ["launch-genesis-recoveries", deployment.descriptor.deploymentId],
-    enabled: Boolean(publicClient && epoch.data === false),
-    queryFn: async (): Promise<readonly RecoveryCredit[]> => {
-      if (!publicClient) return [];
-      await verifyLaunchDeployment(publicClient, deployment);
-      const block = await publicClient.getBlock({ blockTag: "latest" });
-      const indexed = await loadRecoverableGenesisCredits(
-        block.timestamp,
-        deployment.descriptor.deploymentId
-      );
-      const checked = await Promise.all(
-        indexed.map(async (candidate): Promise<RecoveryCredit | null> => {
-          const [credit, quote] = await Promise.all([
-            publicClient.readContract({
-              address: deployment.contracts.vault,
-              abi: staticsGenesisCreditAbi,
-              functionName: "credit",
-              args: [candidate.genesisId],
-            }),
-            publicClient
-              .readContract({
-                address: deployment.contracts.vault,
-                abi: staticsGenesisCreditAbi,
-                functionName: "quoteGenesisCreditRecovery",
-                args: [candidate.genesisId],
-              })
-              .catch(() => null),
-          ]);
-          if (!credit.active || !quote || BigInt(credit.recoverableAt) >= block.timestamp)
-            return null;
-          return {
-            genesisId: candidate.genesisId,
-            owner: getAddress(credit.owner),
-            principal: credit.principal,
-            maturity: BigInt(credit.maturity),
-            recoverableAt: BigInt(credit.recoverableAt),
-            unusedCredit: quote.unusedCredit,
-            callerIncentive: quote.callerIncentive,
-            genesisDistribution: quote.genesisDistribution,
-          };
-        })
-      );
-      return checked.filter((item): item is RecoveryCredit => item !== null);
+      return {
+        epochActive: accounting.epochActive,
+        genesisEpochEnd: Number(accounting.genesisEpochEnd),
+        vaultPrice: accounting.vaultPrice,
+        maximumSupply: accounting.maximumSupply,
+        circulatingGenesis: accounting.circulatingGenesis,
+      };
     },
   });
 
@@ -151,7 +101,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     queryKey: ["launch-genesis-owned", deployment.descriptor.deploymentId, wallet],
     enabled: Boolean(publicClient && wallet),
     queryFn: async () => {
-      if (!publicClient || !wallet)
+      if (!publicClient || !wallet) {
         return {
           items: [] as readonly OwnedGenesis[],
           tierCosts: [] as readonly bigint[],
@@ -160,6 +110,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
           ownerStatics: 0n,
           ownerWeth: 0n,
         };
+      }
       await verifyLaunchDeployment(publicClient, deployment);
       const [ids, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth] =
         await Promise.all([
@@ -199,45 +150,61 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         ]);
       const items = await Promise.all(
         ids.map(async (id): Promise<OwnedGenesis> => {
-          const [tier, multiplierBps, registered, rewardWeight, pendingStatics, pendingWeth] =
-            await Promise.all([
-              publicClient.readContract({
-                address: deployment.contracts.activationRegistry,
-                abi: genesisActivationRegistryAbi,
-                functionName: "tierOf",
-                args: [id],
-              }),
-              publicClient.readContract({
-                address: deployment.contracts.activationRegistry,
-                abi: genesisActivationRegistryAbi,
-                functionName: "multiplierBps",
-                args: [id],
-              }),
-              publicClient.readContract({
-                address: deployment.contracts.launchDistributor,
-                abi: genesisLaunchDistributorAbi,
-                functionName: "registered",
-                args: [id],
-              }),
-              publicClient.readContract({
-                address: deployment.contracts.launchDistributor,
-                abi: genesisLaunchDistributorAbi,
-                functionName: "effectiveWeight",
-                args: [id],
-              }),
-              publicClient.readContract({
-                address: deployment.contracts.launchDistributor,
-                abi: genesisLaunchDistributorAbi,
-                functionName: "pendingGenesis",
-                args: [id, deployment.contracts.statics],
-              }),
-              publicClient.readContract({
-                address: deployment.contracts.launchDistributor,
-                abi: genesisLaunchDistributorAbi,
-                functionName: "pendingGenesis",
-                args: [id, deployment.contracts.weth],
-              }),
-            ]);
+          const [
+            tier,
+            multiplierBps,
+            registered,
+            rewardWeight,
+            pendingStatics,
+            pendingWeth,
+            credit,
+          ] = await Promise.all([
+            publicClient.readContract({
+              address: deployment.contracts.activationRegistry,
+              abi: genesisActivationRegistryAbi,
+              functionName: "tierOf",
+              args: [id],
+            }),
+            publicClient.readContract({
+              address: deployment.contracts.activationRegistry,
+              abi: genesisActivationRegistryAbi,
+              functionName: "multiplierBps",
+              args: [id],
+            }),
+            publicClient.readContract({
+              address: deployment.contracts.launchDistributor,
+              abi: genesisLaunchDistributorAbi,
+              functionName: "registered",
+              args: [id],
+            }),
+            publicClient.readContract({
+              address: deployment.contracts.launchDistributor,
+              abi: genesisLaunchDistributorAbi,
+              functionName: "effectiveWeight",
+              args: [id],
+            }),
+            publicClient.readContract({
+              address: deployment.contracts.launchDistributor,
+              abi: genesisLaunchDistributorAbi,
+              functionName: "pendingGenesis",
+              args: [id, deployment.contracts.statics],
+            }),
+            publicClient.readContract({
+              address: deployment.contracts.launchDistributor,
+              abi: genesisLaunchDistributorAbi,
+              functionName: "pendingGenesis",
+              args: [id, deployment.contracts.weth],
+            }),
+            // Credit state travels with the list so the carousel can flag a
+            // transfer lock and the summary can total what is owed, without a
+            // per-card query fanning out behind the scenes.
+            publicClient.readContract({
+              address: deployment.contracts.vault,
+              abi: staticsGenesisCreditAbi,
+              functionName: "credit",
+              args: [id],
+            }),
+          ]);
           return {
             id,
             tier: Number(tier),
@@ -246,6 +213,9 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
             rewardWeight,
             pendingStatics,
             pendingWeth,
+            creditActive: credit.active,
+            creditPrincipal: credit.principal,
+            creditMaturity: Number(credit.maturity),
           };
         })
       );
@@ -253,609 +223,727 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     },
   });
 
-  const items = owned.data?.items ?? [];
-  const selected = items.find((item) => item.id.toString() === selectedKey) ?? items[0] ?? null;
+  const items = useMemo(() => owned.data?.items ?? [], [owned.data]);
+  const selected = useMemo(
+    () => items.find((item) => item.id === selectedId) ?? items[0] ?? null,
+    [items, selectedId]
+  );
+
+  const summary = useMemo(() => {
+    const pendingStatics = items.reduce((total, item) => total + item.pendingStatics, 0n);
+    const pendingWeth = items.reduce((total, item) => total + item.pendingWeth, 0n);
+    const ownerStatics = owned.data?.ownerStatics ?? 0n;
+    const ownerWeth = owned.data?.ownerWeth ?? 0n;
+    const credits = items.filter((item) => item.creditActive);
+    const owed = credits.reduce((total, item) => total + item.creditPrincipal, 0n);
+    const soonest = credits.reduce<OwnedGenesis | null>(
+      (earliest, item) =>
+        !earliest || item.creditMaturity < earliest.creditMaturity ? item : earliest,
+      null
+    );
+    // One claim call per NFT and asset, and the distributor exposes no batch
+    // entry point, so the button says up front how many signatures it wants.
+    const claimCount =
+      items.reduce(
+        (total, item) =>
+          total + (item.pendingStatics > 0n ? 1 : 0) + (item.pendingWeth > 0n ? 1 : 0),
+        0
+      ) +
+      (ownerStatics > 0n ? 1 : 0) +
+      (ownerWeth > 0n ? 1 : 0);
+    return {
+      claimableStatics: pendingStatics + ownerStatics,
+      claimableWeth: pendingWeth + ownerWeth,
+      ownerStatics,
+      ownerWeth,
+      owed,
+      creditCount: credits.length,
+      soonest,
+      claimCount,
+      activated: items.filter((item) => item.tier > 0).length,
+      unregistered: items.filter((item) => !item.registered).length,
+    };
+  }, [items, owned.data]);
 
   const refresh = async () => {
     await queryClient.invalidateQueries({
-      queryKey: ["launch-genesis-owned", deployment.descriptor.deploymentId],
+      predicate: (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey.includes(deployment.descriptor.deploymentId) &&
+        ["launch-genesis", "genesis-vault"].some((prefix) =>
+          String(query.queryKey[0]).startsWith(prefix)
+        ),
     });
   };
 
-  const activate = async (id: bigint, displayedTier: number, targetTier: number) => {
-    if (!wallet || !publicClient) return;
+  const guardChain = async (): Promise<boolean> => {
     if (!walletState.isTargetChain) {
       await walletState.switchNetwork();
-      return;
+      return false;
     }
-    setBusy(id);
+    return true;
+  };
+
+  const send = async (
+    kind: Parameters<typeof executeProtocolTransaction>[0]["kind"],
+    label: string,
+    to: `0x${string}`,
+    data: `0x${string}`,
+    amount: string
+  ) => {
+    if (!wallet || !publicClient) return;
+    await executeProtocolTransaction({
+      publicClient,
+      wallet,
+      chainId: deployment.descriptor.chainId,
+      deploymentId: deployment.descriptor.deploymentId,
+      kind,
+      label,
+      amount,
+      to,
+      data,
+      sendTransaction: walletState.sendEvmTransaction,
+      describeError: describeGenesisError,
+    });
+  };
+
+  const act = async (key: string, action: () => Promise<void>) => {
+    if (!publicClient || !wallet) return;
+    if (!(await guardChain())) return;
+    setBusy(key);
     setError(null);
     try {
       await verifyLaunchDeployment(publicClient, deployment);
-      const [currentTier, currentCosts] = await Promise.all([
-        publicClient.readContract({
-          address: deployment.contracts.activationRegistry,
-          abi: genesisActivationRegistryAbi,
-          functionName: "tierOf",
-          args: [id],
-        }),
-        Promise.all(
-          [1, 2, 3, 4].map((tier) =>
-            publicClient.readContract({
-              address: deployment.contracts.activationRegistry,
-              abi: genesisActivationRegistryAbi,
-              functionName: "tierCost",
-              args: [tier],
-            })
-          )
-        ).then(oneIndexedGenesisTierCosts),
-      ]);
-      if (Number(currentTier) !== displayedTier) {
-        throw new Error("The activation tier changed. Review the refreshed NFT before confirming.");
-      }
-      const cost = cumulativeGenesisActivationCost(currentCosts, Number(currentTier), targetTier);
-      const [balance, allowance] = await Promise.all([
-        publicClient.readContract({
-          address: deployment.contracts.statics,
-          abi: dopplerStaticsTokenAbi,
-          functionName: "balanceOf",
-          args: [wallet],
-        }),
-        publicClient.readContract({
-          address: deployment.contracts.statics,
-          abi: dopplerStaticsTokenAbi,
-          functionName: "allowance",
-          args: [wallet, deployment.contracts.activationRegistry],
-        }),
-      ]);
-      if (balance < cost) throw new Error("Insufficient STATICS for this activation tier.");
-      if (allowance < cost) {
-        await executeProtocolTransaction({
-          publicClient,
-          wallet,
-          chainId: deployment.descriptor.chainId,
-          deploymentId: deployment.descriptor.deploymentId,
-          kind: "approve-staking-token",
-          label: "Enable Genesis activation",
-          amount: "Maximum STATICS",
-          to: deployment.contracts.statics,
-          data: encodeFunctionData({
-            abi: dopplerStaticsTokenAbi,
-            functionName: "approve",
-            args: [deployment.contracts.activationRegistry, MAX_ERC20_ALLOWANCE],
-          }),
-          sendTransaction: walletState.sendEvmTransaction,
-          describeError: describeGenesisError,
-        });
-      }
-      await executeProtocolTransaction({
-        publicClient,
-        wallet,
-        chainId: deployment.descriptor.chainId,
-        deploymentId: deployment.descriptor.deploymentId,
-        kind: "activate-genesis",
-        label: `Activate Genesis #${id} to tier ${targetTier}`,
-        amount: `${formatEther(cost)} STATICS activation payment`,
-        to: deployment.contracts.activationRegistry,
-        data: buildActivateGenesisCall(id, targetTier),
-        sendTransaction: walletState.sendEvmTransaction,
-        describeError: describeGenesisError,
-      });
+      await action();
       await refresh();
     } catch (cause) {
       setError(describeGenesisError(cause));
       await refresh();
     } finally {
       setBusy(null);
+      setClaimProgress(null);
     }
   };
 
-  const recover = async (credit: RecoveryCredit) => {
-    if (!publicClient) return;
-    if (!wallet) {
-      if (walletState.status === "wallet-missing") void walletState.createWallet();
-      else walletState.connectWallet();
-      return;
+  const activate = async (item: OwnedGenesis, targetTier: number) => {
+    if (!publicClient || !wallet) return;
+    // The tier is re-read immediately before the payment: a transfer or a
+    // concurrent activation between render and confirmation would otherwise
+    // charge for tiers already paid for.
+    const [currentTier, currentCosts] = await Promise.all([
+      publicClient.readContract({
+        address: deployment.contracts.activationRegistry,
+        abi: genesisActivationRegistryAbi,
+        functionName: "tierOf",
+        args: [item.id],
+      }),
+      Promise.all(
+        [1, 2, 3, 4].map((tier) =>
+          publicClient.readContract({
+            address: deployment.contracts.activationRegistry,
+            abi: genesisActivationRegistryAbi,
+            functionName: "tierCost",
+            args: [tier],
+          })
+        )
+      ).then(oneIndexedGenesisTierCosts),
+    ]);
+    if (Number(currentTier) !== item.tier) {
+      throw new Error("The activation tier changed. Review the refreshed NFT before confirming.");
     }
-    if (!walletState.isTargetChain) {
-      await walletState.switchNetwork();
-      return;
+    const cost = cumulativeGenesisActivationCost(currentCosts, Number(currentTier), targetTier);
+    const [balance, allowance] = await Promise.all([
+      publicClient.readContract({
+        address: deployment.contracts.statics,
+        abi: dopplerStaticsTokenAbi,
+        functionName: "balanceOf",
+        args: [wallet],
+      }),
+      publicClient.readContract({
+        address: deployment.contracts.statics,
+        abi: dopplerStaticsTokenAbi,
+        functionName: "allowance",
+        args: [wallet, deployment.contracts.activationRegistry],
+      }),
+    ]);
+    if (balance < cost) throw new Error("Insufficient STATICS for this activation tier.");
+    if (allowance < cost) {
+      await send(
+        "approve-staking-token",
+        "Enable Genesis activation",
+        deployment.contracts.statics,
+        encodeFunctionData({
+          abi: dopplerStaticsTokenAbi,
+          functionName: "approve",
+          args: [deployment.contracts.activationRegistry, MAX_ERC20_ALLOWANCE],
+        }),
+        "Maximum STATICS"
+      );
     }
-    setRecoveryBusy(credit.genesisId);
-    setRecoveryError(null);
-    try {
-      await verifyLaunchDeployment(publicClient, deployment);
-      await executeProtocolTransaction({
-        publicClient,
-        wallet,
-        chainId: deployment.descriptor.chainId,
-        deploymentId: deployment.descriptor.deploymentId,
-        kind: "recover-genesis-credit",
-        label: `Recover Genesis #${credit.genesisId}`,
-        amount: `${formatEther(credit.callerIncentive)} STATICS caller incentive`,
-        to: deployment.contracts.vault,
-        data: buildRecoverGenesisCreditCall(credit.genesisId),
-        sendTransaction: walletState.sendEvmTransaction,
-        describeError: describeGenesisError,
-        verifyConfirmation: async () => {
-          const current = await publicClient.readContract({
-            address: deployment.contracts.vault,
-            abi: staticsGenesisCreditAbi,
-            functionName: "credit",
-            args: [credit.genesisId],
-          });
-          if (current.active) throw new Error("Recovery is not reflected onchain yet.");
-        },
+    await send(
+      "activate-genesis",
+      `Activate Genesis #${item.id} to tier ${targetTier}`,
+      deployment.contracts.activationRegistry,
+      buildActivateGenesisCall(item.id, targetTier),
+      `${formatEther(cost)} STATICS activation payment`
+    );
+  };
+
+  const claimEverything = async () => {
+    const jobs: { label: string; data: `0x${string}`; amount: string }[] = [];
+    for (const item of items) {
+      if (item.pendingStatics > 0n) {
+        jobs.push({
+          label: `Claim Genesis #${item.id} STATICS rewards`,
+          data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.statics, wallet!),
+          amount: `${formatEther(item.pendingStatics)} STATICS`,
+        });
+      }
+      if (item.pendingWeth > 0n) {
+        jobs.push({
+          label: `Claim Genesis #${item.id} WETH rewards`,
+          data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.weth, wallet!),
+          amount: `${formatEther(item.pendingWeth)} WETH`,
+        });
+      }
+    }
+    if (summary.ownerStatics > 0n) {
+      jobs.push({
+        label: "Claim previous-owner STATICS rewards",
+        data: buildClaimOwnerGenesisLaunchRewardsCall(deployment.contracts.statics, wallet!),
+        amount: `${formatEther(summary.ownerStatics)} STATICS`,
       });
-      await queryClient.invalidateQueries({
-        predicate: (query) =>
-          Array.isArray(query.queryKey) &&
-          query.queryKey.includes(deployment.descriptor.deploymentId) &&
-          ["launch-genesis", "genesis-vault"].some((prefix) =>
-            String(query.queryKey[0]).startsWith(prefix)
-          ),
+    }
+    if (summary.ownerWeth > 0n) {
+      jobs.push({
+        label: "Claim previous-owner WETH rewards",
+        data: buildClaimOwnerGenesisLaunchRewardsCall(deployment.contracts.weth, wallet!),
+        amount: `${formatEther(summary.ownerWeth)} WETH`,
       });
-    } catch (cause) {
-      setRecoveryError(describeGenesisError(cause));
-      await recoveries.refetch();
-    } finally {
-      setRecoveryBusy(null);
+    }
+    for (const [index, job] of jobs.entries()) {
+      setClaimProgress(`${index + 1} of ${jobs.length}`);
+      await send(
+        "claim-rewards",
+        job.label,
+        deployment.contracts.launchDistributor,
+        job.data,
+        job.amount
+      );
     }
   };
 
-  const sendReward = async (key: string, label: string, data: `0x${string}`, amount: string) => {
-    if (!wallet || !publicClient) return;
-    if (!walletState.isTargetChain) {
-      await walletState.switchNetwork();
-      return;
-    }
-    setRewardsBusy(key);
-    setRewardsError(null);
-    try {
-      await verifyLaunchDeployment(publicClient, deployment);
-      await executeProtocolTransaction({
-        publicClient,
-        wallet,
-        chainId: deployment.descriptor.chainId,
-        deploymentId: deployment.descriptor.deploymentId,
-        kind: key === "accrue" ? "accrue-genesis-rewards" : "claim-rewards",
-        label,
-        amount,
-        to: deployment.contracts.launchDistributor,
-        data,
-        sendTransaction: walletState.sendEvmTransaction,
-        describeError: describeGenesisError,
-      });
-      await refresh();
-    } catch (cause) {
-      setRewardsError(describeGenesisError(cause));
-    } finally {
-      setRewardsBusy(null);
-    }
-  };
+  // Recovery is open to anyone once the Epoch ends, whether or not this wallet
+  // holds a Genesis, so its entry point sits above the wallet gate.
+  const recoveriesLink =
+    vault.data?.epochActive === false ? (
+      <Link className="genesis-recoveries-link" href="/app/genesis/recoveries">
+        Recover matured Genesis credit <span aria-hidden="true">→</span>
+      </Link>
+    ) : null;
 
-  if (!wallet && epoch.data !== false) {
+  if (!wallet) {
     return (
-      <EmptyState
-        title="Connect your wallet"
-        description="Connect to view and manage your Genesis NFTs."
-      />
+      <div className="genesis-page">
+        {recoveriesLink}
+        <EmptyState
+          title="Connect your wallet"
+          description="Connect to view and manage your Genesis NFTs."
+        />
+      </div>
     );
   }
-  if (wallet && owned.isLoading) return <p className="dapp-loading">Loading Genesis NFTs…</p>;
-  if (wallet && owned.error) {
+  if (owned.isLoading) return <p className="dapp-loading">Loading Genesis NFTs…</p>;
+  if (owned.error) {
     return (
-      <EmptyState
-        title="Genesis data unavailable"
-        description={describeGenesisError(owned.error)}
-      />
+      <div className="genesis-page">
+        {recoveriesLink}
+        <EmptyState
+          title="Genesis data unavailable"
+          description={describeGenesisError(owned.error)}
+        />
+      </div>
     );
   }
-  return (
-    <div className="genesis-page standalone-genesis">
-      {epoch.data === false && (
-        <div className="portal-direction-tabs" role="tablist" aria-label="Genesis management view">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={view === "owned"}
-            onClick={() => setView("owned")}
-          >
-            Owned
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={view === "recoveries"}
-            onClick={() => setView("recoveries")}
-          >
-            Recoveries
-          </button>
-        </div>
-      )}
-      {view === "recoveries" && epoch.data === false ? (
-        <section aria-label="Recoverable Genesis credits">
-          {recoveryError && (
-            <p className="dapp-inline-error" role="alert">
-              {recoveryError}
-            </p>
-          )}
-          {recoveries.isLoading ? (
-            <p className="dapp-loading">Loading recoverable Genesis credits…</p>
-          ) : recoveries.error ? (
-            <p className="dapp-inline-error" role="alert">
-              Recovery discovery is temporarily unavailable because the deployment indexer could not
-              be reached. Owned Genesis management remains available.
-            </p>
-          ) : !recoveries.data?.length ? (
-            <EmptyState
-              title="No recoverable Genesis credits"
-              description="No indexed credit is currently eligible for permissionless recovery."
-            />
-          ) : (
-            <div className="genesis-grid">
-              {recoveries.data.map((credit) => (
-                <article className="ui-card genesis-card" key={credit.genesisId.toString()}>
-                  <h2 className="ui-section-title">Genesis #{credit.genesisId.toString()}</h2>
-                  <AddressDisplay
-                    address={credit.owner}
-                    chainId={deployment.descriptor.chainId}
-                    label="Previous owner"
-                  />
-                  <p>Principal: {formatEther(credit.principal)} STATICS</p>
-                  <p>Maturity: {displayTimestamp(credit.maturity)}</p>
-                  <p>Recoverable since: {displayTimestamp(credit.recoverableAt)}</p>
-                  <p>Unused credit: {formatEther(credit.unusedCredit)} STATICS</p>
-                  <p>Caller incentive: {formatEther(credit.callerIncentive)} STATICS</p>
-                  <p>Genesis distribution: {formatEther(credit.genesisDistribution)} STATICS</p>
-                  <button
-                    className="ui-button ui-button--primary ui-button--block"
-                    type="button"
-                    disabled={recoveryBusy !== null && recoveryBusy !== credit.genesisId}
-                    onClick={() => void recover(credit)}
-                  >
-                    {recoveryBusy === credit.genesisId
-                      ? "Recovering…"
-                      : `Recover Genesis #${credit.genesisId}`}
-                  </button>
-                </article>
-              ))}
+  if (!items.length) {
+    return (
+      <div className="genesis-page">
+        {recoveriesLink}
+        <EmptyState
+          title="No Genesis NFTs yet"
+          description={
+            vault.data
+              ? `${vault.data.circulatingGenesis} of ${vault.data.maximumSupply} Genesis NFTs are in circulation, each backed by ${formatTokenAmountGrouped(vault.data.vaultPrice, 18, 0)} STATICS.`
+              : "Acquire a fully backed Genesis NFT through the Vault."
+          }
+          action={{ label: "Acquire a Genesis NFT", href: "/app/swap?mode=nft" }}
+        />
+        {/* Rewards earned before a Genesis changed hands stay claimable by the
+            previous owner, so a wallet holding none of them still has somewhere
+            to collect from. */}
+        {(summary.ownerStatics > 0n || summary.ownerWeth > 0n) && (
+          <section className="ui-card genesis-panel" aria-label="Rewards from past ownership">
+            <div className="genesis-panel-head">
+              <h3>Rewards from past ownership</h3>
+              <p>
+                These accrued while you held a Genesis NFT that has since moved on. They remain
+                yours to claim.
+              </p>
             </div>
-          )}
-        </section>
-      ) : (
-        <>
-          {!wallet ? (
-            <EmptyState
-              title="Connect your wallet"
-              description="Connect to view and manage your Genesis NFTs."
-            />
-          ) : (
-            <>
-              <section
-                className="ui-card genesis-rewards-strip"
-                aria-label="Genesis launch rewards"
-              >
-                <div className="genesis-summary">
-                  <div className="ui-stat">
-                    <span className="ui-stat__label">Genesis reward share</span>
-                    <strong className="ui-stat__value">
-                      {Number(owned.data?.rewardShareBps ?? 0n) / 100}%
+            <ul className="genesis-claims">
+              {(
+                [
+                  [deployment.contracts.statics, "STATICS", summary.ownerStatics, 2],
+                  [deployment.contracts.weth, "WETH", summary.ownerWeth, 4],
+                ] as const
+              ).map(([asset, symbol, amount, digits]) => (
+                <li key={asset}>
+                  <div>
+                    <span>{symbol}</span>
+                    <strong className={amount === 0n ? "is-muted" : undefined}>
+                      {formatTokenAmountGrouped(amount, 18, digits)}
                     </strong>
                   </div>
-                  <div className="ui-stat">
-                    <span className="ui-stat__label">Total registered weight</span>
-                    <strong className="ui-stat__value">
-                      {(owned.data?.totalWeight ?? 0n).toString()}
-                    </strong>
-                  </div>
-                  <div className="ui-stat">
-                    <span className="ui-stat__label">Retained after transfer</span>
-                    <strong className="ui-stat__value">
-                      {formatEther(owned.data?.ownerStatics ?? 0n)} STATICS ·{" "}
-                      {formatEther(owned.data?.ownerWeth ?? 0n)} WETH
-                    </strong>
-                  </div>
-                </div>
-                <div className="ui-inline-actions">
                   <button
-                    className="ui-button ui-button--primary"
+                    className="ui-button ui-button--secondary ui-button--sm"
                     type="button"
-                    disabled={rewardsBusy !== null}
+                    disabled={busy !== null || amount === 0n}
                     onClick={() =>
-                      void sendReward(
-                        "accrue",
-                        "Update Genesis launch rewards",
-                        buildAccrueGenesisLaunchRewardsCall(),
-                        "Current market fees"
-                      )
-                    }
-                  >
-                    {rewardsBusy === "accrue" ? "Updating…" : "Update rewards"}
-                  </button>
-                  {(
-                    [
-                      [deployment.contracts.statics, "STATICS", owned.data?.ownerStatics ?? 0n],
-                      [deployment.contracts.weth, "WETH", owned.data?.ownerWeth ?? 0n],
-                    ] as const
-                  ).map(([asset, symbol, amount]) => (
-                    <button
-                      key={asset}
-                      className="ui-button ui-button--secondary"
-                      type="button"
-                      disabled={rewardsBusy !== null || amount === 0n}
-                      onClick={() =>
-                        void sendReward(
-                          `owner-${symbol}`,
+                      void act(`claim-owner-${symbol}`, () =>
+                        send(
+                          "claim-rewards",
                           `Claim previous-owner ${symbol} rewards`,
+                          deployment.contracts.launchDistributor,
                           buildClaimOwnerGenesisLaunchRewardsCall(asset, wallet),
                           symbol
                         )
+                      )
+                    }
+                  >
+                    {busy === `claim-owner-${symbol}` ? "Claiming…" : "Claim"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+            {error && (
+              <p className="dapp-inline-error" role="alert">
+                {error}
+              </p>
+            )}
+          </section>
+        )}
+      </div>
+    );
+  }
+
+  const targetTier = selected
+    ? (targetTiers[selected.id.toString()] ?? Math.min(GENESIS_MAX_TIER, selected.tier + 1))
+    : 0;
+  const activationCost = selected
+    ? cumulativeGenesisActivationCost(owned.data?.tierCosts ?? [], selected.tier, targetTier)
+    : 0n;
+
+  return (
+    <div className="genesis-page">
+      {recoveriesLink}
+      <section className="genesis-summary ui-card" aria-label="Your Genesis holdings">
+        <div className="ui-stat">
+          <span className="ui-stat__label">Genesis held</span>
+          <strong className="ui-stat__value">{items.length}</strong>
+          <small>
+            {summary.activated} activated · {summary.unregistered} not registered
+          </small>
+        </div>
+        <div className="ui-stat">
+          <span className="ui-stat__label">Backed by</span>
+          <strong className="ui-stat__value">
+            {vault.data
+              ? `${formatTokenAmountGrouped(vault.data.vaultPrice * BigInt(items.length), 18, 0)} STATICS`
+              : "—"}
+          </strong>
+          <small>
+            {vault.data ? `+ ${items.length}/${vault.data.maximumSupply} of ETH reserve` : ""}
+          </small>
+        </div>
+        <div className="ui-stat">
+          <span className="ui-stat__label">Claimable now</span>
+          <strong className="ui-stat__value is-accent">
+            {formatTokenAmountGrouped(summary.claimableStatics, 18, 2)} STATICS
+          </strong>
+          <small>
+            {formatTokenAmountGrouped(summary.claimableWeth, 18, 4)} WETH
+            {summary.ownerStatics > 0n || summary.ownerWeth > 0n
+              ? " · includes past ownership"
+              : ""}
+          </small>
+        </div>
+        <div className="ui-stat">
+          <span className="ui-stat__label">Credit outstanding</span>
+          <strong className={`ui-stat__value${summary.owed > 0n ? " is-warning" : ""}`}>
+            {summary.owed > 0n
+              ? `${formatTokenAmountGrouped(summary.owed, 18, 0)} STATICS`
+              : "None"}
+          </strong>
+          <small>
+            {summary.soonest
+              ? `${summary.creditCount} open · #${summary.soonest.id} due ${new Date(summary.soonest.creditMaturity * 1_000).toLocaleDateString()}`
+              : "Nothing to repay"}
+          </small>
+        </div>
+        <button
+          className="ui-button ui-button--primary"
+          type="button"
+          disabled={busy !== null || summary.claimCount === 0}
+          onClick={() => void act("claim-all", claimEverything)}
+        >
+          {busy === "claim-all"
+            ? `Claiming ${claimProgress ?? ""}…`
+            : summary.claimCount > 1
+              ? `Claim all · ${summary.claimCount} transactions`
+              : "Claim all"}
+        </button>
+      </section>
+
+      {error && (
+        <p className="dapp-inline-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <GenesisCarousel
+        items={items.map((item) => ({
+          id: item.id,
+          tier: item.tier,
+          registered: item.registered,
+          hasPendingRewards: item.pendingStatics > 0n || item.pendingWeth > 0n,
+          creditActive: item.creditActive,
+        }))}
+        selectedId={selected?.id ?? null}
+        onSelect={(id) => {
+          setSelectedId(id);
+          setError(null);
+        }}
+        chainId={deployment.descriptor.chainId}
+        collection={deployment.contracts.genesis}
+      />
+
+      {selected && (
+        <div className="genesis-detail">
+          <GenesisIdentityPanel
+            id={selected.id}
+            tier={selected.tier}
+            registered={selected.registered}
+            rewardWeight={selected.rewardWeight}
+            creditActive={selected.creditActive}
+            chainId={deployment.descriptor.chainId}
+            collection={deployment.contracts.genesis}
+            vaultPrice={vault.data?.vaultPrice ?? 0n}
+            maximumSupply={vault.data?.maximumSupply ?? 0n}
+          />
+
+          <div className="genesis-actions">
+            <div className="genesis-tabs" role="tablist" aria-label="Genesis actions">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "activate"}
+                onClick={() => setTab("activate")}
+              >
+                <b>Activate</b>
+                <small>
+                  {selected.tier === GENESIS_MAX_TIER
+                    ? "Top tier reached"
+                    : `Tier ${selected.tier} → ${targetTier}`}
+                </small>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "rewards"}
+                data-alert={
+                  !selected.registered || selected.pendingStatics > 0n || selected.pendingWeth > 0n
+                    ? "true"
+                    : undefined
+                }
+                onClick={() => setTab("rewards")}
+              >
+                <b>Rewards</b>
+                <small>
+                  {!selected.registered
+                    ? "Not registered"
+                    : `${formatTokenAmountGrouped(selected.pendingStatics, 18, 2)} STATICS pending`}
+                </small>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "credit"}
+                onClick={() => setTab("credit")}
+              >
+                <b>Credit</b>
+                <small>
+                  {selected.creditActive
+                    ? `${formatTokenAmountGrouped(selected.creditPrincipal, 18, 0)} owed`
+                    : vault.data?.epochActive
+                      ? "Opens after the Epoch"
+                      : "Borrow against backing"}
+                </small>
+              </button>
+            </div>
+
+            {tab === "activate" && (
+              <section className="ui-card genesis-panel" aria-label="Activation tier">
+                <div className="genesis-panel-head">
+                  <h3>Activation tier</h3>
+                  <p>
+                    A permanent multiplier on this NFT&apos;s share of launch rewards. Pay once and
+                    keep it, until the NFT changes hands.
+                  </p>
+                </div>
+                <GenesisTierLadder
+                  currentTier={selected.tier}
+                  targetTier={targetTier}
+                  tierCosts={owned.data?.tierCosts ?? []}
+                  disabled={busy !== null || selected.tier === GENESIS_MAX_TIER}
+                  onSelect={(tier) => {
+                    setTargetTiers((current) => ({ ...current, [selected.id.toString()]: tier }));
+                    setError(null);
+                  }}
+                />
+                {selected.tier < GENESIS_MAX_TIER ? (
+                  <>
+                    <dl className="genesis-figures">
+                      <div>
+                        <dt>Reward weight</dt>
+                        <dd>
+                          {genesisTierMultiplier(selected.tier).toFixed(2)}× →{" "}
+                          {genesisTierMultiplier(targetTier).toFixed(2)}×
+                        </dd>
+                      </div>
+                      <div className="is-total">
+                        <dt>You pay</dt>
+                        <dd>{formatTokenAmountGrouped(activationCost, 18, 0)} STATICS</dd>
+                      </div>
+                    </dl>
+                    <p className="genesis-note">
+                      <b>Paid to the Statics treasury.</b> STATICS is never burned — total supply is
+                      unchanged and this NFT&apos;s backing is untouched.
+                    </p>
+                    <p className="genesis-note is-warning">
+                      <b>Transferring resets this to Tier 0.</b> The next owner starts at 1.00×.
+                      Rewards you accrued before the transfer stay claimable by you.
+                    </p>
+                    <button
+                      className="ui-button ui-button--primary ui-button--block"
+                      type="button"
+                      disabled={busy !== null}
+                      onClick={() =>
+                        void act(`activate-${selected.id}`, () => activate(selected, targetTier))
                       }
                     >
-                      {rewardsBusy === `owner-${symbol}`
-                        ? "Claiming…"
-                        : `Claim ${symbol} from past ownership`}
+                      {busy === `activate-${selected.id}`
+                        ? "Confirming…"
+                        : `Activate to Tier ${targetTier} · ${formatTokenAmountGrouped(activationCost, 18, 0)} STATICS`}
                     </button>
-                  ))}
-                </div>
-                <p className="genesis-rewards-note">
-                  Updating rewards is permissionless: it harvests current market fees into the
-                  Genesis reward indexes. Rewards accrued before a Genesis is registered, or before
-                  an NFT changed hands, are not included.
-                </p>
-                {rewardsError && (
-                  <p className="dapp-inline-error" role="alert">
-                    {rewardsError}
+                  </>
+                ) : (
+                  <p className="genesis-note">
+                    <b>Tier 4 reached.</b> This Genesis earns the maximum 1.25× reward weight.
                   </p>
                 )}
               </section>
-              {!items.length ? (
-                <EmptyState
-                  title="No Genesis NFTs found"
-                  description="Use Swap → NFT to acquire a fully backed Genesis NFT."
-                />
-              ) : (
-                <>
-                  {items.length > 1 && (
-                    <div className="genesis-selector" role="tablist" aria-label="Your Genesis NFTs">
-                      {items.map((item) => {
-                        const isSelected = selected?.id === item.id;
-                        const hasPending = item.pendingStatics > 0n || item.pendingWeth > 0n;
-                        return (
-                          <button
-                            key={item.id.toString()}
-                            type="button"
-                            role="tab"
-                            aria-selected={isSelected}
-                            className="genesis-selector-chip"
-                            onClick={() => setSelectedKey(item.id.toString())}
-                          >
-                            <NftArtwork
-                              chainId={deployment.descriptor.chainId}
-                              nft={{
-                                kind: "collection",
-                                tokenId: item.id,
-                                contract: deployment.contracts.genesis,
-                                name: `Genesis #${item.id}`,
-                                summary: `Tier ${item.tier}`,
-                                carries: [],
-                                blockedReason: null,
-                              }}
-                            />
-                            <span>#{item.id.toString()}</span>
-                            <span className="genesis-selector-badges">
-                              {!item.registered && (
-                                <span className="ui-pill genesis-selector-badge">
-                                  Not registered
-                                </span>
-                              )}
-                              {hasPending && (
-                                <span className="ui-pill genesis-selector-badge">
-                                  Rewards pending
-                                </span>
-                              )}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                  {selected && (
-                    <article className="ui-card genesis-card">
-                      <div className="genesis-card-heading">
-                        <div>
-                          <h2 className="ui-section-title">Genesis #{selected.id.toString()}</h2>
-                          <span className="ui-pill">
-                            Tier {selected.tier} · {(selected.multiplierBps / 10_000).toFixed(2)}×
-                            reward weight
-                          </span>
-                        </div>
-                        <NftArtwork
-                          chainId={deployment.descriptor.chainId}
-                          expandable
-                          nft={{
-                            kind: "collection",
-                            tokenId: selected.id,
-                            contract: deployment.contracts.genesis,
-                            name: `Genesis #${selected.id}`,
-                            summary: `Tier ${selected.tier}`,
-                            carries: [],
-                            blockedReason: null,
-                          }}
-                        />
+            )}
+
+            {tab === "rewards" && (
+              <section className="ui-card genesis-panel" aria-label="Launch rewards">
+                <div className="genesis-panel-head">
+                  <h3>Launch rewards</h3>
+                  <p>
+                    Registered Genesis NFTs split {Number(owned.data?.rewardShareBps ?? 0n) / 100}%
+                    of market fees, weighted by activation tier.
+                  </p>
+                </div>
+
+                {!selected.registered ? (
+                  <>
+                    <p className="genesis-note is-warning">
+                      <b>This Genesis is earning nothing.</b> Register it to start taking a share of
+                      market fees at its current {genesisTierMultiplier(selected.tier).toFixed(2)}×
+                      weight.
+                    </p>
+                    <dl className="genesis-figures">
+                      <div>
+                        <dt>Weight once registered</dt>
+                        <dd>{selected.multiplierBps.toString()}</dd>
                       </div>
-                      {selected.tier < 4 && (
-                        <div className="genesis-action">
-                          <label className="ui-field">
-                            Activate through tier
-                            <select
-                              value={
-                                targetTiers[selected.id.toString()] ??
-                                Math.min(4, selected.tier + 1)
-                              }
-                              onChange={(event) =>
-                                setTargetTiers((current) => ({
-                                  ...current,
-                                  [selected.id.toString()]: Number(event.target.value),
-                                }))
-                              }
-                            >
-                              {[1, 2, 3, 4]
-                                .filter((tier) => tier > selected.tier)
-                                .map((tier) => (
-                                  <option key={tier} value={tier}>
-                                    Tier {tier}
-                                  </option>
-                                ))}
-                            </select>
-                          </label>
-                          <p>
-                            Activation cost:{" "}
-                            {formatEther(
-                              cumulativeGenesisActivationCost(
-                                owned.data?.tierCosts ?? [],
-                                selected.tier,
-                                targetTiers[selected.id.toString()] ??
-                                  Math.min(4, selected.tier + 1)
-                              )
-                            )}{" "}
-                            STATICS
-                          </p>
+                      <div>
+                        <dt>Total registered weight</dt>
+                        <dd>{(owned.data?.totalWeight ?? 0n).toString()}</dd>
+                      </div>
+                    </dl>
+                    <button
+                      className="ui-button ui-button--primary ui-button--block"
+                      type="button"
+                      disabled={busy !== null}
+                      onClick={() =>
+                        void act(`register-${selected.id}`, () =>
+                          send(
+                            "claim-rewards",
+                            `Register Genesis #${selected.id}`,
+                            deployment.contracts.launchDistributor,
+                            buildRegisterGenesisCall(selected.id),
+                            `Genesis #${selected.id}`
+                          )
+                        )
+                      }
+                    >
+                      {busy === `register-${selected.id}`
+                        ? "Registering…"
+                        : `Register Genesis #${selected.id} for rewards`}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <dl className="genesis-figures">
+                      <div>
+                        <dt>Your weight</dt>
+                        <dd>{selected.rewardWeight.toString()}</dd>
+                      </div>
+                      <div>
+                        <dt>Share of the pool</dt>
+                        <dd>
+                          {owned.data?.totalWeight
+                            ? `${((Number(selected.rewardWeight) / Number(owned.data.totalWeight)) * 100).toFixed(4)}%`
+                            : "—"}
+                        </dd>
+                      </div>
+                    </dl>
+                    <ul className="genesis-claims">
+                      {(
+                        [
+                          [deployment.contracts.statics, "STATICS", selected.pendingStatics, 2],
+                          [deployment.contracts.weth, "WETH", selected.pendingWeth, 4],
+                        ] as const
+                      ).map(([asset, symbol, amount, digits]) => (
+                        <li key={asset}>
+                          <div>
+                            <span>Pending {symbol}</span>
+                            <strong className={amount === 0n ? "is-muted" : undefined}>
+                              {formatTokenAmountGrouped(amount, 18, digits)}
+                            </strong>
+                          </div>
                           <button
-                            className="ui-button ui-button--primary ui-button--block"
+                            className="ui-button ui-button--secondary ui-button--sm"
                             type="button"
-                            disabled={busy !== null}
+                            disabled={busy !== null || amount === 0n}
                             onClick={() =>
-                              void activate(
-                                selected.id,
-                                selected.tier,
-                                targetTiers[selected.id.toString()] ??
-                                  Math.min(4, selected.tier + 1)
+                              void act(`claim-${selected.id}-${symbol}`, () =>
+                                send(
+                                  "claim-rewards",
+                                  `Claim Genesis #${selected.id} ${symbol} rewards`,
+                                  deployment.contracts.launchDistributor,
+                                  buildClaimGenesisLaunchRewardsCall(selected.id, asset, wallet),
+                                  symbol
+                                )
                               )
                             }
                           >
-                            {busy === selected.id ? "Confirming…" : "Activate"}
+                            {busy === `claim-${selected.id}-${symbol}` ? "Claiming…" : "Claim"}
                           </button>
-                          <p>Activation payments are transferred to the Statics treasury.</p>
-                        </div>
-                      )}
-                      <section
-                        className="genesis-rewards-block"
-                        aria-label="Genesis launch rewards"
-                      >
-                        <p className="dapp-eyebrow">Launch rewards</p>
-                        {!selected.registered ? (
-                          <>
-                            <button
-                              className="ui-button ui-button--secondary ui-button--block"
-                              type="button"
-                              disabled={rewardsBusy !== null}
-                              onClick={() =>
-                                void sendReward(
-                                  `register-${selected.id.toString()}`,
-                                  `Register Genesis #${selected.id}`,
-                                  buildRegisterGenesisCall(selected.id),
-                                  `Genesis #${selected.id}`
-                                )
-                              }
-                            >
-                              {rewardsBusy === `register-${selected.id.toString()}`
-                                ? "Registering…"
-                                : "Register for rewards"}
-                            </button>
-                            <p>
-                              Registration starts accruing from the current reward index with this
-                              NFT&apos;s activation weight. Fees earned before registration are not
-                              included.
-                            </p>
-                          </>
-                        ) : (
-                          <>
-                            <p>Effective reward weight: {selected.rewardWeight.toString()}</p>
-                            <p>
-                              Pending: {formatEther(selected.pendingStatics)} STATICS ·{" "}
-                              {formatEther(selected.pendingWeth)} WETH
-                            </p>
-                            <div className="ui-inline-actions">
-                              {(
-                                [
-                                  [
+                        </li>
+                      ))}
+                      {(summary.ownerStatics > 0n || summary.ownerWeth > 0n) && (
+                        <li>
+                          <div>
+                            <span>From Genesis you no longer own</span>
+                            <strong>
+                              {formatTokenAmountGrouped(summary.ownerStatics, 18, 2)} STATICS
+                            </strong>
+                          </div>
+                          <button
+                            className="ui-button ui-button--secondary ui-button--sm"
+                            type="button"
+                            disabled={busy !== null || summary.ownerStatics === 0n}
+                            onClick={() =>
+                              void act("claim-owner-statics", () =>
+                                send(
+                                  "claim-rewards",
+                                  "Claim previous-owner STATICS rewards",
+                                  deployment.contracts.launchDistributor,
+                                  buildClaimOwnerGenesisLaunchRewardsCall(
                                     deployment.contracts.statics,
-                                    "STATICS",
-                                    selected.pendingStatics,
-                                  ],
-                                  [deployment.contracts.weth, "WETH", selected.pendingWeth],
-                                ] as const
-                              ).map(([asset, symbol, amount]) => (
-                                <button
-                                  key={asset}
-                                  className="ui-button ui-button--secondary"
-                                  type="button"
-                                  disabled={rewardsBusy !== null || amount === 0n}
-                                  onClick={() =>
-                                    void sendReward(
-                                      `claim-${selected.id.toString()}-${symbol}`,
-                                      `Claim Genesis #${selected.id} ${symbol} rewards`,
-                                      buildClaimGenesisLaunchRewardsCall(
-                                        selected.id,
-                                        asset,
-                                        wallet
-                                      ),
-                                      symbol
-                                    )
-                                  }
-                                >
-                                  {rewardsBusy === `claim-${selected.id.toString()}-${symbol}`
-                                    ? "Claiming…"
-                                    : `Claim ${symbol}`}
-                                </button>
-                              ))}
-                            </div>
-                          </>
-                        )}
-                      </section>
-                      <GenesisCreditPanel deployment={deployment} genesisId={selected.id} />
-                      <p className="genesis-warning">
-                        Transferring this Genesis NFT resets its activation to Tier 0. Rewards
-                        earned before transfer remain claimable by the previous owner. Active
-                        secured credit locks transfers until repayment or recovery.
-                      </p>
-                      {error && (
-                        <p className="dapp-inline-error" role="alert">
-                          {error}
-                        </p>
+                                    wallet
+                                  ),
+                                  "STATICS"
+                                )
+                              )
+                            }
+                          >
+                            {busy === "claim-owner-statics" ? "Claiming…" : "Claim"}
+                          </button>
+                        </li>
                       )}
-                    </article>
-                  )}
-                </>
-              )}
-              <section className="genesis-contracts ui-card">
-                <AddressDisplay
-                  address={deployment.contracts.genesis}
-                  chainId={deployment.descriptor.chainId}
-                  label="Genesis NFT"
-                />
-                <AddressDisplay
-                  address={deployment.contracts.launchDistributor}
-                  chainId={deployment.descriptor.chainId}
-                  label="Rewards distributor"
-                />
-                <AddressDisplay
-                  address={deployment.contracts.activationRegistry}
-                  chainId={deployment.descriptor.chainId}
-                  label="Activation registry"
-                />
-                <AddressDisplay
-                  address={deployment.contracts.vault}
-                  chainId={deployment.descriptor.chainId}
-                  label="Genesis Vault"
-                />
+                    </ul>
+                  </>
+                )}
+
+                <p className="genesis-note">
+                  <b>Rewards accrue from the moment you register.</b> Fees collected before
+                  registration, or before this NFT changed hands, are not included.
+                </p>
+                <div className="genesis-maintenance">
+                  <button
+                    className="ui-button ui-button--ghost ui-button--sm"
+                    type="button"
+                    disabled={busy !== null}
+                    onClick={() =>
+                      void act("accrue", () =>
+                        send(
+                          "accrue-genesis-rewards",
+                          "Update Genesis launch rewards",
+                          deployment.contracts.launchDistributor,
+                          buildAccrueGenesisLaunchRewardsCall(),
+                          "Current market fees"
+                        )
+                      )
+                    }
+                  >
+                    {busy === "accrue" ? "Updating…" : "Harvest market fees into the reward index"}
+                  </button>
+                  <span>Anyone can run this</span>
+                </div>
               </section>
-            </>
-          )}
-        </>
+            )}
+
+            {tab === "credit" && (
+              <GenesisCreditPanel deployment={deployment} genesisId={selected.id} />
+            )}
+          </div>
+        </div>
       )}
+
+      <section className="genesis-contracts ui-card">
+        <AddressDisplay
+          address={deployment.contracts.genesis}
+          chainId={deployment.descriptor.chainId}
+          label="Genesis NFT"
+        />
+        <AddressDisplay
+          address={deployment.contracts.launchDistributor}
+          chainId={deployment.descriptor.chainId}
+          label="Rewards distributor"
+        />
+        <AddressDisplay
+          address={deployment.contracts.activationRegistry}
+          chainId={deployment.descriptor.chainId}
+          label="Activation registry"
+        />
+        <AddressDisplay
+          address={deployment.contracts.vault}
+          chainId={deployment.descriptor.chainId}
+          label="Genesis Vault"
+        />
+      </section>
     </div>
   );
 }

--- a/components/wallet/NftArtwork.tsx
+++ b/components/wallet/NftArtwork.tsx
@@ -22,10 +22,13 @@ export function NftArtwork({
   nft,
   chainId,
   expandable = false,
+  size = "sm",
 }: {
   nft: WalletNft;
   chainId: number;
   expandable?: boolean;
+  /** "sm" is the 48px corner thumbnail; "lg" fills its container. */
+  size?: "sm" | "lg";
 }) {
   const publicClient = usePublicClient({ chainId });
   const t = useTranslations("nftArtwork");
@@ -43,6 +46,8 @@ export function NftArtwork({
     },
   });
 
+  const sizeClass = size === "lg" ? " is-lg" : "";
+
   if (image.data && !failed) {
     const artwork = (
       /* eslint-disable-next-line @next/next/no-img-element --
@@ -50,7 +55,7 @@ export function NftArtwork({
          domain allow-listed up front, which is impossible for user-added
          contracts. */
       <img
-        className="wallet-nft-art"
+        className={`wallet-nft-art${sizeClass}`}
         src={image.data}
         alt=""
         loading="lazy"
@@ -61,7 +66,7 @@ export function NftArtwork({
     return (
       <>
         <button
-          className="wallet-nft-art-trigger"
+          className={`wallet-nft-art-trigger${sizeClass}`}
           type="button"
           aria-label={t("viewFullSize", { name: nft.name })}
           onClick={() => setViewerOpen(true)}
@@ -79,8 +84,8 @@ export function NftArtwork({
     nft.kind === "position" ? Boxes : nft.kind === "liquidity" ? Droplets : ImageIcon;
 
   return (
-    <span className="wallet-nft-art is-placeholder" aria-hidden="true">
-      <Placeholder size={20} />
+    <span className={`wallet-nft-art is-placeholder${sizeClass}`} aria-hidden="true">
+      <Placeholder size={size === "lg" ? 40 : 20} />
     </span>
   );
 }

--- a/docs/adr/network-aware-genesis-launch-application.md
+++ b/docs/adr/network-aware-genesis-launch-application.md
@@ -71,7 +71,11 @@ NFT mode is the Genesis Vault conversion surface:
 
 There is no Genesis inventory catalog and no user-facing pagination over 5,555 NFTs.
 
-Genesis management is the My Genesis destination, and it consolidates ownership, activation, credit, and launch rewards into one surface. A wallet-scoped strip carries permissionless reward accrual, previous-owner pull claims, and collection-wide reward totals. Each owned Genesis NFT is managed through a single dashboard card: artwork, activation tier and upgrade, reward registration, effective weight, pending current-holder claims, and post-Epoch secured credit. When a wallet owns several NFTs, a chip selector labeled with each token's registration and pending-reward state switches the dashboard between them; a single-NFT wallet needs no selector. After the Epoch the same destination also discovers permissionless recoverable credits through the deployment-scoped Ponder index; every indexed candidate is revalidated onchain before a recovery action. The former `/app/genesis-rewards` route redirects to `/app/genesis`.
+Genesis management is the My Genesis destination, and it consolidates ownership, activation, credit, and launch rewards into one surface. The destination opens with a wallet summary — holdings, aggregate backing, everything claimable, and any credit outstanding with its nearest maturity — before any single NFT. Owned NFTs are then a single-row carousel that pages horizontally rather than wrapping, each card carrying its artwork and a status flag for registration, pending rewards, and an active credit lock; past twelve NFTs a filterable grid replaces the carousel. The selected NFT splits into its identity — artwork at full size, derived traits read from the token metadata document, backing, and reward weight — and one action panel at a time behind an Activate / Rewards / Credit control, so each of the three decisions is presented on its own.
+
+Activation presents the whole tier ladder rather than a tier picker, because the multiplier curve flattens after the first tier and the trade-off is only legible when every rung is visible. Secured credit presents the term, the grace period, and the recoverable window as one timeline with a live position marker, and states the recovery consequence before the borrow control rather than after it.
+
+Permissionless recovery moved to `/app/genesis/recoveries`, its own destination: it is keeper work rather than Genesis ownership, and it remains reachable without owning a Genesis or connecting a wallet. Every indexed candidate is revalidated onchain before a recovery action. The former `/app/genesis-rewards` route redirects to `/app/genesis`.
 
 ### Event-derived Genesis indexing
 
@@ -114,8 +118,9 @@ create a user-visible deployment mode, replace pages, or disable canonical swaps
 4. NFT acquisition rechecks that the displayed token is still Vault inventory before submitting.
 5. Genesis redemption remains subject to ownership, approval, activation-lock, and backing checks.
 6. Mainnet, testnet, and local-fork indexed records cannot collide.
-7. Launch primary navigation is Overview, Trade, and My Genesis; contextual Wallet, Activity, and Approval Tools remain reachable; unsupported known full-protocol URLs replace to `/app`, unknown paths remain 404s, and full-protocol stage restores the complete catalog.
-8. Local-fork support cannot be enabled outside development or against a non-loopback RPC.
+7. Launch primary navigation is Overview, Trade, and My Genesis; contextual Wallet, Activity, Approval Tools, and Genesis recoveries remain reachable; unsupported known full-protocol URLs replace to `/app`, unknown paths remain 404s, and full-protocol stage restores the complete catalog.
+8. Every dapp route states its own name and purpose; the route header is not reserved for the overview.
+9. Local-fork support cannot be enabled outside development or against a non-loopback RPC.
 
 ## Consequences
 

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -6,7 +6,7 @@ export type DappRouteCapability = DeploymentCapability;
 export function getDappRouteCapability(pathname: string): DappRouteCapability | null {
   if (pathname === "/app" || pathname === "/app/") return "overview";
   if (pathname === "/app/swap") return "canonical-statics-market";
-  if (pathname === "/app/genesis") return "genesis-vault";
+  if (pathname === "/app/genesis" || pathname === "/app/genesis/recoveries") return "genesis-vault";
   if (pathname === "/app/wallet" || pathname === "/app/portal") return "wallet";
   if (pathname === "/app/activity") return "activity";
   if (pathname === "/app/tools") return "approval-tools";
@@ -130,6 +130,13 @@ const routePresentations = {
     description:
       "Activate a Genesis NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
   },
+  genesisRecoveries: {
+    label: "Recoveries",
+    status: "Genesis recoveries",
+    title: "Recover matured Genesis credit",
+    description:
+      "Find Genesis NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive.",
+  },
   liquidity: {
     label: "Liquidity",
     status: "Liquidity",
@@ -172,6 +179,8 @@ export function getDappRouteId(pathname: string): DappRouteId {
   if (pathname.startsWith("/app/positions")) return "positions";
   if (pathname.startsWith("/app/loans")) return "loans";
   if (pathname.startsWith("/app/rewards")) return "rewards";
+  // Ordered before the /app/genesis prefix, which would otherwise swallow it.
+  if (pathname.startsWith("/app/genesis/recoveries")) return "genesisRecoveries";
   if (pathname.startsWith("/app/genesis")) return "genesis";
   if (pathname.startsWith("/app/liquidity")) return "liquidity";
   if (pathname.startsWith("/app/activity")) return "activity";

--- a/lib/protocol/ux.ts
+++ b/lib/protocol/ux.ts
@@ -27,6 +27,24 @@ export function parseRecipientAddress(input: string, rejectZero = true): Address
   return rejectZero && address === zeroAddress ? null : address;
 }
 
+/**
+ * `formatTokenAmount` with thousands separators.
+ *
+ * Genesis figures are five and six digits wide -- 180,000 backing, 171,000
+ * credit, 100,000 to reach the top tier -- and are read as quantities rather
+ * than parsed character by character, so they group. Machine data (addresses,
+ * hashes, calldata) keeps the ungrouped form.
+ */
+export function formatTokenAmountGrouped(
+  value: bigint,
+  decimals: number,
+  fractionDigits = 2
+): string {
+  const [whole, fraction] = formatTokenAmount(value, decimals, fractionDigits).split(".");
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return fraction ? `${grouped}.${fraction}` : grouped;
+}
+
 export function formatTokenAmount(value: bigint, decimals: number, fractionDigits = 6): string {
   const negative = value < 0n;
   const absolute = negative ? -value : value;

--- a/lib/wallet/nft-image.ts
+++ b/lib/wallet/nft-image.ts
@@ -49,6 +49,103 @@ function imageFromMetadata(metadata: unknown): string | null {
   return typeof candidate === "string" && candidate.trim() ? resolveUri(candidate) : null;
 }
 
+/** One entry of an ERC-721 metadata `attributes` array. */
+export type NftTrait = Readonly<{
+  label: string;
+  value: string;
+  /** Set when the trait declares `display_type: "number"`, as tiers do. */
+  max: number | null;
+}>;
+
+export type NftMetadata = Readonly<{
+  image: string | null;
+  traits: readonly NftTrait[];
+}>;
+
+const EMPTY_METADATA: NftMetadata = { image: null, traits: [] };
+
+/**
+ * Reads the `attributes` array, tolerating every shape a collection might use.
+ *
+ * Statics Genesis returns eight string traits plus a numeric Activation Tier
+ * carrying a `max_value`. Arbitrary collections return anything at all, so a
+ * malformed entry is skipped rather than failing the whole list -- artwork must
+ * still render when the traits beside it are unusable.
+ */
+function traitsFromMetadata(metadata: unknown): readonly NftTrait[] {
+  if (typeof metadata !== "object" || metadata === null) return [];
+  const attributes = (metadata as { attributes?: unknown }).attributes;
+  if (!Array.isArray(attributes)) return [];
+
+  const traits: NftTrait[] = [];
+  for (const entry of attributes) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    const label = typeof record.trait_type === "string" ? record.trait_type.trim() : "";
+    const rawValue = record.value;
+    if (!label) continue;
+    if (typeof rawValue !== "string" && typeof rawValue !== "number") continue;
+    const value = String(rawValue).trim();
+    if (!value) continue;
+    const rawMax = record.max_value;
+    traits.push({
+      label,
+      value,
+      max: typeof rawMax === "number" && Number.isFinite(rawMax) ? rawMax : null,
+    });
+  }
+  return traits;
+}
+
+/**
+ * Reads a token's metadata once and returns both its artwork and its traits.
+ *
+ * The traits come free with the image: the metadata document is already
+ * decoded to find `image`, so surfacing `attributes` costs no extra RPC and no
+ * extra fetch. Never throws, for the same reason `resolveNftImage` does not.
+ */
+export async function resolveNftMetadata(
+  publicClient: PublicClient,
+  contract: Address,
+  tokenId: bigint,
+  signal?: AbortSignal
+): Promise<NftMetadata> {
+  let uri: string;
+  try {
+    uri = await publicClient.readContract({
+      address: contract,
+      abi: tokenUriAbi,
+      functionName: "tokenURI",
+      args: [tokenId],
+    });
+  } catch {
+    return EMPTY_METADATA;
+  }
+
+  // Missing metadata is valid for arbitrary user-added collections.
+  if (!uri || !uri.trim()) return EMPTY_METADATA;
+
+  if (uri.startsWith("data:")) {
+    const metadata = decodeDataUri(uri);
+    return { image: imageFromMetadata(metadata), traits: traitsFromMetadata(metadata) };
+  }
+
+  const resolved = resolveUri(uri);
+  if (!/^https?:\/\//i.test(resolved)) return EMPTY_METADATA;
+
+  try {
+    const response = await fetch(resolved, { signal });
+    if (!response.ok) return EMPTY_METADATA;
+    const contentType = response.headers.get("content-type") ?? "";
+    // Some collections point tokenURI straight at an image rather than JSON.
+    if (contentType.startsWith("image/")) return { image: resolved, traits: [] };
+    const metadata: unknown = await response.json();
+    return { image: imageFromMetadata(metadata), traits: traitsFromMetadata(metadata) };
+  } catch {
+    return EMPTY_METADATA;
+  }
+}
+
 /**
  * Reads a token's metadata and returns its image URL, or null.
  *
@@ -62,34 +159,6 @@ export async function resolveNftImage(
   tokenId: bigint,
   signal?: AbortSignal
 ): Promise<string | null> {
-  let uri: string;
-  try {
-    uri = await publicClient.readContract({
-      address: contract,
-      abi: tokenUriAbi,
-      functionName: "tokenURI",
-      args: [tokenId],
-    });
-  } catch {
-    return null;
-  }
-
-  // Missing metadata is valid for arbitrary user-added collections.
-  if (!uri || !uri.trim()) return null;
-
-  if (uri.startsWith("data:")) return imageFromMetadata(decodeDataUri(uri));
-
-  const resolved = resolveUri(uri);
-  if (!/^https?:\/\//i.test(resolved)) return null;
-
-  try {
-    const response = await fetch(resolved, { signal });
-    if (!response.ok) return null;
-    const contentType = response.headers.get("content-type") ?? "";
-    // Some collections point tokenURI straight at an image rather than JSON.
-    if (contentType.startsWith("image/")) return resolved;
-    return imageFromMetadata(await response.json());
-  } catch {
-    return null;
-  }
+  const metadata = await resolveNftMetadata(publicClient, contract, tokenId, signal);
+  return metadata.image;
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -160,6 +160,12 @@
       "title": "Manage your Genesis NFTs",
       "description": "View Genesis artwork, activate reward tiers with STATICS payments, and manage each NFT's protocol features."
     },
+    "genesisRecoveries": {
+      "label": "Recoveries",
+      "status": "Genesis recoveries",
+      "title": "Recover matured Genesis credit",
+      "description": "Find Genesis NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive."
+    },
     "liquidity": {
       "label": "Liquidity",
       "status": "Liquidity",

--- a/messages/es.json
+++ b/messages/es.json
@@ -160,6 +160,12 @@
       "title": "Gestiona tus Genesis NFTs",
       "description": "Consulta el arte de Genesis, activa niveles de recompensa mediante pagos en STATICS y gestiona las funciones de cada NFT."
     },
+    "genesisRecoveries": {
+      "label": "Recuperaciones",
+      "status": "Recuperaciones de Genesis",
+      "title": "Recupera crédito Genesis vencido",
+      "description": "Encuentra NFT Genesis cuyo crédito garantizado superó su plazo y recupera uno para ganar el incentivo de quien lo ejecuta."
+    },
     "liquidity": {
       "label": "Liquidez",
       "status": "Liquidez",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -160,6 +160,12 @@
       "title": "管理你的 Genesis NFTs",
       "description": "查看 Genesis 艺术作品，通过支付 STATICS 激活奖励等级，并管理每个 NFT 的协议功能。"
     },
+    "genesisRecoveries": {
+      "label": "回收",
+      "status": "Genesis 回收",
+      "title": "回收已到期的 Genesis 信贷",
+      "description": "查找担保信贷已超过期限的 Genesis NFT，回收其中一个即可获得执行者奖励。"
+    },
     "liquidity": {
       "label": "流动性",
       "status": "流动性",

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@/test/render";
+import { fireEvent, render, screen, waitFor, within } from "@/test/render";
 import { getAddress, parseEther, zeroAddress } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,6 +31,13 @@ vi.mock("@/lib/genesis/discovery", () => ({
 }));
 vi.mock("@/lib/wallet/nft-image", () => ({
   resolveNftImage: vi.fn().mockResolvedValue("data:image/svg+xml,%3Csvg/%3E"),
+  resolveNftMetadata: vi.fn().mockResolvedValue({
+    image: "data:image/svg+xml,%3Csvg/%3E",
+    traits: [
+      { label: "Field", value: "Quiescent", max: null },
+      { label: "Activation Tier", value: "2", max: 4 },
+    ],
+  }),
 }));
 const discoverWalletGenesisIds = vi.fn();
 
@@ -187,32 +194,51 @@ describe("Genesis credit presentation", () => {
     });
   }
 
-  it("shows the exact Epoch end and no borrow controls during the Epoch", async () => {
+  it("shows when the Epoch ends and no borrow controls during the Epoch", async () => {
     creditReads(true, false);
     renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
 
-    expect(await screen.findByText(/maximum principal is 171000 STATICS/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Borrow STATICS" })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Borrow STATICS")).not.toBeInTheDocument();
+    expect(await screen.findByText(/borrow up to 171,000 STATICS/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Borrow/ })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Amount to borrow")).not.toBeInTheDocument();
   });
 
   it("shows post-Epoch borrow controls when originations are open", async () => {
     creditReads(false, false);
     renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
 
-    expect(await screen.findByRole("button", { name: "Borrow STATICS" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Borrow STATICS")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /^Borrow/ })).toBeInTheDocument();
+    expect(screen.getByLabelText("Amount to borrow")).toBeInTheDocument();
+  });
+
+  it("states the recovery consequence before any borrow is confirmed", async () => {
+    creditReads(false, false);
+    renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
+
+    expect(await screen.findByText(/Miss the deadline and you lose the NFT/i)).toBeInTheDocument();
+    expect(screen.getByText("Recoverable")).toBeInTheDocument();
+    expect(screen.getByText("1h grace")).toBeInTheDocument();
+  });
+
+  it("caps the borrow amount at this Genesis credit limit", async () => {
+    creditReads(false, false);
+    renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
+
+    const exact = await screen.findByLabelText("Or enter an exact amount");
+    fireEvent.change(exact, { target: { value: "900000" } });
+
+    expect(
+      await screen.findByRole("button", { name: "Borrow 171,000 STATICS" })
+    ).toBeInTheDocument();
   });
 
   it("shows only pause status when post-Epoch originations are paused", async () => {
     creditReads(false, true);
     renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
 
-    expect(
-      await screen.findByText("New Genesis credit is temporarily paused.")
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Borrow STATICS" })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Borrow STATICS")).not.toBeInTheDocument();
+    expect(await screen.findByText(/New Genesis credit is temporarily paused/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Borrow/ })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Amount to borrow")).not.toBeInTheDocument();
   });
 });
 
@@ -222,7 +248,7 @@ describe("Genesis recovery navigation", () => {
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />, false);
 
     await waitFor(() => expect(readContract).toHaveBeenCalled());
-    expect(screen.queryByRole("tab", { name: "Recoveries" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Recover matured/ })).not.toBeInTheDocument();
   });
 
   it("exposes Recoveries after the Genesis Epoch without requiring an owned NFT", async () => {
@@ -231,7 +257,10 @@ describe("Genesis recovery navigation", () => {
     loadRecoverableGenesisCredits.mockResolvedValue([]);
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />, false);
 
-    expect(await screen.findByRole("tab", { name: "Recoveries" })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: /Recover matured/ })).toHaveAttribute(
+      "href",
+      "/app/genesis/recoveries"
+    );
   });
 });
 
@@ -270,32 +299,69 @@ describe("consolidated Genesis rewards surface", () => {
     );
   }
 
-  it("shows the wallet-global reward strip and manages the selected NFT", async () => {
+  it("summarises the whole wallet before any single NFT", async () => {
     rewardsReads();
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
 
-    expect(await screen.findByText("Genesis reward share")).toBeInTheDocument();
-    expect(screen.getByText("10%")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update rewards" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Claim STATICS from past ownership" })
-    ).toHaveProperty("disabled", false);
-
-    expect(await screen.findByText("Effective reward weight: 12500")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Claim STATICS" })).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("tab", { name: /#2/ }));
-    expect(await screen.findByRole("button", { name: "Register for rewards" })).toBeInTheDocument();
-    expect(screen.queryByText("Effective reward weight: 12500")).not.toBeInTheDocument();
+    expect(await screen.findByText("Genesis held")).toBeInTheDocument();
+    // Two NFTs at 2 STATICS each, plus 5 STATICS retained from past ownership.
+    expect(screen.getByText("Claimable now").closest(".ui-stat")).toHaveTextContent("9 STATICS");
+    expect(screen.getByText("Credit outstanding").closest(".ui-stat")).toHaveTextContent(
+      "Nothing to repay"
+    );
   });
 
-  it("keeps the permissionless strip usable with no owned NFTs", async () => {
+  it("states the claim transaction count rather than hiding it", async () => {
+    rewardsReads();
+    renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
+
+    // Two assets on each of two NFTs, plus both past-ownership assets.
+    expect(
+      await screen.findByRole("button", { name: "Claim all · 6 transactions" })
+    ).toBeInTheDocument();
+  });
+
+  it("manages the selected NFT and switches between them", async () => {
+    rewardsReads();
+    renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /^Rewards/ }));
+    expect(await screen.findByText("Your weight")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Claim" }).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("tab", { name: /Genesis #2/ }));
+    expect(
+      await screen.findByRole("button", { name: "Register Genesis #2 for rewards" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the activation ladder in full rather than a bare tier picker", async () => {
+    rewardsReads();
+    renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
+
+    const ladder = await screen.findByRole("list", { name: "Activation tiers" });
+    expect(within(ladder).getByText("Tier 0")).toBeInTheDocument();
+    expect(within(ladder).getByText("Tier 4")).toBeInTheDocument();
+    expect(within(ladder).getByText("You are here")).toBeInTheDocument();
+    expect(within(ladder).getByText("1.25× reward weight")).toBeInTheDocument();
+  });
+
+  it("never describes activation as burning STATICS", async () => {
+    rewardsReads();
+    renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
+
+    expect(await screen.findByText(/Paid to the Statics treasury/)).toBeInTheDocument();
+    expect(screen.queryByText(/burn cost/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps past-ownership rewards claimable when the wallet owns no Genesis", async () => {
     rewardsReads();
     discoverWalletGenesisIds.mockResolvedValue([]);
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
 
-    expect(await screen.findByText("No Genesis NFTs found")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update rewards" })).toBeInTheDocument();
-    expect(screen.queryByRole("tab", { name: /#1/ })).not.toBeInTheDocument();
+    expect(await screen.findByText("No Genesis NFTs yet")).toBeInTheDocument();
+    expect(screen.getByText("Rewards from past ownership")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Claim" })).toHaveLength(2);
+    expect(screen.queryByRole("tab", { name: /Genesis #1/ })).not.toBeInTheDocument();
   });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,4 +3,18 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+/**
+ * jsdom implements no layout, and so ships no ResizeObserver. Components that
+ * measure themselves -- the Genesis carousel decides whether it can still page
+ * -- would otherwise throw on mount. The stub reports nothing, which matches
+ * the zero-sized boxes jsdom already reports everywhere else.
+ */
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
 afterEach(() => cleanup());


### PR DESCRIPTION
Stacked on #30. Review that first — this branches from its head, and the diff below is only the redesign.

## Why

`/app/genesis` opened with no heading, three collection-wide numbers, and a 180,000-STATICS collectible rendered at 48 pixels in the corner of a card. Four unrelated decisions — upgrade a tier, register for fees, claim, borrow against the backing — stacked into one scrolling column in a layout that was mostly empty to the right.

## What changed

**The wallet comes first.** Holdings, aggregate backing, everything claimable, and credit outstanding with its nearest maturity — before any single NFT. The global constants that used to open the page (reward share, total registered weight) moved into the Rewards panel where they are context for a number you have already seen.

**Owned NFTs are a paged carousel**, six across, that never wraps to a second row. `.genesis-selector` was `flex-wrap: wrap`: at twelve NFTs it became three ragged rows that pushed the content below the fold and reflowed whenever a badge appeared. Each card carries its artwork and a status flag for registration, pending rewards, and a transfer lock. Past twelve NFTs a filterable grid takes over — paging six at a time through sixty is worse than the wrap it replaced.

**The asset gets a column.** Artwork at full size, and the eight traits the renderer already emits — Field, Boundary, Shell, Interface, Mantle, Telemetry, Sigil, Signal — which the page previously decoded and discarded. No extra RPC: `resolveNftMetadata` returns `attributes` alongside `image` from the same tokenURI document.

**One action panel at a time**, behind an Activate / Rewards / Credit control.

- *Activate* draws the whole tier ladder rather than a `<select>`. The multiplier curve flattens after Tier 1, so the last 0.05× costs 40,000 STATICS — only weighable when every rung is visible.
- *Credit* draws the term, the grace hour, and the recoverable window as one timeline with a live position marker, and states the consequence **before** the borrow control. `MAX_CREDIT_PRINCIPAL` is 171,000 against 180,000 backing on a 30-day term; the UI previously expressed the default path as `<p>Recovery available: 3/14/2026, 4:05:12 PM</p>`.

**Recovery moved to `/app/genesis/recoveries`.** Hunting other people's defaulted credit is keeper work, and it was the first tab every holder had to step past to reach their own NFTs. It stays reachable without owning a Genesis or connecting a wallet, as before.

## Two things reviewers should push back on if they disagree

**`Claim all` is labelled with its transaction count.** `GenesisLaunchDistributor` exposes no batch claim and no multicall, so a wallet with several NFTs signs once per NFT and asset. Rather than a button that quietly fires 24 wallet prompts, it reads `Claim all · 6 transactions`. If that is the wrong trade, the alternative is dropping the button and leaving the aggregate as a read-only figure.

**The route header change touches every route** (`6b752ad`, split out deliberately). It is the only `<h1>` in the dapp and it was gated to `/app`, so every other destination shipped without one — an accessibility defect app-wide, not just here. Reverting that commit alone leaves the rest of this PR working, minus the Genesis heading.

## Also fixed

`GenesisPage` described activation as burning STATICS ("Burned STATICS; resets on transfer", "Burn cost"). `GenesisActivationRegistry` states the opposite in its own header comment: the payment forwards in full to the treasury and total supply is never reduced. The launch page was already correct; the protocol page contradicted it.

## Validation

- `npm test` — 103 files, 548 tests passed (was 542; 6 net new covering the carousel, the ladder, the claim count, the recovery consequence, and past-ownership claims for a wallet holding no Genesis).
- `npm run typecheck` — passed.
- `npm run lint` — passed; one pre-existing simulator warning.
- `npm run lint:css` — passed.
- `npm run format:check` — passed.
- `npm run build` — passed; `/app/genesis/recoveries` registered.

Not run: `npm run verify:genesis-launch-fork`. This changes presentation only — no call, ABI, or transaction shape moved — but the fork harness is the right gate before merge and I have not driven it.

## Regressions caught and fixed while restructuring

- A wallet owning no Genesis but holding `ownerClaimable` rewards from a since-transferred NFT could no longer reach them; the empty state now carries those claims.
- The recoveries entry point sat below the wallet gate, so signed-out users lost the access they had before; it now renders above it.

https://claude.ai/code/session_01CXJpvfPVqtsSDDgYKRarXd