### PR TITLE
feat(overview): build the launch Overview around the Epoch

### DIFF
--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -626,18 +626,537 @@
   font-size: var(--text-caption);
 }
 
-.launch-overview,
-.launch-overview-hero,
+.launch-overview {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .launch-overview-actions {
   display: grid;
   gap: 1rem;
 }
 
-.launch-overview-hero h2,
-.launch-overview-hero p,
 .launch-overview-actions h2,
 .launch-overview-actions p {
   margin: 0;
+}
+
+/* ---- Epoch banner ---------------------------------------------------
+ * The deadline is the launch's one time-critical fact, so it leads the
+ * page rather than sitting as one tile among nine. */
+
+.epoch-banner {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(120% 140% at 12% 0%, var(--accent-wash), transparent 62%),
+    linear-gradient(180deg, var(--app-raised), var(--app-surface));
+}
+
+.epoch-banner.is-complete {
+  background: linear-gradient(180deg, var(--app-raised), var(--app-surface));
+}
+
+.epoch-banner-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem 2rem;
+}
+
+.epoch-banner-label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.epoch-banner-label h2 {
+  margin: 0;
+  font-size: var(--text-2xl);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: var(--leading-tight);
+}
+
+.epoch-banner-label > p:last-child {
+  margin: 0;
+  max-width: 46ch;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.epoch-countdown {
+  margin-left: auto;
+  text-align: right;
+}
+
+.epoch-countdown-figure {
+  display: flex;
+  gap: 0.875rem;
+  justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+
+.epoch-countdown-figure > div {
+  display: grid;
+  gap: 0.1rem;
+  text-align: center;
+}
+
+.epoch-countdown-figure b {
+  color: var(--accent);
+  font-size: var(--text-4xl);
+  font-weight: 650;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.epoch-banner.is-complete .epoch-countdown-figure b {
+  color: var(--app-text-muted);
+}
+
+.epoch-countdown-figure span {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.epoch-countdown-when {
+  margin: 0.4rem 0 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+}
+
+.epoch-changes {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.epoch-change {
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+  padding: 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.epoch-change-primary,
+.epoch-change-secondary {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.epoch-change-primary {
+  font-weight: 600;
+}
+
+.epoch-banner.is-complete .epoch-change-secondary b.is-past {
+  color: var(--app-text-muted);
+  text-decoration: line-through;
+}
+
+.epoch-change-secondary span {
+  color: var(--app-text-muted);
+}
+
+.epoch-change-secondary b.is-next {
+  color: var(--accent);
+}
+
+.epoch-change-caveat {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  line-height: var(--leading-snug);
+}
+
+/* ---- Launch actions and position ------------------------------------- */
+
+.launch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+}
+
+.launch-actions .ui-button {
+  flex-direction: column;
+  gap: 0.1rem;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 3.25rem;
+}
+
+.launch-actions .ui-button small {
+  font-weight: 400;
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
+}
+
+.launch-position {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.launch-position.is-signed-out {
+  grid-template-columns: 1fr auto;
+}
+
+.launch-position.is-signed-out strong {
+  display: block;
+  font-size: var(--text-base);
+  font-weight: 620;
+}
+
+.launch-position.is-signed-out p {
+  margin: 0.2rem 0 0;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.launch-position .ui-stat {
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.launch-position .ui-stat__value {
+  font-size: var(--text-lg);
+  overflow-wrap: anywhere;
+}
+
+.launch-position .ui-stat__value.is-accent {
+  color: var(--accent);
+}
+
+.launch-position .ui-stat small {
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- Supply and market ------------------------------------------------ */
+
+.launch-duo {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+.overview-panel {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.overview-panel-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.overview-panel-head h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 640;
+}
+
+.overview-panel-head span {
+  margin-left: auto;
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-panel-head span.is-accent {
+  color: var(--accent);
+}
+
+.overview-panel-head span.is-negative {
+  color: var(--negative);
+}
+
+.overview-figure {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-figure b {
+  font-size: var(--text-3xl);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+}
+
+.overview-figure span {
+  color: var(--app-text-muted);
+  font-size: var(--text-sm);
+}
+
+.supply-bar {
+  display: flex;
+  height: 12px;
+  border-radius: var(--radius-pill);
+  background: var(--app-sunken);
+  overflow: hidden;
+}
+
+.supply-bar i {
+  display: block;
+  height: 100%;
+}
+
+.supply-bar i.is-treasury,
+.supply-key i.is-treasury {
+  background: var(--app-border-strong);
+}
+
+.supply-bar i.is-circulating,
+.supply-key i.is-circulating {
+  background: var(--accent);
+}
+
+.supply-bar i.is-inventory,
+.supply-key i.is-inventory {
+  background: var(--app-overlay);
+}
+
+.supply-key {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.supply-key > div {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+}
+
+.supply-key dt {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--app-text-secondary);
+}
+
+.supply-key i {
+  display: block;
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border-radius: var(--radius-sm);
+}
+
+.supply-key dd {
+  margin: 0 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-rows {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.overview-rows > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--app-sunken);
+  font-size: var(--text-sm);
+}
+
+.overview-rows dt {
+  color: var(--app-text-secondary);
+}
+
+.overview-rows dd {
+  margin: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-rows > div.is-total {
+  background: var(--app-raised);
+}
+
+.overview-rows > div.is-total dd {
+  color: var(--accent);
+  font-size: var(--text-base);
+}
+
+.overview-note {
+  margin: 0;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+  color: var(--app-text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.overview-note b {
+  color: var(--app-text);
+}
+
+/* ---- Solvency ---------------------------------------------------------- */
+
+.solvency-checks {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.solvency-checks li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.875rem;
+  align-items: center;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.solvency-mark {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent-wash);
+  color: var(--accent);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.solvency-checks li.is-failing .solvency-mark {
+  background: var(--negative-wash);
+  color: var(--negative);
+}
+
+.solvency-body {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.solvency-body strong {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.solvency-body > span {
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.solvency-surplus {
+  color: var(--accent);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.solvency-checks li.is-failing .solvency-surplus {
+  color: var(--negative);
+}
+
+.solvency-reconcile {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.solvency-reconcile > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.solvency-reconcile dt {
+  color: var(--app-text-secondary);
+}
+
+.solvency-reconcile dd {
+  margin: 0;
+}
+
+.solvency-reconcile > div.is-total {
+  padding-top: 0.4rem;
+  border-top: 1px solid var(--app-border);
+}
+
+.solvency-reconcile > div.is-total dd {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .launch-duo,
+  .epoch-changes {
+    grid-template-columns: 1fr;
+  }
+
+  .launch-position {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .launch-position > .ui-button {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 560px) {
+  .launch-position,
+  .launch-position.is-signed-out {
+    grid-template-columns: 1fr;
+  }
+
+  .epoch-countdown {
+    margin-left: 0;
+    text-align: left;
+  }
+
+  .epoch-countdown-figure {
+    justify-content: flex-start;
+  }
+
+  .solvency-checks li {
+    grid-template-columns: auto 1fr;
+  }
+
+  .solvency-surplus {
+    grid-column: 2;
+    text-align: left;
+  }
 }
 
 .locale-switcher--dapp-mobile {

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -14,9 +14,7 @@ import {
   cumulativeGenesisActivationCost,
   dopplerStaticsTokenAbi,
   genesisActivationRegistryAbi,
-  genesisLaunchDistributorAbi,
 } from "@statics-protocol/sdk";
-import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
 
 import { EmptyState } from "@/components/common/EmptyState";
 import { GenesisCarousel } from "@/components/genesis/GenesisCarousel";
@@ -32,7 +30,13 @@ import type { LaunchDeployment } from "@/lib/deployments/types";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
 import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
-import { discoverWalletGenesisIds } from "@/lib/genesis/discovery";
+import {
+  EMPTY_GENESIS_PORTFOLIO,
+  loadOwnedGenesis,
+  ownedGenesisQueryKey,
+  summariseGenesisRewards,
+  type OwnedGenesis,
+} from "@/lib/genesis/owned";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
@@ -47,19 +51,6 @@ function describeGenesisError(error: unknown): string {
   if (message.includes("NoRewards")) return "There is nothing to claim for that asset yet.";
   return message || "The Genesis transaction failed.";
 }
-
-type OwnedGenesis = Readonly<{
-  id: bigint;
-  tier: number;
-  multiplierBps: number;
-  registered: boolean;
-  rewardWeight: bigint;
-  pendingStatics: bigint;
-  pendingWeth: bigint;
-  creditActive: boolean;
-  creditPrincipal: bigint;
-  creditMaturity: number;
-}>;
 
 type ActionTab = "activate" | "rewards" | "credit";
 
@@ -97,129 +88,13 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     },
   });
 
+  // Shared with the Overview: same key, same fetcher, one walk of the wallet.
   const owned = useQuery({
-    queryKey: ["launch-genesis-owned", deployment.descriptor.deploymentId, wallet],
+    queryKey: ownedGenesisQueryKey(deployment.descriptor.deploymentId, wallet),
     enabled: Boolean(publicClient && wallet),
     queryFn: async () => {
-      if (!publicClient || !wallet) {
-        return {
-          items: [] as readonly OwnedGenesis[],
-          tierCosts: [] as readonly bigint[],
-          rewardShareBps: 0n,
-          totalWeight: 0n,
-          ownerStatics: 0n,
-          ownerWeth: 0n,
-        };
-      }
-      await verifyLaunchDeployment(publicClient, deployment);
-      const [ids, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth] =
-        await Promise.all([
-          discoverWalletGenesisIds(publicClient, deployment, wallet),
-          Promise.all(
-            [1, 2, 3, 4].map((tier) =>
-              publicClient.readContract({
-                address: deployment.contracts.activationRegistry,
-                abi: genesisActivationRegistryAbi,
-                functionName: "tierCost",
-                args: [tier],
-              })
-            )
-          ).then(oneIndexedGenesisTierCosts),
-          publicClient.readContract({
-            address: deployment.contracts.launchDistributor,
-            abi: genesisLaunchDistributorAbi,
-            functionName: "genesisRewardShareBps",
-          }),
-          publicClient.readContract({
-            address: deployment.contracts.launchDistributor,
-            abi: genesisLaunchDistributorAbi,
-            functionName: "totalWeight",
-          }),
-          publicClient.readContract({
-            address: deployment.contracts.launchDistributor,
-            abi: genesisLaunchDistributorAbi,
-            functionName: "ownerClaimable",
-            args: [wallet, deployment.contracts.statics],
-          }),
-          publicClient.readContract({
-            address: deployment.contracts.launchDistributor,
-            abi: genesisLaunchDistributorAbi,
-            functionName: "ownerClaimable",
-            args: [wallet, deployment.contracts.weth],
-          }),
-        ]);
-      const items = await Promise.all(
-        ids.map(async (id): Promise<OwnedGenesis> => {
-          const [
-            tier,
-            multiplierBps,
-            registered,
-            rewardWeight,
-            pendingStatics,
-            pendingWeth,
-            credit,
-          ] = await Promise.all([
-            publicClient.readContract({
-              address: deployment.contracts.activationRegistry,
-              abi: genesisActivationRegistryAbi,
-              functionName: "tierOf",
-              args: [id],
-            }),
-            publicClient.readContract({
-              address: deployment.contracts.activationRegistry,
-              abi: genesisActivationRegistryAbi,
-              functionName: "multiplierBps",
-              args: [id],
-            }),
-            publicClient.readContract({
-              address: deployment.contracts.launchDistributor,
-              abi: genesisLaunchDistributorAbi,
-              functionName: "registered",
-              args: [id],
-            }),
-            publicClient.readContract({
-              address: deployment.contracts.launchDistributor,
-              abi: genesisLaunchDistributorAbi,
-              functionName: "effectiveWeight",
-              args: [id],
-            }),
-            publicClient.readContract({
-              address: deployment.contracts.launchDistributor,
-              abi: genesisLaunchDistributorAbi,
-              functionName: "pendingGenesis",
-              args: [id, deployment.contracts.statics],
-            }),
-            publicClient.readContract({
-              address: deployment.contracts.launchDistributor,
-              abi: genesisLaunchDistributorAbi,
-              functionName: "pendingGenesis",
-              args: [id, deployment.contracts.weth],
-            }),
-            // Credit state travels with the list so the carousel can flag a
-            // transfer lock and the summary can total what is owed, without a
-            // per-card query fanning out behind the scenes.
-            publicClient.readContract({
-              address: deployment.contracts.vault,
-              abi: staticsGenesisCreditAbi,
-              functionName: "credit",
-              args: [id],
-            }),
-          ]);
-          return {
-            id,
-            tier: Number(tier),
-            multiplierBps: Number(multiplierBps),
-            registered,
-            rewardWeight,
-            pendingStatics,
-            pendingWeth,
-            creditActive: credit.active,
-            creditPrincipal: credit.principal,
-            creditMaturity: Number(credit.maturity),
-          };
-        })
-      );
-      return { items, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth };
+      if (!publicClient || !wallet) return EMPTY_GENESIS_PORTFOLIO;
+      return loadOwnedGenesis(publicClient, deployment, wallet);
     },
   });
 
@@ -230,10 +105,10 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
   );
 
   const summary = useMemo(() => {
-    const pendingStatics = items.reduce((total, item) => total + item.pendingStatics, 0n);
-    const pendingWeth = items.reduce((total, item) => total + item.pendingWeth, 0n);
-    const ownerStatics = owned.data?.ownerStatics ?? 0n;
-    const ownerWeth = owned.data?.ownerWeth ?? 0n;
+    const portfolio = owned.data ?? EMPTY_GENESIS_PORTFOLIO;
+    // Reward totals and the claim signature count are shared with the Overview,
+    // so both surfaces quote the same figures.
+    const rewards = summariseGenesisRewards(portfolio);
     const credits = items.filter((item) => item.creditActive);
     const owed = credits.reduce((total, item) => total + item.creditPrincipal, 0n);
     const soonest = credits.reduce<OwnedGenesis | null>(
@@ -241,25 +116,12 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         !earliest || item.creditMaturity < earliest.creditMaturity ? item : earliest,
       null
     );
-    // One claim call per NFT and asset, and the distributor exposes no batch
-    // entry point, so the button says up front how many signatures it wants.
-    const claimCount =
-      items.reduce(
-        (total, item) =>
-          total + (item.pendingStatics > 0n ? 1 : 0) + (item.pendingWeth > 0n ? 1 : 0),
-        0
-      ) +
-      (ownerStatics > 0n ? 1 : 0) +
-      (ownerWeth > 0n ? 1 : 0);
     return {
-      claimableStatics: pendingStatics + ownerStatics,
-      claimableWeth: pendingWeth + ownerWeth,
-      ownerStatics,
-      ownerWeth,
+      ...rewards,
+      claimCount: rewards.claimTransactionCount,
       owed,
       creditCount: credits.length,
       soonest,
-      claimCount,
       activated: items.filter((item) => item.tier > 0).length,
       unregistered: items.filter((item) => !item.registered).length,
     };
@@ -759,7 +621,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                 <div className="genesis-panel-head">
                   <h3>Launch rewards</h3>
                   <p>
-                    Registered Genesis NFTs split {Number(owned.data?.rewardShareBps ?? 0n) / 100}%
+                    Registered Genesis NFTs split {Number(owned.data?.rewardShareBps ?? 0) / 100}%
                     of market fees, weighted by activation tier.
                   </p>
                 </div>

--- a/components/overview/DeploymentOverview.tsx
+++ b/components/overview/DeploymentOverview.tsx
@@ -2,22 +2,40 @@
 
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { useLocale } from "next-intl";
-import { formatEther, getAddress, type Address } from "viem";
+import { getAddress, type Address } from "viem";
 import { usePublicClient } from "wagmi";
 
 import { dopplerStaticsTokenAbi, v4StateViewReadAbi } from "@statics-protocol/sdk";
+import { GENESIS_MAX_CREDIT_PRINCIPAL } from "@statics-protocol/sdk/genesis-credit";
 
 import { EmptyState } from "@/components/common/EmptyState";
 import { DollarOverview } from "@/components/dollar/DollarPage";
+import { EpochBanner, type EpochQuotes } from "@/components/overview/EpochBanner";
+import { VaultSolvency } from "@/components/overview/VaultSolvency";
 import type { LaunchDeployment } from "@/lib/deployments/types";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
+import { genesisAcquisitionCost, genesisBackingInNumeraire } from "@/lib/genesis/market-value";
+import {
+  EMPTY_GENESIS_PORTFOLIO,
+  loadOwnedGenesis,
+  ownedGenesisQueryKey,
+  summariseGenesisRewards,
+} from "@/lib/genesis/owned";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
 import { useDeployment } from "@/providers/deployment-context";
 import { useWalletState } from "@/providers/wallet-context";
 
 const Q192 = 1n << 192n;
 const PRICE_DECIMALS = 8;
+
+/** Genesis held by the treasury at launch, StaticsGenesisVault.INITIAL_TREASURY_GENESIS. */
+const TREASURY_GENESIS = 555n;
+
+/** A whole-unit count -- NFTs, not token amounts -- with thousands separators. */
+function count(value: bigint): string {
+  return formatTokenAmountGrouped(value, 0, 0);
+}
 
 function decimalFromScaled(value: bigint, decimals: number): string {
   const base = 10n ** BigInt(decimals);
@@ -67,21 +85,31 @@ export function DeploymentOverview() {
 
 function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
   const publicClient = usePublicClient({ chainId: deployment.descriptor.chainId });
-  const locale = useLocale();
   const walletState = useWalletState();
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
+
   const metrics = useQuery({
     queryKey: ["launch-overview", deployment.descriptor.deploymentId, wallet],
     enabled: Boolean(publicClient),
     queryFn: async () => {
-      if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
+      if (!publicClient) throw new Error("The deployment RPC is unavailable.");
       await verifyLaunchDeployment(publicClient, deployment);
-      const [vault, slot0, liquidity, staticsBalance] = await Promise.all([
+      const [vault, purchase, redemption, slot0, liquidity, staticsBalance] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: currentGenesisVaultAbi,
           functionName: "vaultAccounting",
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: currentGenesisVaultAbi,
+          functionName: "quoteGenesisPurchase",
+        }),
+        publicClient.readContract({
+          address: deployment.contracts.vault,
+          abi: currentGenesisVaultAbi,
+          functionName: "quoteGenesisRedemption",
         }),
         publicClient.readContract({
           address: deployment.contracts.stateView,
@@ -104,101 +132,270 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
             })
           : 0n,
       ]);
-      return { vault, sqrtPriceX96: slot0[0], liquidity, staticsBalance };
+      return { vault, purchase, redemption, sqrtPriceX96: slot0[0], liquidity, staticsBalance };
     },
   });
+
+  // Same key and fetcher My Genesis mounts, so the two surfaces share one walk
+  // of the wallet rather than each paying for it.
+  const portfolio = useQuery({
+    queryKey: ownedGenesisQueryKey(deployment.descriptor.deploymentId, wallet),
+    enabled: Boolean(publicClient && wallet),
+    queryFn: async () => {
+      if (!publicClient || !wallet) return EMPTY_GENESIS_PORTFOLIO;
+      return loadOwnedGenesis(publicClient, deployment, wallet);
+    },
+  });
+
+  const vault = metrics.data?.vault ?? null;
+  const rewards = summariseGenesisRewards(portfolio.data ?? EMPTY_GENESIS_PORTFOLIO);
+  const genesisHeld = portfolio.data?.items.length ?? 0;
+
+  // The reserve grows on every acquisition fee whether or not the Epoch has
+  // ended, so the buy-in owed at the boundary is always derivable -- and always
+  // rising. Quoting zero during the Epoch would read as a settled future price.
+  const reserveETH = vault?.reserveETH ?? 0n;
+  const projectedBuyIn = reserveETH > 0n ? (reserveETH + 5_553n) / 5_554n : 0n; // ceil(R / 5,554)
+  const projectedPayout = reserveETH > 0n ? reserveETH / 5_555n : 0n; // floor(R / 5,555)
+
+  const quotes: EpochQuotes | null =
+    metrics.data && vault
+      ? {
+          staticsPrice: metrics.data.purchase.staticsPrice,
+          reserveBuyIn: metrics.data.purchase.reserveBuyIn,
+          nativeFee: metrics.data.purchase.nativeFee,
+          reservePayout: metrics.data.redemption.reservePayout,
+          projectedBuyIn,
+          projectedPayout,
+          maxCredit: GENESIS_MAX_CREDIT_PRINCIPAL,
+        }
+      : null;
+
+  const backingAtMarket = metrics.data
+    ? genesisBackingInNumeraire(
+        metrics.data.sqrtPriceX96,
+        deployment.market.poolKey.currency0,
+        deployment.contracts.statics,
+        metrics.data.purchase.staticsPrice
+      )
+    : null;
+  const allInCost = metrics.data
+    ? genesisAcquisitionCost(backingAtMarket, metrics.data.purchase.requiredNative)
+    : null;
+
+  const marketPrice = metrics.data
+    ? formatCanonicalMarketPrice(
+        metrics.data.sqrtPriceX96,
+        deployment.market.poolKey.currency0,
+        deployment.contracts.statics
+      )
+    : null;
+
+  const circulating = vault?.circulatingGenesis ?? 0n;
+  const inventory = vault?.vaultInventory ?? 0n;
+  const supply = vault?.maximumSupply ?? 0n;
+  const heldByMarket = circulating > TREASURY_GENESIS ? circulating - TREASURY_GENESIS : 0n;
+  const share = (count: bigint) =>
+    supply > 0n ? `${(Number(count) / Number(supply)) * 100}%` : "0%";
+
   return (
     <div className="launch-overview">
-      <section className="ui-card launch-overview-hero">
-        <p className="dapp-eyebrow">Statics Genesis · Robinhood Chain</p>
-        <h2>Trade STATICS and acquire a fully backed Genesis NFT</h2>
-        <p>
-          The launch market discovers the STATICS price. Every Genesis NFT in circulation remains
-          redeemable for its fixed STATICS backing, while registered holders share launch fees.
-        </p>
-        <div className="ui-inline-actions">
-          <Link className="ui-button ui-button--primary" href="/app/swap">
-            Buy STATICS
-          </Link>
-          <Link className="ui-button ui-button--secondary" href="/app/swap?mode=nft">
-            Acquire Genesis
-          </Link>
+      <EpochBanner
+        epochActive={vault?.epochActive ?? true}
+        epochEnd={Number(vault?.genesisEpochEnd ?? 0n)}
+        quotes={quotes}
+      />
+
+      <div className="launch-actions">
+        <Link className="ui-button ui-button--primary" href="/app/swap?mode=nft">
+          Acquire Genesis
+          <small>
+            {metrics.data
+              ? `${formatTokenAmountGrouped(metrics.data.purchase.staticsPrice, 18, 0)} STATICS + ${formatTokenAmountGrouped(metrics.data.purchase.requiredNative, 18, 5)} ETH`
+              : "—"}
+          </small>
+        </Link>
+        <Link className="ui-button ui-button--secondary" href="/app/swap">
+          Buy STATICS
+        </Link>
+        {genesisHeld > 0 && (
           <Link className="ui-button ui-button--secondary" href="/app/genesis">
-            Manage my Genesis
+            {`Manage my ${genesisHeld} Genesis`}
           </Link>
-        </div>
-      </section>
-      <section className="genesis-summary ui-card">
-        <div className="ui-stat">
-          <span className="ui-stat__label">Genesis Epoch</span>
-          <strong className="ui-stat__value">
-            {metrics.data
-              ? metrics.data.vault.epochActive
-                ? `Active until ${new Intl.DateTimeFormat(locale, {
-                    dateStyle: "medium",
-                    timeStyle: "short",
-                  }).format(new Date(Number(metrics.data.vault.genesisEpochEnd) * 1_000))}`
-                : "Complete"
-              : "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">Vault inventory</span>
-          <strong className="ui-stat__value">
-            {metrics.data?.vault.vaultInventory.toString() ?? "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">Genesis in circulation</span>
-          <strong className="ui-stat__value">
-            {metrics.data?.vault.circulatingGenesis.toString() ?? "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">STATICS backing</span>
-          <strong className="ui-stat__value">
-            {metrics.data
-              ? `${formatEther(metrics.data.vault.tokenBacking)} / ${formatEther(metrics.data.vault.requiredBacking)} STATICS`
-              : "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">Native reserve</span>
-          <strong className="ui-stat__value">
-            {metrics.data ? `${formatEther(metrics.data.vault.reserveETH)} ETH` : "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">Reserve backing per Genesis</span>
-          <strong className="ui-stat__value">
-            {metrics.data ? `${formatEther(metrics.data.vault.reserveBackingPerGenesis)} ETH` : "—"}
-          </strong>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">STATICS/WETH market price</span>
-          <strong className="ui-stat__value">
-            {metrics.data
-              ? (() => {
-                  const price = formatCanonicalMarketPrice(
-                    metrics.data.sqrtPriceX96,
-                    deployment.market.poolKey.currency0,
-                    deployment.contracts.statics
-                  );
-                  return `${price.value} ${price.unit}`;
-                })()
-              : "—"}
-          </strong>
-          <span>
-            {metrics.data?.liquidity ? "Canonical liquidity active" : "No active liquidity"}
-          </span>
-        </div>
-        <div className="ui-stat">
-          <span className="ui-stat__label">Your STATICS</span>
-          <strong className="ui-stat__value">
-            {wallet && metrics.data ? formatEther(metrics.data.staticsBalance) : "—"}
-          </strong>
-        </div>
-      </section>
+        )}
+        {vault?.epochActive === false && (
+          <Link className="ui-button ui-button--secondary" href="/app/genesis/recoveries">
+            Recover matured credit
+          </Link>
+        )}
+      </div>
+
+      {wallet ? (
+        <section className="ui-card launch-position" aria-label="Your position">
+          <div className="ui-stat">
+            <span className="ui-stat__label">Your STATICS</span>
+            <strong className="ui-stat__value">
+              {metrics.data ? formatTokenAmountGrouped(metrics.data.staticsBalance, 18, 2) : "—"}
+            </strong>
+          </div>
+          <div className="ui-stat">
+            <span className="ui-stat__label">Your Genesis</span>
+            <strong className="ui-stat__value">{portfolio.isLoading ? "—" : genesisHeld}</strong>
+            <small>
+              {genesisHeld > 0 && vault
+                ? `${formatTokenAmountGrouped(vault.vaultPrice * BigInt(genesisHeld), 18, 0)} STATICS backing`
+                : "None held"}
+            </small>
+          </div>
+          <div className="ui-stat">
+            <span className="ui-stat__label">Claimable</span>
+            <strong className="ui-stat__value is-accent">
+              {formatTokenAmountGrouped(rewards.claimableStatics, 18, 2)} STATICS
+            </strong>
+            <small>{formatTokenAmountGrouped(rewards.claimableWeth, 18, 4)} WETH</small>
+          </div>
+          {/* Names its destination, not an action: claiming is one transaction
+              per NFT and asset, and My Genesis is where that sequence is priced
+              honestly. Revisit when the batch claim entry point lands. */}
+          <Link className="ui-button ui-button--secondary" href="/app/genesis">
+            Open My Genesis
+          </Link>
+        </section>
+      ) : (
+        <section className="ui-card launch-position is-signed-out" aria-label="Your position">
+          <div>
+            <strong>Connect to see where you stand</strong>
+            <p>Your STATICS, the Genesis you hold, and anything waiting to be claimed.</p>
+          </div>
+          <button
+            className="ui-button ui-button--primary"
+            type="button"
+            onClick={walletState.status === "signed-out" ? walletState.login : undefined}
+            disabled={walletState.status !== "signed-out"}
+          >
+            Connect wallet
+          </button>
+        </section>
+      )}
+
+      <div className="launch-duo">
+        <section className="ui-card overview-panel" aria-label="Genesis supply">
+          <div className="overview-panel-head">
+            <h3>Supply</h3>
+            <span>Fixed at {count(supply)}</span>
+          </div>
+          <p className="overview-figure">
+            <b>{count(inventory)}</b>
+            <span>still in the Vault</span>
+          </p>
+          <div className="supply-bar" aria-hidden="true">
+            <i className="is-treasury" style={{ width: share(TREASURY_GENESIS) }} />
+            <i className="is-circulating" style={{ width: share(heldByMarket) }} />
+            <i className="is-inventory" style={{ width: share(inventory) }} />
+          </div>
+          <dl className="supply-key">
+            <div>
+              <dt>
+                <i className="is-treasury" aria-hidden="true" />
+                Treasury at genesis
+              </dt>
+              <dd>{count(TREASURY_GENESIS)}</dd>
+            </div>
+            <div>
+              <dt>
+                <i className="is-circulating" aria-hidden="true" />
+                Held by the market
+              </dt>
+              <dd>{count(heldByMarket)}</dd>
+            </div>
+            <div>
+              <dt>
+                <i className="is-inventory" aria-hidden="true" />
+                Vault inventory
+              </dt>
+              <dd>{count(inventory)}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="ui-card overview-panel" aria-label="STATICS market">
+          <div className="overview-panel-head">
+            <h3>Market</h3>
+            <span>{metrics.data?.liquidity ? "Liquidity active" : "No active liquidity"}</span>
+          </div>
+          <p className="overview-figure">
+            <b>{marketPrice?.value ?? "—"}</b>
+            <span>{marketPrice?.unit ?? "WETH per STATICS"}</span>
+          </p>
+          <dl className="overview-rows">
+            <div>
+              <dt>
+                {vault ? formatTokenAmountGrouped(vault.vaultPrice, 18, 0) : "—"} STATICS at market
+              </dt>
+              <dd>
+                {backingAtMarket !== null
+                  ? `${formatTokenAmountGrouped(backingAtMarket, 18, 4)} ETH`
+                  : "—"}
+              </dd>
+            </div>
+            <div>
+              <dt>Reserve share per Genesis</dt>
+              <dd>
+                {vault
+                  ? `${formatTokenAmountGrouped(vault.reserveBackingPerGenesis, 18, 6)} ETH`
+                  : "—"}
+              </dd>
+            </div>
+            <div>
+              <dt>
+                {vault?.epochActive ? "Buy-in if the Epoch ended now" : "Buy-in charged today"}
+              </dt>
+              <dd>{`${formatTokenAmountGrouped(projectedBuyIn, 18, 5)} ETH`}</dd>
+            </div>
+            <div className="is-total">
+              <dt>A Genesis costs you, all in</dt>
+              <dd>
+                {allInCost !== null ? `${formatTokenAmountGrouped(allInCost, 18, 4)} ETH` : "—"}
+              </dd>
+            </div>
+          </dl>
+          <p className="overview-note">
+            {vault?.epochActive ? (
+              <>
+                <b>No buy-in is charged yet, but it is already accruing.</b> Every sale adds its
+                acquisition fee to the reserve, so the buy-in owed the moment the Epoch ends rises
+                with each one.
+              </>
+            ) : (
+              <>
+                <b>The reserve compounds.</b> Each acquisition returns its own buy-in to the
+                reserve, so the buy-in climbs with every sale. Redemption pays out over 5,555 while
+                buy-in divides by 5,554, and both round toward the reserve — so the share held by
+                everyone still holding only grows.
+              </>
+            )}
+          </p>
+        </section>
+      </div>
+
+      <VaultSolvency
+        figures={
+          vault
+            ? {
+                circulatingGenesis: vault.circulatingGenesis,
+                vaultPrice: vault.vaultPrice,
+                grossBacking: vault.grossBacking,
+                outstandingGenesisCredit: vault.outstandingGenesisCredit,
+                requiredBacking: vault.requiredBacking,
+                tokenBacking: vault.tokenBacking,
+                tokenCustody: vault.tokenCustody,
+                reserveETH: vault.reserveETH,
+                nativeCustody: vault.nativeCustody,
+              }
+            : null
+        }
+      />
+
       {metrics.error && (
         <p className="dapp-inline-error" role="alert">
           Launch metrics are temporarily unavailable. Trading and Vault actions remain independently

--- a/components/overview/EpochBanner.tsx
+++ b/components/overview/EpochBanner.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+
+export type EpochQuotes = Readonly<{
+  /** Fixed STATICS backing paid on acquisition, GENESIS_PRICE. */
+  staticsPrice: bigint;
+  /** ceil(reserve / 5,554). Zero while the Epoch runs. */
+  reserveBuyIn: bigint;
+  /** The flat native acquisition fee, charged in both phases. */
+  nativeFee: bigint;
+  /** floor(reserve / 5,555) returned on redemption. Zero while the Epoch runs. */
+  reservePayout: bigint;
+  /**
+   * What the buy-in would be at the reserve as it stands right now.
+   *
+   * During the Epoch `reserveBuyIn` is zero because none is charged, but the
+   * reserve is already growing on acquisition fees, so the amount owed the
+   * moment the Epoch ends is climbing the whole time. Showing zero there would
+   * imply the post-Epoch cost is settled, and it never is.
+   */
+  projectedBuyIn: bigint;
+  /** floor(reserve / 5,555) at today's reserve, charged or not. */
+  projectedPayout: bigint;
+  /** GENESIS_MAX_CREDIT_PRINCIPAL. */
+  maxCredit: bigint;
+}>;
+
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1_000));
+  useEffect(() => {
+    if (!active) return;
+    const timer = window.setInterval(() => setNow(Math.floor(Date.now() / 1_000)), 1_000);
+    return () => window.clearInterval(timer);
+  }, [active]);
+  return now;
+}
+
+function CountdownUnit({ value, label }: { value: number; label: string }) {
+  return (
+    <div>
+      <b>{String(Math.max(0, value)).padStart(2, "0")}</b>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function Change({
+  label,
+  current,
+  other,
+  caveat,
+  complete,
+}: Readonly<{
+  label: string;
+  /** What is true while the Epoch runs. */
+  current: string;
+  /** What is true once it has ended. */
+  other: string;
+  caveat?: string;
+  complete: boolean;
+}>) {
+  return (
+    <div className="epoch-change">
+      <span className="dapp-eyebrow">{label}</span>
+      <p className="epoch-change-primary">{complete ? other : current}</p>
+      <p className="epoch-change-secondary">
+        <span aria-hidden="true">{complete ? "was" : "then"}</span>
+        <b className={complete ? "is-past" : "is-next"}>{complete ? current : other}</b>
+      </p>
+      {caveat && <p className="epoch-change-caveat">{caveat}</p>}
+    </div>
+  );
+}
+
+/**
+ * The Genesis Epoch, as the Overview's thesis rather than one tile among nine.
+ *
+ * `genesisEpochEnd` is immutable -- fixed at Vault construction, it cannot be
+ * moved -- and it changes three economics at once. The page it replaced stated
+ * that as "Active until <locale timestamp>", and afterwards as "Complete".
+ */
+export function EpochBanner({
+  epochActive,
+  epochEnd,
+  quotes,
+}: Readonly<{
+  epochActive: boolean;
+  /** Unix seconds. */
+  epochEnd: number;
+  quotes: EpochQuotes | null;
+}>) {
+  const now = useNow(epochActive);
+  const remaining = Math.max(0, epochEnd - now);
+  const days = Math.floor(remaining / 86_400);
+  const hours = Math.floor((remaining % 86_400) / 3_600);
+  const minutes = Math.floor((remaining % 3_600) / 60);
+  const seconds = remaining % 60;
+
+  const statics = quotes ? formatTokenAmountGrouped(quotes.staticsPrice, 18, 0) : "—";
+  const feeOnly = quotes ? formatTokenAmountGrouped(quotes.nativeFee, 18, 3) : "—";
+  const feePlusBuyIn = quotes
+    ? formatTokenAmountGrouped(quotes.nativeFee + quotes.projectedBuyIn, 18, 5)
+    : "—";
+  const payout = quotes ? formatTokenAmountGrouped(quotes.projectedPayout, 18, 5) : "—";
+  const maxCredit = quotes ? formatTokenAmountGrouped(quotes.maxCredit, 18, 0) : "—";
+
+  return (
+    <section
+      className={`epoch-banner${epochActive ? "" : " is-complete"}`}
+      aria-label="Genesis Epoch"
+    >
+      <div className="epoch-banner-top">
+        <div className="epoch-banner-label">
+          <p className="dapp-eyebrow">
+            {epochActive ? "Genesis Epoch · in progress" : "Genesis Epoch · complete"}
+          </p>
+          <h2>{epochActive ? "The Epoch ends in" : "The Epoch has ended"}</h2>
+          <p>
+            {epochActive
+              ? "This date was fixed when the Vault was deployed and cannot be moved. Three things change the moment it passes."
+              : "These three changes took effect the moment it passed, and are permanent."}
+          </p>
+        </div>
+        <div className="epoch-countdown">
+          {epochActive ? (
+            <div className="epoch-countdown-figure">
+              <CountdownUnit value={days} label="days" />
+              <CountdownUnit value={hours} label="hrs" />
+              <CountdownUnit value={minutes} label="min" />
+              <CountdownUnit value={seconds} label="sec" />
+            </div>
+          ) : (
+            <div className="epoch-countdown-figure">
+              <div>
+                <b>—</b>
+                <span>complete</span>
+              </div>
+            </div>
+          )}
+          <p className="epoch-countdown-when">
+            {epochActive ? "Ends " : "Ended "}
+            {epochEnd > 0 ? new Date(epochEnd * 1_000).toLocaleString() : "—"}
+          </p>
+        </div>
+      </div>
+
+      <div className="epoch-changes">
+        <Change
+          label="Acquiring a Genesis"
+          current={`${statics} STATICS + ${feeOnly} ETH`}
+          other={`${statics} STATICS + ${feePlusBuyIn} ETH`}
+          caveat="Buy-in shown at today's reserve. Every acquisition fee accretes to it, so the amount owed rises with each sale."
+          complete={!epochActive}
+        />
+        <Change
+          label="Redeeming a Genesis"
+          current={`${statics} STATICS, no ETH`}
+          other={`${statics} STATICS + ${payout} ETH`}
+          caveat="Reserve share at today's reserve. It rises for the same reason."
+          complete={!epochActive}
+        />
+        <Change
+          label="Secured credit"
+          current="Closed"
+          other={`Up to ${maxCredit} STATICS`}
+          complete={!epochActive}
+        />
+      </div>
+    </section>
+  );
+}

--- a/components/overview/VaultSolvency.tsx
+++ b/components/overview/VaultSolvency.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+
+export type VaultSolvencyFigures = Readonly<{
+  circulatingGenesis: bigint;
+  vaultPrice: bigint;
+  grossBacking: bigint;
+  outstandingGenesisCredit: bigint;
+  requiredBacking: bigint;
+  tokenBacking: bigint;
+  tokenCustody: bigint;
+  reserveETH: bigint;
+  nativeCustody: bigint;
+}>;
+
+type Invariant = Readonly<{
+  label: string;
+  left: string;
+  right: string;
+  holds: boolean;
+  surplus: string;
+}>;
+
+/**
+ * The three invariants `_enforceSolvency` holds, checked against the values the
+ * Overview already fetched.
+ *
+ * `vaultAccounting` returns `tokenCustody` and `nativeCustody` for no purpose
+ * other than letting a client verify this, and nothing in the app was reading
+ * either. They cost no extra request -- they arrive in the same struct as the
+ * numbers the page was already showing.
+ *
+ * These cannot fail against a healthy node: the Vault reverts any transaction
+ * that would break them. A failure here means the client is reading a stale or
+ * inconsistent view, which is worth surfacing rather than hiding.
+ */
+function invariants(figures: VaultSolvencyFigures): readonly Invariant[] {
+  const statics = (value: bigint, digits = 0) =>
+    `${formatTokenAmountGrouped(value, 18, digits)} STATICS`;
+  const eth = (value: bigint) => `${formatTokenAmountGrouped(value, 18, 4)} ETH`;
+
+  return [
+    {
+      label: "Backing covers every circulating Genesis",
+      left: statics(figures.tokenBacking),
+      right: statics(figures.requiredBacking),
+      holds: figures.tokenBacking >= figures.requiredBacking,
+      surplus: statics(figures.tokenBacking - figures.requiredBacking, 2),
+    },
+    {
+      label: "The Vault holds that STATICS",
+      left: statics(figures.tokenCustody),
+      right: statics(figures.tokenBacking),
+      holds: figures.tokenCustody >= figures.tokenBacking,
+      surplus: statics(figures.tokenCustody - figures.tokenBacking, 2),
+    },
+    {
+      label: "The Vault holds the ETH reserve",
+      left: eth(figures.nativeCustody),
+      right: eth(figures.reserveETH),
+      holds: figures.nativeCustody >= figures.reserveETH,
+      surplus: eth(figures.nativeCustody - figures.reserveETH),
+    },
+  ];
+}
+
+export function VaultSolvency({ figures }: { figures: VaultSolvencyFigures | null }) {
+  if (!figures) return null;
+  const checks = invariants(figures);
+  const allHold = checks.every((check) => check.holds);
+
+  return (
+    <section className="ui-card overview-panel" aria-label="Vault solvency">
+      <div className="overview-panel-head">
+        <h3>Solvency</h3>
+        <span className={allHold ? "is-accent" : "is-negative"}>
+          {allHold ? "All three hold" : "Reading is inconsistent"}
+        </span>
+      </div>
+
+      <ul className="solvency-checks">
+        {checks.map((check) => (
+          <li key={check.label} className={check.holds ? undefined : "is-failing"}>
+            <span className="solvency-mark" aria-hidden="true">
+              {check.holds ? "✓" : "!"}
+            </span>
+            <span className="solvency-body">
+              <strong>{check.label}</strong>
+              <span>
+                {check.left} ≥ {check.right}
+              </span>
+            </span>
+            <span className="solvency-surplus">{check.holds ? `+${check.surplus}` : "short"}</span>
+          </li>
+        ))}
+      </ul>
+
+      <dl className="solvency-reconcile">
+        <div>
+          <dt>
+            {formatTokenAmountGrouped(figures.circulatingGenesis, 0, 0)} circulating ×{" "}
+            {formatTokenAmountGrouped(figures.vaultPrice, 18, 0)}
+          </dt>
+          <dd>{formatTokenAmountGrouped(figures.grossBacking, 18, 0)}</dd>
+        </div>
+        <div>
+          <dt>less credit drawn against backing</dt>
+          <dd>
+            {figures.outstandingGenesisCredit > 0n
+              ? `−${formatTokenAmountGrouped(figures.outstandingGenesisCredit, 18, 0)}`
+              : "0"}
+          </dd>
+        </div>
+        <div className="is-total">
+          <dt>Backing required</dt>
+          <dd>{formatTokenAmountGrouped(figures.requiredBacking, 18, 0)} STATICS</dd>
+        </div>
+      </dl>
+
+      <p className="overview-note">
+        <b>These are invariants, not targets.</b> The Vault re-checks all three at the end of every
+        purchase, redemption, credit and repayment, and reverts the whole transaction if any fails.
+      </p>
+    </section>
+  );
+}

--- a/docs/adr/network-aware-genesis-launch-application.md
+++ b/docs/adr/network-aware-genesis-launch-application.md
@@ -31,6 +31,8 @@ Each network target may have a reviewed launch deployment, a full-protocol deplo
 neither. Chain and manifest identity remain part of internal cache and database keys so records
 cannot cross networks. This internal isolation is not exposed as a second product-selection model.
 
+The Overview is organised around the Genesis Epoch. `genesisEpochEnd` is immutable and changes three economics the moment it passes — acquisition gains a reserve buy-in, redemption begins paying a reserve share, and secured credit opens — so it leads the page as a live countdown stating what changes, rather than as one metric tile among many. Because the reserve accrues acquisition fees during the Epoch, the buy-in owed at the boundary is always quoted from the current reserve and labelled as rising, never as a settled future price. Below it the page reports the wallet's own position, the fixed 5,555 supply as one division, the market price with the Genesis backing valued against it, and the three solvency invariants the Vault enforces — verified client-side from the custody figures `vaultAccounting` already returns.
+
 Launch deployments expose only three primary product destinations: Overview, Trade, and My Genesis. Wallet, Activity, and Approval Tools remain contextual utilities reachable from product flows; funding Portal access remains contextual through Wallet. Unsupported known full-protocol URLs replace to `/app`, while unknown `/app/*` paths remain Next.js 404s. Full-protocol deployments restore the complete application catalog and its existing route behavior.
 
 The network selector uses stable target identities rather than treating a deployment as a second

--- a/lib/genesis/market-value.ts
+++ b/lib/genesis/market-value.ts
@@ -1,0 +1,49 @@
+import type { Address } from "viem";
+
+const Q192 = 1n << 192n;
+
+/**
+ * What a Genesis NFT's STATICS backing is worth at the current market price,
+ * denominated in the pool's numeraire (WETH), in wei.
+ *
+ * This is the figure the Overview was missing: a raw `WETH per STATICS` ratio
+ * does not tell anyone whether the Vault's fixed 180,000 STATICS price is cheap.
+ * Multiplying it out does.
+ *
+ * Kept in bigint end to end. Converting through a float first loses precision
+ * exactly where it matters, because `sqrtPriceX96` squared is a 192-bit number
+ * and the ratio it encodes is frequently far from 1.
+ *
+ * Returns null when the pool has no price yet, rather than a misleading zero.
+ */
+export function genesisBackingInNumeraire(
+  sqrtPriceX96: bigint,
+  currency0: Address,
+  statics: Address,
+  vaultPrice: bigint
+): bigint | null {
+  if (sqrtPriceX96 <= 0n || vaultPrice <= 0n) return null;
+
+  const numerator = sqrtPriceX96 * sqrtPriceX96;
+  const staticsIsCurrency0 = currency0.toLowerCase() === statics.toLowerCase();
+
+  // sqrtPriceX96^2 / Q192 is token1 per token0. STATICS and the numeraire are
+  // both 18-decimal, so the raw ratio is also the human one.
+  return staticsIsCurrency0 ? (vaultPrice * numerator) / Q192 : (vaultPrice * Q192) / numerator;
+}
+
+/**
+ * Total cost of acquiring one Genesis right now, in the numeraire: its STATICS
+ * backing valued at market, plus the native ETH the Vault requires.
+ *
+ * `requiredNative` already folds the reserve buy-in together with the
+ * acquisition fee, and is zero-buy-in during the Epoch, so this stays correct
+ * across the Epoch boundary without branching on it.
+ */
+export function genesisAcquisitionCost(
+  backingInNumeraire: bigint | null,
+  requiredNative: bigint
+): bigint | null {
+  if (backingInNumeraire === null) return null;
+  return backingInNumeraire + requiredNative;
+}

--- a/lib/genesis/owned.ts
+++ b/lib/genesis/owned.ts
@@ -1,0 +1,197 @@
+import type { PublicClient } from "viem";
+import { genesisActivationRegistryAbi, genesisLaunchDistributorAbi } from "@statics-protocol/sdk";
+import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
+import { discoverWalletGenesisIds } from "@/lib/genesis/discovery";
+
+export type OwnedGenesis = Readonly<{
+  id: bigint;
+  tier: number;
+  multiplierBps: number;
+  registered: boolean;
+  rewardWeight: bigint;
+  pendingStatics: bigint;
+  pendingWeth: bigint;
+  creditActive: boolean;
+  creditPrincipal: bigint;
+  creditMaturity: number;
+}>;
+
+export type OwnedGenesisPortfolio = Readonly<{
+  items: readonly OwnedGenesis[];
+  tierCosts: readonly bigint[];
+  /** uint16 onchain, so viem hands this back as a number. */
+  rewardShareBps: number;
+  totalWeight: bigint;
+  ownerStatics: bigint;
+  ownerWeth: bigint;
+}>;
+
+export const EMPTY_GENESIS_PORTFOLIO: OwnedGenesisPortfolio = {
+  items: [],
+  tierCosts: [],
+  rewardShareBps: 0,
+  totalWeight: 0n,
+  ownerStatics: 0n,
+  ownerWeth: 0n,
+};
+
+/**
+ * The query key both My Genesis and the Overview mount.
+ *
+ * Sharing the key is the point: this walk is one discovery call plus seven
+ * reads per NFT, and the Overview needs the same totals My Genesis already
+ * fetched. Same key, same fetcher, one request.
+ */
+export function ownedGenesisQueryKey(deploymentId: string, wallet: `0x${string}` | null) {
+  return ["launch-genesis-owned", deploymentId, wallet] as const;
+}
+
+/** Everything this wallet holds, with each NFT's reward and credit state. */
+export async function loadOwnedGenesis(
+  publicClient: PublicClient,
+  deployment: LaunchDeployment,
+  wallet: `0x${string}`
+): Promise<OwnedGenesisPortfolio> {
+  await verifyLaunchDeployment(publicClient, deployment);
+  const [ids, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth] = await Promise.all([
+    discoverWalletGenesisIds(publicClient, deployment, wallet),
+    Promise.all(
+      [1, 2, 3, 4].map((tier) =>
+        publicClient.readContract({
+          address: deployment.contracts.activationRegistry,
+          abi: genesisActivationRegistryAbi,
+          functionName: "tierCost",
+          args: [tier],
+        })
+      )
+    ).then(oneIndexedGenesisTierCosts),
+    publicClient.readContract({
+      address: deployment.contracts.launchDistributor,
+      abi: genesisLaunchDistributorAbi,
+      functionName: "genesisRewardShareBps",
+    }),
+    publicClient.readContract({
+      address: deployment.contracts.launchDistributor,
+      abi: genesisLaunchDistributorAbi,
+      functionName: "totalWeight",
+    }),
+    publicClient.readContract({
+      address: deployment.contracts.launchDistributor,
+      abi: genesisLaunchDistributorAbi,
+      functionName: "ownerClaimable",
+      args: [wallet, deployment.contracts.statics],
+    }),
+    publicClient.readContract({
+      address: deployment.contracts.launchDistributor,
+      abi: genesisLaunchDistributorAbi,
+      functionName: "ownerClaimable",
+      args: [wallet, deployment.contracts.weth],
+    }),
+  ]);
+
+  const items = await Promise.all(
+    ids.map(async (id): Promise<OwnedGenesis> => {
+      const [tier, multiplierBps, registered, rewardWeight, pendingStatics, pendingWeth, credit] =
+        await Promise.all([
+          publicClient.readContract({
+            address: deployment.contracts.activationRegistry,
+            abi: genesisActivationRegistryAbi,
+            functionName: "tierOf",
+            args: [id],
+          }),
+          publicClient.readContract({
+            address: deployment.contracts.activationRegistry,
+            abi: genesisActivationRegistryAbi,
+            functionName: "multiplierBps",
+            args: [id],
+          }),
+          publicClient.readContract({
+            address: deployment.contracts.launchDistributor,
+            abi: genesisLaunchDistributorAbi,
+            functionName: "registered",
+            args: [id],
+          }),
+          publicClient.readContract({
+            address: deployment.contracts.launchDistributor,
+            abi: genesisLaunchDistributorAbi,
+            functionName: "effectiveWeight",
+            args: [id],
+          }),
+          publicClient.readContract({
+            address: deployment.contracts.launchDistributor,
+            abi: genesisLaunchDistributorAbi,
+            functionName: "pendingGenesis",
+            args: [id, deployment.contracts.statics],
+          }),
+          publicClient.readContract({
+            address: deployment.contracts.launchDistributor,
+            abi: genesisLaunchDistributorAbi,
+            functionName: "pendingGenesis",
+            args: [id, deployment.contracts.weth],
+          }),
+          // Credit state travels with the list so the carousel can flag a
+          // transfer lock and the summary can total what is owed, without a
+          // per-card query fanning out behind the scenes.
+          publicClient.readContract({
+            address: deployment.contracts.vault,
+            abi: staticsGenesisCreditAbi,
+            functionName: "credit",
+            args: [id],
+          }),
+        ]);
+      return {
+        id,
+        tier: Number(tier),
+        multiplierBps: Number(multiplierBps),
+        registered,
+        rewardWeight,
+        pendingStatics,
+        pendingWeth,
+        creditActive: credit.active,
+        creditPrincipal: credit.principal,
+        creditMaturity: Number(credit.maturity),
+      };
+    })
+  );
+
+  return { items, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth };
+}
+
+export type GenesisRewardSummary = Readonly<{
+  claimableStatics: bigint;
+  claimableWeth: bigint;
+  ownerStatics: bigint;
+  ownerWeth: bigint;
+  /**
+   * How many wallet signatures a full claim currently takes.
+   *
+   * `GenesisLaunchDistributor` exposes `claimGenesis` and `claimOwnerRewards`
+   * one asset at a time, so this is the honest count to put in front of anyone
+   * about to start the sequence. It collapses to 1 when the batch entry point
+   * lands.
+   */
+  claimTransactionCount: number;
+}>;
+
+export function summariseGenesisRewards(portfolio: OwnedGenesisPortfolio): GenesisRewardSummary {
+  const pendingStatics = portfolio.items.reduce((total, item) => total + item.pendingStatics, 0n);
+  const pendingWeth = portfolio.items.reduce((total, item) => total + item.pendingWeth, 0n);
+  const claimTransactionCount =
+    portfolio.items.reduce(
+      (total, item) => total + (item.pendingStatics > 0n ? 1 : 0) + (item.pendingWeth > 0n ? 1 : 0),
+      0
+    ) +
+    (portfolio.ownerStatics > 0n ? 1 : 0) +
+    (portfolio.ownerWeth > 0n ? 1 : 0);
+  return {
+    claimableStatics: pendingStatics + portfolio.ownerStatics,
+    claimableWeth: pendingWeth + portfolio.ownerWeth,
+    ownerStatics: portfolio.ownerStatics,
+    ownerWeth: portfolio.ownerWeth,
+    claimTransactionCount,
+  };
+}

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -93,22 +93,45 @@ const option = {
 } satisfies DeploymentOption;
 
 function vaultAccounting(epochActive: boolean) {
+  // 655 circulating + 4,900 in the Vault = the fixed 5,555, and backing that
+  // equals circulating x vaultPrice, so the solvency invariants actually hold.
+  const backing = parseEther("117900000"); // 655 x 180,000
   return {
     vaultPrice: parseEther("180000"),
     maximumSupply: 5_555n,
     mintedSupply: 5_555n,
-    vaultInventory: 5_500n,
-    circulatingGenesis: 55n,
-    tokenBacking: parseEther("9900000"),
-    grossBacking: parseEther("9900000"),
+    vaultInventory: 4_900n,
+    circulatingGenesis: 655n,
+    tokenBacking: backing,
+    grossBacking: backing,
     outstandingGenesisCredit: 0n,
-    requiredBacking: parseEther("9900000"),
-    tokenCustody: parseEther("9900000"),
+    requiredBacking: backing,
+    tokenCustody: backing,
     reserveETH: parseEther("5"),
     nativeCustody: parseEther("5"),
     genesisEpochEnd: 2_000_000_000n,
     epochActive,
-    reserveBackingPerGenesis: parseEther("0.001"),
+    reserveBackingPerGenesis: parseEther("5") / 5_555n,
+  };
+}
+
+function purchaseQuote(epochActive: boolean) {
+  const reserveBuyIn = epochActive ? 0n : (parseEther("5") + 5_553n) / 5_554n;
+  const nativeFee = parseEther("0.003");
+  return {
+    staticsPrice: parseEther("180000"),
+    reserveBuyIn,
+    nativeFee,
+    requiredNative: reserveBuyIn + nativeFee,
+    epochActive,
+  };
+}
+
+function redemptionQuote(epochActive: boolean) {
+  return {
+    staticsPayout: parseEther("180000"),
+    reservePayout: epochActive ? 0n : parseEther("5") / 5_555n,
+    epochActive,
   };
 }
 
@@ -144,29 +167,101 @@ beforeEach(() => {
 });
 
 describe("launch overview", () => {
-  it("shows only launch metrics and the three launch actions", async () => {
+  function overviewReads(epochActive: boolean) {
+    discoverWalletGenesisIds.mockResolvedValue([]);
     readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
-      if (functionName === "vaultAccounting") return vaultAccounting(true);
+      if (functionName === "vaultAccounting") return vaultAccounting(epochActive);
+      if (functionName === "quoteGenesisPurchase") return purchaseQuote(epochActive);
+      if (functionName === "quoteGenesisRedemption") return redemptionQuote(epochActive);
       if (functionName === "getSlot0") return [1n << 96n, 0, 0, 0];
       if (functionName === "getLiquidity") return 1n;
       if (functionName === "balanceOf") return parseEther("42");
+      if (functionName === "genesisRewardShareBps") return 1_000;
+      if (functionName === "totalWeight") return 25_000n;
+      if (functionName === "ownerClaimable") return 0n;
       throw new Error(`Unexpected read ${functionName}`);
     });
+  }
 
+  it("leads with the Epoch and prices the acquisition inline", async () => {
+    overviewReads(true);
     renderWithProviders(<DeploymentOverview />);
 
-    expect(await screen.findByText(/Active until/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Buy STATICS" })).toHaveAttribute("href", "/app/swap");
-    expect(screen.getByRole("link", { name: "Acquire Genesis" })).toHaveAttribute(
+    expect(await screen.findByText("The Epoch ends in")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Acquire Genesis/ })).toHaveAttribute(
       "href",
       "/app/swap?mode=nft"
     );
-    expect(screen.getByRole("link", { name: "Manage my Genesis" })).toHaveAttribute(
-      "href",
-      "/app/genesis"
-    );
+    expect(screen.getByRole("link", { name: "Buy STATICS" })).toHaveAttribute("href", "/app/swap");
     expect(screen.queryByText("Registered reward weight")).not.toBeInTheDocument();
-    expect(screen.queryByText("Fees harvested")).not.toBeInTheDocument();
+  });
+
+  it("states what the deadline changes, in both directions", async () => {
+    overviewReads(true);
+    renderWithProviders(<DeploymentOverview />);
+
+    // Await a figure rather than a static label, so the quotes have landed.
+    expect(await screen.findByText("180,000 STATICS, no ETH")).toBeInTheDocument();
+    expect(screen.getByText("Acquiring a Genesis")).toBeInTheDocument();
+    expect(screen.getByText("Redeeming a Genesis")).toBeInTheDocument();
+    expect(screen.getByText("Secured credit")).toBeInTheDocument();
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+    expect(screen.getByText("Up to 171,000 STATICS")).toBeInTheDocument();
+  });
+
+  it("projects the buy-in from today's reserve rather than quoting zero", async () => {
+    overviewReads(true);
+    renderWithProviders(<DeploymentOverview />);
+
+    // Charged buy-in is zero during the Epoch, but ceil(5 ETH / 5,554) is what
+    // the next buyer owes the moment it ends -- and it climbs on every fee.
+    // Await a quoted figure so the reads have landed, then scope: the reserve
+    // share (R / 5,555) and the buy-in (R / 5,554) round to the same string at
+    // this precision, which is the asymmetry working as designed.
+    await screen.findByText("180,000 STATICS, no ETH");
+    const row = screen.getByText("Buy-in if the Epoch ended now").closest("div");
+    expect(row).toHaveTextContent("0.0009 ETH");
+    expect(screen.getByText(/already accruing/)).toBeInTheDocument();
+  });
+
+  it("charges the buy-in once the Epoch is complete", async () => {
+    overviewReads(false);
+    renderWithProviders(<DeploymentOverview />);
+
+    expect(await screen.findByText("The Epoch has ended")).toBeInTheDocument();
+    expect(screen.getByText("Buy-in charged today")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Recover matured credit/ })).toHaveAttribute(
+      "href",
+      "/app/genesis/recoveries"
+    );
+  });
+
+  it("verifies the three solvency invariants the Vault enforces", async () => {
+    overviewReads(true);
+    renderWithProviders(<DeploymentOverview />);
+
+    expect(await screen.findByText("All three hold")).toBeInTheDocument();
+    expect(screen.getByText("Backing covers every circulating Genesis")).toBeInTheDocument();
+    expect(screen.getByText("The Vault holds that STATICS")).toBeInTheDocument();
+    expect(screen.getByText("The Vault holds the ETH reserve")).toBeInTheDocument();
+    expect(screen.getByText("655 circulating × 180,000")).toBeInTheDocument();
+  });
+
+  it("reports the supply as one fixed collection", async () => {
+    overviewReads(true);
+    renderWithProviders(<DeploymentOverview />);
+
+    expect(await screen.findByText("Fixed at 5,555")).toBeInTheDocument();
+    expect(screen.getByText("Treasury at genesis")).toBeInTheDocument();
+    expect(screen.getByText("Vault inventory")).toBeInTheDocument();
+  });
+
+  it("prompts a signed-out visitor instead of showing dashes", async () => {
+    overviewReads(true);
+    renderWithProviders(<DeploymentOverview />, false);
+
+    expect(await screen.findByText("Connect to see where you stand")).toBeInTheDocument();
+    expect(screen.queryByText("Your Genesis")).not.toBeInTheDocument();
   });
 
   it("formats either canonical token ordering without floating-point input", () => {

--- a/test/genesis/market-value.test.ts
+++ b/test/genesis/market-value.test.ts
@@ -1,0 +1,77 @@
+import { getAddress, parseEther } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { genesisAcquisitionCost, genesisBackingInNumeraire } from "@/lib/genesis/market-value";
+
+const statics = getAddress("0x1111111111111111111111111111111111111111");
+const weth = getAddress("0x7777777777777777777777777777777777777777");
+const vaultPrice = parseEther("180000");
+
+/** sqrtPriceX96 for a whole-number ratio of token1 per token0. */
+function sqrtPriceFor(ratio: bigint): bigint {
+  // Exact for perfect squares, which is all these cases use.
+  let root = 1n;
+  while (root * root < ratio) root += 1n;
+  return root << 96n;
+}
+
+describe("Genesis backing valued at market", () => {
+  it("multiplies out when STATICS is currency0", () => {
+    // 1 WETH per STATICS: the whole 180,000 backing is worth 180,000 WETH.
+    expect(genesisBackingInNumeraire(1n << 96n, statics, statics, vaultPrice)).toBe(vaultPrice);
+  });
+
+  it("inverts when STATICS is currency1", () => {
+    // The pool then quotes STATICS per WETH, so the backing divides rather than
+    // multiplies. Getting this backwards is the whole reason it is tested.
+    expect(genesisBackingInNumeraire(1n << 96n, weth, statics, vaultPrice)).toBe(vaultPrice);
+
+    const fourStaticsPerWeth = sqrtPriceFor(4n);
+    expect(genesisBackingInNumeraire(fourStaticsPerWeth, weth, statics, vaultPrice)).toBe(
+      vaultPrice / 4n
+    );
+  });
+
+  it("scales with the price when STATICS is currency0", () => {
+    const fourWethPerStatics = sqrtPriceFor(4n);
+    expect(genesisBackingInNumeraire(fourWethPerStatics, statics, statics, vaultPrice)).toBe(
+      vaultPrice * 4n
+    );
+  });
+
+  it("keeps precision on a ratio far from one", () => {
+    // A realistic launch price is a very small WETH-per-STATICS number. Routing
+    // this through a float first would round the result to zero.
+    const scaled = genesisBackingInNumeraire(1n << 80n, statics, statics, vaultPrice);
+    expect(scaled).not.toBeNull();
+    expect(scaled).toBeGreaterThan(0n);
+    // (2^80)^2 / 2^192 = 2^-32 of the backing.
+    expect(scaled).toBe(vaultPrice / 2n ** 32n);
+  });
+
+  it("reports no price rather than a misleading zero", () => {
+    expect(genesisBackingInNumeraire(0n, statics, statics, vaultPrice)).toBeNull();
+    expect(genesisBackingInNumeraire(1n << 96n, statics, statics, 0n)).toBeNull();
+  });
+});
+
+describe("Genesis acquisition cost", () => {
+  it("adds the native the Vault requires to the backing at market", () => {
+    const backing = parseEther("0.378");
+    const requiredNative = parseEther("0.0037");
+    expect(genesisAcquisitionCost(backing, requiredNative)).toBe(backing + requiredNative);
+  });
+
+  it("stays correct across the Epoch boundary without branching on it", () => {
+    // requiredNative already folds the buy-in in, and is fee-only during the
+    // Epoch, so the same call covers both phases.
+    const backing = parseEther("0.378");
+    const duringEpoch = genesisAcquisitionCost(backing, parseEther("0.003"));
+    const afterEpoch = genesisAcquisitionCost(backing, parseEther("0.0037532"));
+    expect(afterEpoch).toBeGreaterThan(duringEpoch!);
+  });
+
+  it("propagates an absent price", () => {
+    expect(genesisAcquisitionCost(null, parseEther("0.003"))).toBeNull();
+  });
+});


### PR DESCRIPTION
Stacked on #31, which is stacked on #30. Review in that order — the diff below is only the Overview.

## Why

The launch Overview showed nine equal-weight `ui-stat` tiles in a grid borrowed from the Genesis page. One of them read `Active until Sep 12, 2026, 4:05 PM`, and after the deadline, just `Complete`.

`genesisEpochEnd` is `immutable`. It is fixed at Vault construction and cannot move, and three economics change the moment it passes:

| | During the Epoch | After |
|---|---|---|
| Acquire | `GENESIS_PRICE` + native fee | **+ `ceil(reserve / 5,554)` buy-in** |
| Redeem | `GENESIS_PRICE`, **no ETH** | **+ `floor(reserve / 5,555)`** |
| Credit | reverts `CreditUnavailableDuringEpoch` | opens, to `GENESIS_MAX_CREDIT_PRINCIPAL` |

None of that was stated anywhere in the app. A holder would wake up to materially different economics with no warning.

## What changed

**The Epoch leads the page** — a live countdown and the three changes side by side, each quoted from `quoteGenesisPurchase` and `quoteGenesisRedemption` (both already in `currentGenesisVaultAbi`, both already read by the Swap page).

**The buy-in is quoted from the current reserve, not as zero.** This is the subtle one. `buyGenesis` adds the acquisition fee to `reserveETH` on every sale *whether or not the Epoch is running* — the contract comment says so directly: *"the fee always accretes to the reserve; the buy-in joins it after the epoch."* So the amount owed at the boundary is climbing the whole time, and after the Epoch it compounds, because each sale returns its own buy-in. Simulating from a plausible mid-Epoch state: `0.00044` at 1,375 circulating, `0.00073` when the Epoch ends, `0.0042` by full sellout. Showing `0` during the Epoch would read as a settled future price. It is labelled as rising, in both phases.

**A solvency panel, at no extra request.** `_enforceSolvency` holds three invariants on every state change: backing ≥ required, STATICS custody ≥ backing, ETH custody ≥ reserve. `vaultAccounting` returns `tokenCustody` and `nativeCustody` for no purpose other than letting a client verify them — and I counted usages of all fifteen struct fields: `mintedSupply`, `grossBacking`, `tokenCustody` and `nativeCustody` were fetched on every Overview load and rendered **nowhere in the codebase**. The panel checks all three and shows the reconciliation (`gross − credit drawn = required ≤ held`) that makes the backing figure add up. `outstandingGenesisCredit` was likewise fetched and hidden, which is why the backing number looked unexplained.

**Supply is one division**, not two tiles that each omitted the 5,555 denominator.

**Market gained the derived figure that is actually the decision** — what `vaultPrice` STATICS is *worth* at market, against what a Genesis costs all in. A raw `WETH per STATICS` ratio never answered whether the Vault price is cheap.

**A position strip** — your STATICS, your Genesis, anything claimable, or one connect prompt when signed out instead of a row of em-dashes.

## One refactor worth a look

`lib/genesis/owned.ts` extracts the owned-Genesis walk out of `StandaloneGenesisPage`. Both surfaces now mount the same query key and fetcher, so they share one cache entry instead of each paying for a discovery call plus seven reads per NFT. `summariseGenesisRewards` is shared too, so both quote the same claimable totals and the same claim signature count.

## Deliberately not done

The `Open My Genesis` button names its destination rather than an action, because claiming is currently one transaction per NFT per asset and My Genesis is where that sequence is priced honestly. `summariseGenesisRewards.claimTransactionCount` carries a comment marking where the batch entry point collapses this to 1 — a small swap once the contract change lands.

## Validation

- `npm test` — 104 files, 562 tests passed (was 554; 8 new, including unit coverage for the pool-ordering inversion in the market-value math, which is easy to get backwards and silently wrong).
- `npm run typecheck` — passed.
- `npm run lint` — passed; one pre-existing simulator warning.
- `npm run lint:css` — passed.
- `npm run format:check` — passed.
- `npm run build` — passed.

Not run: `npm run verify:genesis-launch-fork`. Presentation plus two added view calls — no transaction shape moved — but the fork harness is the right gate before merge and I have not driven it.

https://claude.ai/code/session_01CXJpvfPVqtsSDDgYKRarXd