### PR TITLE
fix(trade): repair the swap deadline and rebuild the trade card

### DIFF
--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -483,37 +483,6 @@
   cursor: not-allowed;
 }
 
-.dapp-approval-disclosure {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1rem;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1.5rem;
-  padding: 0.875rem 1rem;
-  border: 1px solid var(--app-border);
-  border-radius: var(--radius-lg);
-  background: var(--app-surface);
-  color: var(--app-text-secondary);
-  font-size: var(--text-sm);
-}
-
-.dapp-approval-disclosure p {
-  flex: 1 1 28rem;
-  margin: 0;
-  line-height: var(--leading-normal);
-}
-
-.dapp-approval-disclosure strong {
-  color: var(--app-text);
-}
-
-.dapp-approval-disclosure a {
-  color: var(--accent);
-  font-weight: 650;
-  text-decoration: none;
-}
-
 .dapp-header-actions,
 .dapp-wallet-actions {
   display: flex;
@@ -1698,10 +1667,15 @@
 .wallet-surface,
 .portal-workspace,
 .swap-page {
-  margin-top: 10px;
-  border: 1px solid var(--app-border);
-  background: var(--app-surface);
-  border-radius: var(--radius-md);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+  width: min(34rem, 100%);
+  margin: 1.5rem auto 0;
+}
+
+.swap-page > * {
+  min-width: 0;
 }
 
 .wallet-network-row {
@@ -1717,7 +1691,17 @@
 .portal-field {
   display: grid;
   gap: 0.55rem;
-  min-width: min(100%, 250px);
+  min-width: 0;
+}
+
+/* The label, and only the label. Setting these on the container leaked the
+ * casing and tracking into the amount input, which is nothing but digits. */
+.wallet-network-row label > span,
+.portal-field > span,
+/* The Solana and bridge panels nest their label inside the field head, so it is
+ * not a direct child of .portal-field. */
+.portal-asset-field-head > span:first-of-type,
+.portal-field-label {
   color: var(--app-text-muted);
   font-size: var(--text-caption);
   letter-spacing: 0.08em;
@@ -1735,9 +1719,9 @@
 .portal-chain-tabs button,
 .portal-primary-action,
 .wallet-quick-actions button {
-  min-height: 44px;
+  min-height: var(--control-height);
   border: 1px solid var(--app-border-strong);
-  border-radius: 0;
+  border-radius: var(--radius-md);
   background: var(--app-surface);
   color: var(--app-text);
   font: inherit;
@@ -2314,17 +2298,14 @@
   max-width: 760px;
 }
 
-.swap-page {
-  display: grid;
-  max-width: 760px;
-}
-
 .genesis-vault-swap {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
 }
 
-.genesis-vault-swap > .portal-panel + .portal-panel {
-  border-top: 1px solid var(--app-border);
+.genesis-vault-swap > * {
+  min-width: 0;
 }
 
 .portal-workspace.is-compact {
@@ -2344,9 +2325,29 @@
 
 .portal-direction-tabs {
   grid-template-columns: repeat(2, 1fr);
-  padding: 0;
-  border: 0;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid var(--app-border);
   border-radius: var(--radius-md);
+  background: var(--app-surface);
+}
+
+.portal-direction-tabs button {
+  min-height: 2.5rem;
+  border: 0;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.portal-direction-tabs button:hover {
+  background: var(--app-raised);
+}
+
+.dapp-shell .portal-direction-tabs button[aria-selected="true"] {
+  border-color: transparent;
+  background: var(--app-raised);
+  box-shadow: inset 0 0 0 1px var(--app-border-strong);
+  color: var(--app-text);
 }
 
 .portal-chain-tabs {
@@ -2374,8 +2375,23 @@
 
 .portal-panel {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 0.85rem;
-  padding: clamp(1.25rem, 4vw, 2rem);
+  padding: clamp(1.25rem, 4vw, 1.5rem);
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-lg);
+  background: var(--app-surface);
+}
+
+.portal-panel > * {
+  min-width: 0;
+}
+
+/* The Portal workspace supplies its own frame, so the panel stays flat there. */
+.portal-workspace .portal-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .portal-field {
@@ -2383,31 +2399,88 @@
 }
 
 .portal-asset-field {
-  padding: 1rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
   border: 1px solid var(--app-border);
-  background: var(--app-surface);
-  border-radius: var(--radius-lg);
+  background: var(--app-sunken);
+  border-radius: var(--radius-md);
 }
 
 .portal-asset-field > div {
-  display: grid;
-  gap: 0.6rem;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
 .portal-asset-field input {
+  width: 100%;
   min-width: 0;
-  font-size: var(--text-lg);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: var(--text-3xl);
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.portal-asset-field input:focus {
+  outline: none;
+}
+
+.portal-asset-field input[readonly] {
+  color: var(--app-text-secondary);
 }
 
 .portal-asset-field select {
-  min-width: 90px;
+  flex: 0 1 auto;
+  min-width: 0;
+  min-height: 2.375rem;
+  padding: 0 0.75rem;
   border: 1px solid var(--app-border-strong);
-  background: var(--app-surface);
+  border-radius: var(--radius-pill);
+  background: var(--app-raised);
   color: var(--app-text);
   font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
   text-align: center;
-  border-radius: var(--radius-md);
+  white-space: nowrap;
+}
+
+.portal-asset-field select:hover {
+  background: var(--app-overlay);
+}
+
+.portal-asset-field-foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem 0.75rem;
+  min-width: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.portal-asset-max {
+  min-height: 0;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--accent);
+  font-size: var(--text-caption);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.portal-asset-max:hover:not(:disabled) {
+  background: var(--accent-wash);
 }
 
 .portal-asset-field small {
@@ -2415,14 +2488,24 @@
 }
 
 .portal-switch-assets {
-  width: 44px;
-  min-height: var(--control-height);
-  margin: -0.45rem auto;
-  border: 1px solid var(--accent);
-  background: var(--app-surface);
+  display: grid;
+  place-items: center;
+  width: 2.375rem;
+  height: 2.375rem;
+  min-height: 0;
+  margin: -1.4rem auto;
+  padding: 0;
+  border: 4px solid var(--app-surface);
+  border-radius: 50%;
+  background: var(--app-raised);
   color: var(--accent);
   cursor: pointer;
-  border-radius: var(--radius-md);
+  position: relative;
+  z-index: 1;
+}
+
+.portal-switch-assets:hover:not(:disabled) {
+  background: var(--app-overlay);
 }
 
 .portal-switch-assets:disabled {
@@ -2496,38 +2579,65 @@
 
 .portal-quote-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
+  gap: 0.1rem;
   margin: 0;
-  background: var(--app-border);
-  border: 1px solid var(--app-border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
 }
 
 .portal-quote-grid > div {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.25rem 1rem;
   min-width: 0;
-  padding: 0.9rem;
-  background: var(--app-surface);
-  border-radius: var(--radius-lg);
+  padding: 0.45rem 0.25rem;
 }
 
 .portal-quote-grid dt {
   color: var(--app-text-muted);
-  font-size: var(--text-caption);
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-.portal-quote-grid dd {
-  margin: 0.65rem 0 0;
   font-size: var(--text-sm);
 }
 
-.portal-primary-action {
+.portal-quote-grid dd {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.portal-quote-grid dd.is-positive {
+  color: var(--accent);
+}
+
+.portal-quote-grid dd.is-warning {
+  color: var(--warning);
+}
+
+.portal-quote-grid dd.is-negative {
+  color: var(--negative);
+}
+
+.dapp-shell .portal-primary-action {
   width: 100%;
-  border-color: var(--accent);
-  background: var(--accent-wash);
+  border-color: transparent;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+.dapp-shell .portal-primary-action:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.dapp-shell .portal-primary-action:active:not(:disabled) {
+  background: var(--accent-press);
+}
+
+/* Disabled is a state, not a faded action: a dimmed accent fill reads as a
+ * muddy olive that still competes for the eye. */
+.dapp-shell .portal-primary-action:disabled {
+  border-color: var(--app-border-strong);
+  background: var(--app-raised);
+  color: var(--app-text-muted);
 }
 
 .portal-error {
@@ -7248,4 +7358,195 @@
   .genesis-carousel-rail {
     scroll-behavior: auto;
   }
+}
+
+/* ---- Genesis Vault trade card ---------------------------------------- */
+
+.vault-hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.vault-hero .wallet-nft-art,
+.vault-hero .wallet-nft-art-trigger {
+  width: 8rem;
+  height: 8rem;
+  flex: none;
+  aspect-ratio: 1;
+}
+
+.vault-hero-copy {
+  display: grid;
+  gap: 0.3rem;
+  justify-items: start;
+  flex: 1 1 14rem;
+  min-width: 0;
+}
+
+.vault-hero-copy h3 {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: 650;
+}
+
+.vault-hero-copy p {
+  margin: 0;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+/* Each leg of the price, against what the wallet actually holds. */
+.vault-legs {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.vault-legs li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.25rem 1rem;
+  padding: 0.7rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+}
+
+.vault-legs li > span {
+  min-width: 0;
+  color: var(--app-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.vault-legs li > strong {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.vault-legs li > small {
+  grid-column: 1 / -1;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-variant-numeric: tabular-nums;
+}
+
+.vault-legs li.is-short {
+  background: var(--negative-wash);
+}
+
+.vault-legs li.is-short > small {
+  color: var(--negative);
+}
+
+.vault-notice {
+  margin: 0;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+.vault-notice.is-error {
+  background: var(--negative-wash);
+  color: var(--negative);
+}
+
+.vault-notice a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.vault-owned {
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+  scrollbar-width: thin;
+}
+
+.vault-owned-card {
+  flex: 0 0 calc((100% - 2 * 0.5rem) / 3);
+  min-width: 6rem;
+  padding: 0.5rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+  background: var(--app-sunken);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.vault-owned-card:hover:not(:disabled) {
+  background: var(--app-raised);
+}
+
+.vault-owned-card[aria-checked="true"] {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.vault-owned-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.vault-owned-card .wallet-nft-art,
+.vault-owned-card .wallet-nft-art-trigger {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+}
+
+.vault-owned-card span {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.vault-owned-card small {
+  display: block;
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+}
+
+.vault-owned-card:disabled small {
+  color: var(--negative);
+}
+
+.vault-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.75rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0.6rem 0.875rem;
+  border-radius: var(--radius-md);
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.vault-strip b {
+  color: var(--app-text);
+  font-weight: 600;
+}
+
+.vault-strip a {
+  margin-left: auto;
+  color: var(--accent);
+}
+
+.vault-strip a:hover {
+  text-decoration: underline;
 }

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -1665,7 +1665,13 @@
 }
 
 .wallet-surface,
-.portal-workspace,
+.portal-workspace {
+  margin-top: 10px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+  background: var(--app-surface);
+}
+
 .swap-page {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -1687,7 +1693,17 @@
   border-bottom: 1px solid var(--app-border);
 }
 
-.wallet-network-row label,
+.wallet-network-row label {
+  display: grid;
+  gap: 0.55rem;
+  min-width: min(100%, 250px);
+  color: var(--app-text-muted);
+  font-size: var(--text-caption);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .portal-field {
   display: grid;
   gap: 0.55rem;
@@ -1696,7 +1712,6 @@
 
 /* The label, and only the label. Setting these on the container leaked the
  * casing and tracking into the amount input, which is nothing but digits. */
-.wallet-network-row label > span,
 .portal-field > span,
 /* The Solana and bridge panels nest their label inside the field head, so it is
  * not a direct child of .portal-field. */
@@ -1725,6 +1740,15 @@
   background: var(--app-surface);
   color: var(--app-text);
   font: inherit;
+}
+
+/* Keep the established Wallet controls unchanged. Trade controls share the
+ * base rule above, but their redesign must not leak into the Wallet page. */
+.wallet-network-row select,
+.wallet-network-row button,
+.wallet-quick-actions button {
+  min-height: 44px;
+  border-radius: 0;
 }
 
 .wallet-network-row select,

--- a/app/(dapp)/app/genesis/page.tsx
+++ b/app/(dapp)/app/genesis/page.tsx
@@ -5,7 +5,7 @@ import { GenesisPage } from "@/components/genesis/GenesisPage";
 export const metadata: Metadata = {
   title: "Genesis | Statics",
   description:
-    "View and activate the Statics Genesis NFTs held by your connected wallet, and manage their launch rewards.",
+    "View and activate the Statics Operators NFTs held by your connected wallet, and manage their launch rewards.",
 };
 
 export default function GenesisRoute() {

--- a/app/(dapp)/app/genesis/recoveries/page.tsx
+++ b/app/(dapp)/app/genesis/recoveries/page.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from "next";
 import { GenesisRecoveriesPage } from "@/components/genesis/GenesisRecoveriesPage";
 
 export const metadata: Metadata = {
-  title: "Genesis recoveries | Statics",
+  title: "Operator recoveries | Statics",
   description:
-    "Discover Genesis NFTs whose secured credit has matured and recover them permissionlessly for the caller incentive.",
+    "Discover Operators NFTs whose secured credit has matured and recover them permissionlessly for the caller incentive.",
 };
 
 export default function GenesisRecoveriesRoute() {

--- a/app/(dapp)/app/swap/page.tsx
+++ b/app/(dapp)/app/swap/page.tsx
@@ -4,7 +4,7 @@ import { SwapPage } from "@/components/swap/SwapPage";
 
 export const metadata: Metadata = {
   title: "Swap | Statics",
-  description: "Swap through the canonical STATICS market or the backed Genesis NFT Vault.",
+  description: "Swap through the canonical STATICS market or the backed Operator NFT Vault.",
 };
 
 export default function SwapRoute() {

--- a/components/app-shell/AppShell.tsx
+++ b/components/app-shell/AppShell.tsx
@@ -17,17 +17,6 @@ function formatAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
-const approvalDisclosureRoutes = [
-  "/app/swap",
-  "/app/dollar",
-  "/app/baskets",
-  "/app/positions",
-  "/app/loans",
-  "/app/rewards",
-  "/app/genesis",
-  "/app/liquidity",
-] as const;
-
 function WalletHeaderControls() {
   const wallet = useWalletState();
   const [accountOpen, setAccountOpen] = useState(false);
@@ -255,9 +244,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       ? tLaunchRoutes(`${routeId}.description`)
       : tRoutes(`${routeId}.description`),
   };
-  const showApprovalDisclosure = approvalDisclosureRoutes.some(
-    (route) => currentPath === route || currentPath.startsWith(`${route}/`)
-  );
   const closeNavigation = (restoreFocus = true) => {
     setOpenNavigationPath(null);
     if (restoreFocus) {
@@ -394,15 +380,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <p className="dapp-inline-error" role="alert">
               {wallet.error}
             </p>
-          )}
-
-          {showApprovalDisclosure && (
-            <aside className="dapp-approval-disclosure" aria-label={tShell("approvalsTitle")}>
-              <p>
-                <strong>{tShell("approvalsTitle")}</strong> {tShell("approvalsBody")}
-              </p>
-              <Link href="/app/tools">{tShell("manageApprovals")} →</Link>
-            </aside>
           )}
 
           {children}

--- a/components/baskets/BasketCreatePage.tsx
+++ b/components/baskets/BasketCreatePage.tsx
@@ -101,6 +101,7 @@ function BasketCreateRuntime() {
   const [ltvPercent, setLtvPercent] = useState(bpsToPercentInput(7_500));
   const [recoveryPercent, setRecoveryPercent] = useState(bpsToPercentInput(500));
   const [loanDurationDays, setLoanDurationDays] = useState("30");
+  const MAX_LOAN_DURATION_DAYS = Math.floor(Number((1n << 40n) - 1n) / 86_400);
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState<ProtocolActionProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -224,6 +225,7 @@ function BasketCreateRuntime() {
     Object.values(economics).every((value) => value !== null) &&
     Number.isSafeInteger(durationDays) &&
     durationDays > 0 &&
+    durationDays <= MAX_LOAN_DURATION_DAYS &&
     (economics.ltv ?? 0) + Math.ceil(((economics.ltv ?? 0) * (economics.recovery ?? 0)) / 10_000) <=
       10_000;
   const identityValid = Boolean(name.trim()) && /^[A-Za-z][A-Za-z0-9-]{1,10}$/.test(symbol.trim());

--- a/components/genesis/GenesisCarousel.tsx
+++ b/components/genesis/GenesisCarousel.tsx
@@ -190,7 +190,7 @@ export function GenesisCarousel({
         ref={railRef}
         onScroll={syncOverflow}
         role="tablist"
-        aria-label="Select a Operator NFT"
+        aria-label="Select an Operator NFT"
       >
         {visible.map((item) => {
           const isSelected = item.id === selectedId;
@@ -226,14 +226,14 @@ export function GenesisCarousel({
                   kind: "collection",
                   tokenId: item.id,
                   contract: collection,
-                  name: `Genesis #${item.id}`,
+                  name: `Operator #${item.id}`,
                   summary: `Tier ${item.tier}`,
                   carries: [],
                   blockedReason: null,
                 }}
               />
               <span className="genesis-carousel-id">
-                Genesis #{item.id.toString()}
+                Operator #{item.id.toString()}
                 <b>T{item.tier}</b>
               </span>
               <span className="genesis-carousel-flags">

--- a/components/genesis/GenesisCarousel.tsx
+++ b/components/genesis/GenesisCarousel.tsx
@@ -29,7 +29,7 @@ function matches(item: GenesisCarouselItem, filter: Filter): boolean {
 }
 
 /**
- * The wallet's Genesis NFTs, as a paged rail rather than a wrapping chip row.
+ * The wallet's Operators NFTs, as a paged rail rather than a wrapping chip row.
  *
  * A wrapping row is fine at three NFTs and unusable at thirty: it grows a new
  * line for every few tokens, pushes the NFT you are managing below the fold,
@@ -119,9 +119,9 @@ export function GenesisCarousel({
   const selected = items.find((item) => item.id === selectedId) ?? null;
 
   return (
-    <section className="genesis-carousel" aria-label="Your Genesis NFTs">
+    <section className="genesis-carousel" aria-label="Your Operators NFTs">
       <div className="genesis-carousel-head">
-        <h2 className="ui-section-title">Your Genesis</h2>
+        <h2 className="ui-section-title">Your Operators</h2>
         <span className="genesis-carousel-count">
           {items.length} held{selected ? ` · #${selected.id} selected` : ""}
         </span>
@@ -144,7 +144,7 @@ export function GenesisCarousel({
                 type="button"
                 onClick={() => page(-1)}
                 disabled={!overflow.start}
-                aria-label="Previous Genesis NFTs"
+                aria-label="Previous Operators NFTs"
               >
                 <span aria-hidden="true">‹</span>
               </button>
@@ -152,7 +152,7 @@ export function GenesisCarousel({
                 type="button"
                 onClick={() => page(1)}
                 disabled={!overflow.end}
-                aria-label="More Genesis NFTs"
+                aria-label="More Operators NFTs"
               >
                 <span aria-hidden="true">›</span>
               </button>
@@ -190,7 +190,7 @@ export function GenesisCarousel({
         ref={railRef}
         onScroll={syncOverflow}
         role="tablist"
-        aria-label="Select a Genesis NFT"
+        aria-label="Select a Operator NFT"
       >
         {visible.map((item) => {
           const isSelected = item.id === selectedId;

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -253,7 +253,7 @@ export function GenesisCreditPanel({
     setBusy(key);
     setError(null);
     try {
-      if (!publicClient || !wallet) return;
+      if (!publicClient || !wallet || !walletState.isTargetChain) return;
       await verifyLaunchDeployment(publicClient, deployment);
       await action();
       await refresh();
@@ -273,7 +273,7 @@ export function GenesisCreditPanel({
   }
 
   const credit = state.data.credit;
-  const maxPrincipal = state.data.limit > 0n ? state.data.limit : GENESIS_MAX_CREDIT_PRINCIPAL;
+  const maxPrincipal = state.data.limit;
   const backing = state.data.vaultPrice;
 
   if (credit.active) {
@@ -483,7 +483,7 @@ export function GenesisCreditPanel({
 
       <div className="genesis-borrow">
         <p className="genesis-borrow-amount">
-          <b>{formatTokenAmountGrouped(clamped, 18, 0)}</b>
+          <b>{formatTokenAmountGrouped(clamped, 18, 2)}</b>
           <span>STATICS · {ltv.toFixed(0)}% of backing</span>
         </p>
         <label className="ui-field">
@@ -563,7 +563,7 @@ export function GenesisCreditPanel({
       >
         {busy === "open"
           ? "Borrowing…"
-          : `Borrow ${formatTokenAmountGrouped(clamped, 18, 0)} STATICS`}
+          : `Borrow ${formatTokenAmountGrouped(clamped, 18, 2)} STATICS`}
       </button>
 
       {error && (

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { encodeFunctionData, formatEther, getAddress, parseEther } from "viem";
-import { usePublicClient } from "wagmi";
+import { useBlock, usePublicClient } from "wagmi";
 import { dopplerStaticsTokenAbi } from "@statics-protocol/sdk";
 import {
   GENESIS_MAX_CREDIT_PRINCIPAL,
@@ -152,19 +152,17 @@ export function GenesisCreditPanel({
 }) {
   const walletState = useWalletState();
   const publicClient = usePublicClient({ chainId: deployment.descriptor.chainId });
+  const { data: latestBlock } = useBlock({
+    chainId: deployment.descriptor.chainId,
+    watch: true,
+  });
   const queryClient = useQueryClient();
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
   const [amount, setAmount] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [now, setNow] = useState(() => Math.floor(Date.now() / 1_000));
-  useEffect(() => {
-    const timer = window.setInterval(() => {
-      setNow(Math.floor(Date.now() / 1_000));
-    }, 1_000);
-    return () => window.clearInterval(timer);
-  }, []);
+  const now = latestBlock ? Number(latestBlock.timestamp) : null;
 
   const state = useQuery({
     queryKey: [
@@ -267,7 +265,7 @@ export function GenesisCreditPanel({
     }
   };
 
-  if (!wallet || state.isLoading) {
+  if (!wallet || state.isLoading || now === null) {
     return <p className="dapp-loading">Loading secured credit…</p>;
   }
   if (state.error || !state.data) {

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -433,7 +433,7 @@ export function GenesisCreditPanel({
       >
         <div className="genesis-panel-head">
           <h3>Secured credit</h3>
-          <p>Borrowing against a Genesis NFT opens once the Genesis Epoch ends.</p>
+          <p>Borrowing against a Operator NFT opens once the Genesis Epoch ends.</p>
         </div>
         <div className="genesis-locked">
           <strong>{formatCountdown(state.data.genesisEpochEnd - now)}</strong>

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -287,7 +287,7 @@ export function GenesisCreditPanel({
     return (
       <section
         className="ui-card genesis-panel"
-        aria-label={`Genesis #${genesisId} secured credit`}
+        aria-label={`Operator #${genesisId} secured credit`}
       >
         <div className="genesis-panel-head">
           <h3>Secured credit — active</h3>
@@ -359,7 +359,7 @@ export function GenesisCreditPanel({
                 );
                 await send(
                   "extend-genesis-credit",
-                  `Extend Genesis #${genesisId} credit`,
+                  `Extend Operator #${genesisId} credit`,
                   transaction.data,
                   `${formatEther(quote.totalNativeFee)} ETH fee`,
                   transaction.value
@@ -403,7 +403,7 @@ export function GenesisCreditPanel({
                 }
                 await send(
                   "repay-genesis-credit",
-                  `Repay Genesis #${genesisId} credit`,
+                  `Repay Operator #${genesisId} credit`,
                   buildRepayGenesisCreditCall(genesisId),
                   `${formatEther(credit.principal)} STATICS`
                 );
@@ -429,11 +429,11 @@ export function GenesisCreditPanel({
     return (
       <section
         className="ui-card genesis-panel"
-        aria-label={`Genesis #${genesisId} secured credit`}
+        aria-label={`Operator #${genesisId} secured credit`}
       >
         <div className="genesis-panel-head">
           <h3>Secured credit</h3>
-          <p>Borrowing against a Operator NFT opens once the Genesis Epoch ends.</p>
+          <p>Borrowing against an Operator NFT opens once the Genesis Epoch ends.</p>
         </div>
         <div className="genesis-locked">
           <strong>{formatCountdown(state.data.genesisEpochEnd - now)}</strong>
@@ -451,7 +451,7 @@ export function GenesisCreditPanel({
     return (
       <section
         className="ui-card genesis-panel"
-        aria-label={`Genesis #${genesisId} secured credit`}
+        aria-label={`Operator #${genesisId} secured credit`}
       >
         <div className="genesis-panel-head">
           <h3>Secured credit</h3>
@@ -474,7 +474,7 @@ export function GenesisCreditPanel({
   const maxLtv = backing > 0n ? Number((maxPrincipal * 10_000n) / backing) / 100 : 0;
 
   return (
-    <section className="ui-card genesis-panel" aria-label={`Genesis #${genesisId} secured credit`}>
+    <section className="ui-card genesis-panel" aria-label={`Operator #${genesisId} secured credit`}>
       <div className="genesis-panel-head">
         <h3>Borrow against this Genesis</h3>
         <p>
@@ -554,7 +554,7 @@ export function GenesisCreditPanel({
             );
             await send(
               "open-genesis-credit",
-              `Borrow against Genesis #${genesisId}`,
+              `Borrow against Operator #${genesisId}`,
               transaction.data,
               `${formatEther(clamped)} STATICS + ${formatEther(quote.totalNativeFee)} ETH fee`,
               transaction.value

--- a/components/genesis/GenesisIdentityPanel.tsx
+++ b/components/genesis/GenesisIdentityPanel.tsx
@@ -57,7 +57,7 @@ export function GenesisIdentityPanel({
   );
 
   return (
-    <aside className="genesis-identity ui-card" aria-label={`Genesis #${id} details`}>
+    <aside className="genesis-identity ui-card" aria-label={`Operator #${id} details`}>
       <div className="genesis-identity-art">
         <NftArtwork
           chainId={chainId}
@@ -67,7 +67,7 @@ export function GenesisIdentityPanel({
             kind: "collection",
             tokenId: id,
             contract: collection,
-            name: `Genesis #${id}`,
+            name: `Operator #${id}`,
             summary: `Tier ${tier}`,
             carries: [],
             blockedReason: creditActive ? "Repay secured credit before transfer." : null,
@@ -77,7 +77,7 @@ export function GenesisIdentityPanel({
 
       <div className="genesis-identity-heading">
         <div>
-          <h2 className="ui-section-title">Genesis #{id.toString()}</h2>
+          <h2 className="ui-section-title">Operator #{id.toString()}</h2>
           <p className="genesis-identity-sub">1 of {maximumSupply.toString()} · fully backed</p>
         </div>
         <span className="genesis-tier-badge" data-tier={tier}>

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -33,9 +33,9 @@ import { StandaloneGenesisPage } from "@/components/genesis/StandaloneGenesisPag
 function describeGenesisError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes("GenesisLinkedOnTransfer"))
-    return "Unlink this Genesis NFT before transferring it.";
-  if (message.includes("GenesisAlreadyLinked")) return "This Genesis NFT is already linked.";
-  if (message.includes("PositionAlreadyLinked")) return "That Position already has a Genesis NFT.";
+    return "Unlink this Operator NFT before transferring it.";
+  if (message.includes("GenesisAlreadyLinked")) return "This Operator NFT is already linked.";
+  if (message.includes("PositionAlreadyLinked")) return "That Position already has a Operator NFT.";
   if (message.includes("InvalidActivationTier")) return "Choose a higher activation tier.";
   if (message.includes("ERC20InsufficientAllowance"))
     return "Approve STATICS before activating this tier.";
@@ -151,10 +151,10 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
     return (
       <EmptyState
         title="Connect your wallet"
-        description="Connect to view and activate your Genesis NFTs."
+        description="Connect to view and activate your Operators NFTs."
       />
     );
-  if (portfolio.isLoading) return <p className="dapp-loading">Loading Genesis NFTs…</p>;
+  if (portfolio.isLoading) return <p className="dapp-loading">Loading Operators NFTs…</p>;
   if (portfolio.isError)
     return (
       <EmptyState
@@ -166,8 +166,8 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
   if (!portfolio.data?.genesis.length) {
     return (
       <EmptyState
-        title="No Genesis NFTs found"
-        description="This wallet does not currently own a Statics Genesis NFT."
+        title="No Operators NFTs found"
+        description="This wallet does not currently own a Statics Operators NFT."
       />
     );
   }
@@ -430,7 +430,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
         <AddressDisplay
           address={genesisDeployment.collection}
           chainId={deployment.chainId}
-          label="Genesis NFT"
+          label="Operator NFT"
         />
         <AddressDisplay
           address={genesisDeployment.token}

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -35,7 +35,8 @@ function describeGenesisError(error: unknown): string {
   if (message.includes("GenesisLinkedOnTransfer"))
     return "Unlink this Operator NFT before transferring it.";
   if (message.includes("GenesisAlreadyLinked")) return "This Operator NFT is already linked.";
-  if (message.includes("PositionAlreadyLinked")) return "That Position already has an Operator NFT.";
+  if (message.includes("PositionAlreadyLinked"))
+    return "That Position already has an Operator NFT.";
   if (message.includes("InvalidActivationTier")) return "Choose a higher activation tier.";
   if (message.includes("ERC20InsufficientAllowance"))
     return "Approve STATICS before activating this tier.";

--- a/components/genesis/GenesisPage.tsx
+++ b/components/genesis/GenesisPage.tsx
@@ -35,7 +35,7 @@ function describeGenesisError(error: unknown): string {
   if (message.includes("GenesisLinkedOnTransfer"))
     return "Unlink this Operator NFT before transferring it.";
   if (message.includes("GenesisAlreadyLinked")) return "This Operator NFT is already linked.";
-  if (message.includes("PositionAlreadyLinked")) return "That Position already has a Operator NFT.";
+  if (message.includes("PositionAlreadyLinked")) return "That Position already has an Operator NFT.";
   if (message.includes("InvalidActivationTier")) return "Choose a higher activation tier.";
   if (message.includes("ERC20InsufficientAllowance"))
     return "Approve STATICS before activating this tier.";
@@ -158,7 +158,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
   if (portfolio.isError)
     return (
       <EmptyState
-        title="Genesis data unavailable"
+        title="Operators data unavailable"
         description={portfolio.error.message}
         tone="error"
       />
@@ -233,7 +233,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
           <strong className="ui-stat__value">{formatEther(portfolio.data.balance)} STATICS</strong>
         </div>
         <div className="ui-stat">
-          <span className="ui-stat__label">Genesis collection</span>
+          <span className="ui-stat__label">Operators collection</span>
           <strong className="ui-stat__value">5,555 fixed NFTs</strong>
         </div>
         <div className="ui-stat">
@@ -262,7 +262,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
             <article className="ui-card genesis-card" key={actionKey}>
               <div className="genesis-card-heading">
                 <div>
-                  <h2 className="ui-section-title">Genesis #{actionKey}</h2>
+                  <h2 className="ui-section-title">Operator #{actionKey}</h2>
                   <span className="ui-pill">
                     Tier {currentTier} · {(Number(state.multiplierBps) / 10_000).toFixed(2)}×
                   </span>
@@ -274,7 +274,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                     kind: "collection",
                     tokenId: id,
                     contract: genesisDeployment.collection,
-                    name: `Genesis #${actionKey}`,
+                    name: `Operator #${actionKey}`,
                     summary: `Tier ${currentTier}`,
                     carries: [],
                     blockedReason: linked ? "Unlink before transfer." : null,
@@ -344,7 +344,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                           if (linked) await checkpointPosition(state.linkedPositionId);
                           await send(
                             "activate-genesis",
-                            `Activate Genesis #${actionKey} to tier ${target}`,
+                            `Activate Operator #${actionKey} to tier ${target}`,
                             buildActivateGenesisCall(id, target, cost),
                             `${formatEther(cost)} STATICS activation payment`
                           );
@@ -365,7 +365,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                       await checkpointPosition(state.linkedPositionId);
                       await send(
                         "unlink-genesis",
-                        `Unlink Genesis #${actionKey}`,
+                        `Unlink Operator #${actionKey}`,
                         buildUnlinkGenesisCall(id),
                         `Position #${state.linkedPositionId}`
                       );
@@ -403,7 +403,7 @@ function GenesisRuntime({ deployment }: { deployment: DollarDeployment }) {
                         await checkpointPosition(positionId);
                         await send(
                           "link-genesis",
-                          `Link Genesis #${actionKey}`,
+                          `Link Operator #${actionKey}`,
                           buildLinkGenesisCall(id, positionId),
                           `Position #${positionId}`
                         );

--- a/components/genesis/GenesisRecoveriesPage.tsx
+++ b/components/genesis/GenesisRecoveriesPage.tsx
@@ -179,6 +179,16 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
     }
   };
 
+  if (epoch.isLoading) {
+    return <p className="dapp-loading">Checking recovery availability…</p>;
+  }
+  if (epoch.error) {
+    return (
+      <p className="dapp-inline-error" role="alert">
+        Recovery availability is temporarily unavailable.
+      </p>
+    );
+  }
   if (epoch.data !== false) {
     return (
       <EmptyState
@@ -253,7 +263,9 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
                 disabled={busy !== null && busy !== credit.genesisId}
                 onClick={() => void recover(credit)}
               >
-                {busy === credit.genesisId ? "Recovering…" : `Recover Operator #${credit.genesisId}`}
+                {busy === credit.genesisId
+                  ? "Recovering…"
+                  : `Recover Operator #${credit.genesisId}`}
               </button>
             </article>
           ))}

--- a/components/genesis/GenesisRecoveriesPage.tsx
+++ b/components/genesis/GenesisRecoveriesPage.tsx
@@ -45,7 +45,7 @@ function displayTimestamp(timestamp: bigint): string {
 
 export function GenesisRecoveriesPage() {
   const { active } = useDeployment();
-  if (!active.launch) return <UnconfiguredSurface subject="Genesis recoveries" />;
+  if (!active.launch) return <UnconfiguredSurface subject="Operator recoveries" />;
   return <LaunchGenesisRecoveries deployment={active.launch} />;
 }
 
@@ -53,7 +53,7 @@ export function GenesisRecoveriesPage() {
  * Permissionless recovery of other people's defaulted Genesis credit.
  *
  * This is keeper work, not Genesis ownership, which is why it has its own
- * destination: it used to sit as the first tab on My Genesis, so every holder
+ * destination: it used to sit as the first tab on My Operators, so every holder
  * had to step past somebody else's liquidations to reach their own NFTs.
  */
 function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment }) {
@@ -184,7 +184,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
       <EmptyState
         title="Recovery opens after the Genesis Epoch"
         description="Genesis credit cannot be opened, and so cannot default, while the Epoch is running."
-        secondary={{ label: "Back to My Genesis", href: "/app/genesis" }}
+        secondary={{ label: "Back to My Operators", href: "/app/genesis" }}
       />
     );
   }
@@ -207,7 +207,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
         <EmptyState
           title="No recoverable Genesis credits"
           description="No indexed credit is currently eligible for permissionless recovery."
-          secondary={{ label: "Back to My Genesis", href: "/app/genesis" }}
+          secondary={{ label: "Back to My Operators", href: "/app/genesis" }}
         />
       ) : (
         <div className="genesis-grid">

--- a/components/genesis/GenesisRecoveriesPage.tsx
+++ b/components/genesis/GenesisRecoveriesPage.tsx
@@ -35,7 +35,7 @@ function describeRecoveryError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   if (/rejected/i.test(message)) return "The wallet request was rejected.";
   if (message.includes("CreditNotRecoverable")) return "This credit is not recoverable yet.";
-  if (message.includes("CreditNotActive")) return "This Genesis credit is no longer active.";
+  if (message.includes("CreditNotActive")) return "This Operator credit is no longer active.";
   return message || "The recovery transaction failed.";
 }
 
@@ -147,7 +147,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
         chainId: deployment.descriptor.chainId,
         deploymentId: deployment.descriptor.deploymentId,
         kind: "recover-genesis-credit",
-        label: `Recover Genesis #${credit.genesisId}`,
+        label: `Recover Operator #${credit.genesisId}`,
         amount: `${formatEther(credit.callerIncentive)} STATICS caller incentive`,
         to: deployment.contracts.vault,
         data: buildRecoverGenesisCreditCall(credit.genesisId),
@@ -183,7 +183,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
     return (
       <EmptyState
         title="Recovery opens after the Genesis Epoch"
-        description="Genesis credit cannot be opened, and so cannot default, while the Epoch is running."
+        description="Operator credit cannot be opened, and so cannot default, while the Epoch is running."
         secondary={{ label: "Back to My Operators", href: "/app/genesis" }}
       />
     );
@@ -197,15 +197,15 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
         </p>
       )}
       {recoveries.isLoading ? (
-        <p className="dapp-loading">Loading recoverable Genesis credits…</p>
+        <p className="dapp-loading">Loading recoverable Operator credits…</p>
       ) : recoveries.error ? (
         <p className="dapp-inline-error" role="alert">
           Recovery discovery is temporarily unavailable because the deployment indexer could not be
-          reached. Owned Genesis management remains available.
+          reached. Owned Operators management remains available.
         </p>
       ) : !recoveries.data?.length ? (
         <EmptyState
-          title="No recoverable Genesis credits"
+          title="No recoverable Operator credits"
           description="No indexed credit is currently eligible for permissionless recovery."
           secondary={{ label: "Back to My Operators", href: "/app/genesis" }}
         />
@@ -213,7 +213,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
         <div className="genesis-grid">
           {recoveries.data.map((credit) => (
             <article className="ui-card genesis-card" key={credit.genesisId.toString()}>
-              <h2 className="ui-section-title">Genesis #{credit.genesisId.toString()}</h2>
+              <h2 className="ui-section-title">Operator #{credit.genesisId.toString()}</h2>
               <AddressDisplay
                 address={credit.owner}
                 chainId={deployment.descriptor.chainId}
@@ -253,7 +253,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
                 disabled={busy !== null && busy !== credit.genesisId}
                 onClick={() => void recover(credit)}
               >
-                {busy === credit.genesisId ? "Recovering…" : `Recover Genesis #${credit.genesisId}`}
+                {busy === credit.genesisId ? "Recovering…" : `Recover Operator #${credit.genesisId}`}
               </button>
             </article>
           ))}

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -467,8 +467,9 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
 
                 {selectedLocked ? (
                   <p className="vault-notice is-error">
-                    <b>Operator #{selected?.id.toString()} has active secured credit.</b> Repay it in{" "}
-                    <Link href="/app/genesis">My Operators</Link> before this NFT can be redeemed.
+                    <b>Operator #{selected?.id.toString()} has active secured credit.</b> Repay it
+                    in <Link href="/app/genesis">My Operators</Link> before this NFT can be
+                    redeemed.
                   </p>
                 ) : (
                   <ul className="vault-legs">
@@ -492,7 +493,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                 <button
                   className="portal-primary-action"
                   type="button"
-                  disabled={busy !== null || !selected || selectedLocked}
+                  disabled={busy !== null || !selected || !selectedOwnedId || selectedLocked}
                   onClick={() => void redeem()}
                 >
                   {busy === "redeem"

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -11,6 +11,9 @@ import {
   staticsGenesisAbi,
 } from "@statics-protocol/sdk";
 
+import Link from "next/link";
+import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
+
 import { EmptyState } from "@/components/common/EmptyState";
 import { NftArtwork } from "@/components/wallet/NftArtwork";
 import type { LaunchDeployment } from "@/lib/deployments/types";
@@ -18,8 +21,14 @@ import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import { discoverNextAvailableGenesisId, discoverWalletGenesisIds } from "@/lib/genesis/discovery";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
 import { useWalletState } from "@/providers/wallet-context";
+
+type VaultDirection = "acquire" | "redeem";
+
+/** One owned Genesis, with the credit state that decides whether it can go back. */
+type RedeemableGenesis = Readonly<{ id: bigint; creditActive: boolean }>;
 
 function describeError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -40,6 +49,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
   const wallet =
     walletState.status === "ready" && walletState.address ? getAddress(walletState.address) : null;
   const [selectedOwnedId, setSelectedOwnedId] = useState<string>("");
+  const [direction, setDirection] = useState<VaultDirection>("acquire");
   const [busy, setBusy] = useState<"buy" | "redeem" | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,7 +59,15 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     queryFn: async () => {
       if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
       await verifyLaunchDeployment(publicClient, deployment);
-      const [purchaseQuote, redemptionQuote, accounting, nextId, ownedIds] = await Promise.all([
+      const [
+        purchaseQuote,
+        redemptionQuote,
+        accounting,
+        nextId,
+        ownedIds,
+        staticsBalance,
+        nativeBalance,
+      ] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: currentGenesisVaultAbi,
@@ -67,8 +85,39 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         }),
         discoverNextAvailableGenesisId(publicClient, deployment),
         wallet ? discoverWalletGenesisIds(publicClient, deployment, wallet) : [],
+        wallet
+          ? publicClient.readContract({
+              address: deployment.contracts.statics,
+              abi: dopplerStaticsTokenAbi,
+              functionName: "balanceOf",
+              args: [wallet],
+            })
+          : 0n,
+        wallet ? publicClient.getBalance({ address: wallet }) : 0n,
       ]);
-      return { purchaseQuote, redemptionQuote, accounting, nextId, ownedIds };
+      // Credit locks a Genesis against redemption, and the old panel only found
+      // out by reverting. Resolve it with the list so a locked NFT is marked
+      // before anyone selects it.
+      const owned = await Promise.all(
+        ownedIds.map(async (id): Promise<RedeemableGenesis> => {
+          const credit = await publicClient.readContract({
+            address: deployment.contracts.vault,
+            abi: staticsGenesisCreditAbi,
+            functionName: "credit",
+            args: [id],
+          });
+          return { id, creditActive: credit.active };
+        })
+      );
+      return {
+        purchaseQuote,
+        redemptionQuote,
+        accounting,
+        nextId,
+        owned,
+        staticsBalance,
+        nativeBalance,
+      };
     },
   });
 
@@ -250,128 +299,225 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
   const purchaseQuote = vault.data?.purchaseQuote;
   const redemptionQuote = vault.data?.redemptionQuote;
   const accounting = vault.data?.accounting;
+  const owned = vault.data?.owned ?? [];
+
+  const statics = (value: bigint | undefined, digits = 0) =>
+    `${formatTokenAmountGrouped(value ?? 0n, 18, digits)} STATICS`;
+  const eth = (value: bigint | undefined, digits = 5) =>
+    `${formatTokenAmountGrouped(value ?? 0n, 18, digits)} ETH`;
+
+  // Both legs, checked here rather than inside the click handler. The old panel
+  // enabled the button regardless and reported the shortfall as a thrown error.
+  const staticsNeeded = purchaseQuote?.staticsPrice ?? 0n;
+  const nativeNeeded = purchaseQuote?.requiredNative ?? 0n;
+  const staticsHeld = vault.data?.staticsBalance ?? 0n;
+  const nativeHeld = vault.data?.nativeBalance ?? 0n;
+  const staticsShort = wallet && staticsHeld < staticsNeeded ? staticsNeeded - staticsHeld : 0n;
+  const nativeShort = wallet && nativeHeld < nativeNeeded ? nativeNeeded - nativeHeld : 0n;
+  const cannotAfford = staticsShort > 0n || nativeShort > 0n;
+
+  const selected = owned.find((item) => item.id.toString() === selectedOwnedId) ?? owned[0] ?? null;
+  const selectedLocked = selected?.creditActive ?? false;
+
   return (
     <div className="genesis-vault-swap">
-      <section className="portal-panel" aria-labelledby="genesis-vault-state-title">
-        <p className="dapp-eyebrow">Genesis Vault</p>
-        <h2 id="genesis-vault-state-title">Fully backed Genesis inventory</h2>
-        <dl className="portal-quote-grid">
-          <div>
-            <dt>Remaining</dt>
-            <dd>{accounting?.vaultInventory.toString() ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Circulating</dt>
-            <dd>{accounting?.circulatingGenesis.toString() ?? "—"}</dd>
-          </div>
-          <div>
-            <dt>Native reserve</dt>
-            <dd>{formatEther(accounting?.reserveETH ?? 0n)} ETH</dd>
-          </div>
-          <div>
-            <dt>Reserve / Genesis</dt>
-            <dd>{formatEther(accounting?.reserveBackingPerGenesis ?? 0n)} ETH</dd>
-          </div>
-          <div>
-            <dt>Outstanding credit</dt>
-            <dd>{formatEther(accounting?.outstandingGenesisCredit ?? 0n)} STATICS</dd>
-          </div>
-          <div>
-            <dt>Genesis Epoch</dt>
-            <dd>{accounting?.epochActive ? "Active" : "Complete"}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="portal-panel" aria-labelledby="next-genesis-title">
-        <p className="dapp-eyebrow">STATICS → Genesis NFT</p>
-        <h2 id="next-genesis-title">
-          {nextId === null ? "Vault inventory exhausted" : `Genesis #${nextId}`}
-        </h2>
-        {nextId !== null && (
-          <NftArtwork
-            chainId={deployment.descriptor.chainId}
-            expandable
-            nft={{
-              kind: "collection",
-              tokenId: nextId,
-              contract: deployment.contracts.genesis,
-              name: `Genesis #${nextId}`,
-              summary: "Next available Genesis NFT",
-              carries: [],
-              blockedReason: null,
-            }}
-          />
-        )}
-        <dl className="portal-quote-grid">
-          <div>
-            <dt>STATICS backing</dt>
-            <dd>{formatEther(purchaseQuote?.staticsPrice ?? 0n)} STATICS</dd>
-          </div>
-          <div>
-            <dt>Reserve buy-in</dt>
-            <dd>{formatEther(purchaseQuote?.reserveBuyIn ?? 0n)} ETH</dd>
-          </div>
-          <div>
-            <dt>Acquisition fee</dt>
-            <dd>{formatEther(purchaseQuote?.nativeFee ?? 0n)} ETH</dd>
-          </div>
-          <div>
-            <dt>Total ETH required</dt>
-            <dd>{formatEther(purchaseQuote?.requiredNative ?? 0n)} ETH</dd>
-          </div>
-        </dl>
-        <button
-          className="portal-primary-action"
-          type="button"
-          disabled={busy !== null || nextId === null}
-          onClick={() => void buy()}
-        >
-          {busy === "buy" ? "Confirming…" : "Acquire Genesis NFT"}
-        </button>
-      </section>
-
-      <section className="portal-panel" aria-labelledby="redeem-genesis-title">
-        <p className="dapp-eyebrow">Genesis NFT → backing</p>
-        <h2 id="redeem-genesis-title">Redeem an owned NFT</h2>
-        {wallet && (vault.data?.ownedIds.length ?? 0) > 0 ? (
-          <>
-            <label className="portal-field">
-              <span>Genesis NFT</span>
-              <select
-                value={selectedOwnedId}
-                onChange={(event) => setSelectedOwnedId(event.target.value)}
-              >
-                <option value="">Choose an NFT</option>
-                {vault.data!.ownedIds.map((id) => (
-                  <option key={id.toString()} value={id.toString()}>
-                    Genesis #{id.toString()}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <p>
-              Receive {formatEther(redemptionQuote?.staticsPayout ?? 0n)} STATICS +{" "}
-              {formatEther(redemptionQuote?.reservePayout ?? 0n)} ETH.
-            </p>
+      <section className="portal-panel" aria-label="Genesis Vault">
+        <div className="portal-direction-tabs" role="tablist" aria-label="Vault direction">
+          {(["acquire", "redeem"] as const).map((item) => (
             <button
-              className="portal-primary-action"
+              key={item}
               type="button"
-              disabled={busy !== null || !selectedOwnedId}
-              onClick={() => void redeem()}
+              role="tab"
+              aria-selected={direction === item}
+              onClick={() => {
+                setDirection(item);
+                setError(null);
+              }}
             >
-              {busy === "redeem" ? "Confirming…" : "Redeem Genesis"}
+              {item === "acquire" ? "Acquire" : "Redeem"}
             </button>
-          </>
+          ))}
+        </div>
+
+        {direction === "acquire" ? (
+          nextId === null ? (
+            <EmptyState
+              title="Vault inventory is exhausted"
+              description="Every Genesis NFT has been acquired. They can still be bought from holders, and redeemed back into the Vault at any time."
+            />
+          ) : (
+            <>
+              <div className="vault-hero">
+                <NftArtwork
+                  chainId={deployment.descriptor.chainId}
+                  expandable
+                  size="lg"
+                  nft={{
+                    kind: "collection",
+                    tokenId: nextId,
+                    contract: deployment.contracts.genesis,
+                    name: `Genesis #${nextId}`,
+                    summary: "Next available Genesis NFT",
+                    carries: [],
+                    blockedReason: null,
+                  }}
+                />
+                <div className="vault-hero-copy">
+                  <h3>Genesis #{nextId.toString()}</h3>
+                  <p>Next from the Vault. Redeemable for its full backing at any time.</p>
+                  <span className="ui-pill is-ready">Fully backed</span>
+                </div>
+              </div>
+
+              <ul className="vault-legs">
+                <li className={staticsShort > 0n ? "is-short" : undefined}>
+                  <span>STATICS backing</span>
+                  <strong>{statics(staticsNeeded)}</strong>
+                  <small>
+                    {wallet
+                      ? `You hold ${formatTokenAmountGrouped(staticsHeld, 18, 2)}${staticsShort > 0n ? ` · short ${formatTokenAmountGrouped(staticsShort, 18, 2)}` : ""}`
+                      : "Connect a wallet to check your balance"}
+                  </small>
+                </li>
+                <li className={nativeShort > 0n ? "is-short" : undefined}>
+                  <span>Acquisition fee + reserve buy-in</span>
+                  <strong>{eth(nativeNeeded)}</strong>
+                  <small>
+                    {wallet
+                      ? `You hold ${formatTokenAmountGrouped(nativeHeld, 18, 4)} ETH${nativeShort > 0n ? ` · short ${formatTokenAmountGrouped(nativeShort, 18, 5)}` : ""}`
+                      : "Paid in the chain's native asset"}
+                  </small>
+                </li>
+              </ul>
+
+              {staticsShort > 0n && (
+                <p className="vault-notice is-error">
+                  <b>You need {formatTokenAmountGrouped(staticsShort, 18, 2)} more STATICS.</b>{" "}
+                  <Link href="/app/swap">Buy STATICS on the Token tab</Link>, then come back.
+                </p>
+              )}
+              {nativeShort > 0n && (
+                <p className="vault-notice is-error">
+                  <b>You need {formatTokenAmountGrouped(nativeShort, 18, 5)} more ETH</b> for the
+                  acquisition fee and reserve buy-in.
+                </p>
+              )}
+
+              <button
+                className="portal-primary-action"
+                type="button"
+                disabled={busy !== null || (Boolean(wallet) && cannotAfford)}
+                onClick={() => void buy()}
+              >
+                {busy === "buy"
+                  ? "Confirming…"
+                  : wallet && cannotAfford
+                    ? "Not enough to acquire"
+                    : `Acquire Genesis #${nextId}`}
+              </button>
+            </>
+          )
         ) : (
-          <p>Connect a wallet holding a Genesis NFT to redeem it.</p>
+          <>
+            {!wallet || owned.length === 0 ? (
+              <EmptyState
+                title="No Genesis NFTs to redeem"
+                description="Redeeming returns a Genesis to the Vault in exchange for its full backing. Connect a wallet holding one to continue."
+              />
+            ) : (
+              <>
+                <p className="portal-field-label">Choose a Genesis to redeem</p>
+                <div className="vault-owned" role="radiogroup" aria-label="Your Genesis NFTs">
+                  {owned.map((item) => {
+                    const isSelected = selected?.id === item.id;
+                    return (
+                      <button
+                        key={item.id.toString()}
+                        className="vault-owned-card"
+                        type="button"
+                        role="radio"
+                        aria-checked={isSelected}
+                        disabled={item.creditActive}
+                        onClick={() => {
+                          setSelectedOwnedId(item.id.toString());
+                          setError(null);
+                        }}
+                      >
+                        <NftArtwork
+                          chainId={deployment.descriptor.chainId}
+                          size="lg"
+                          nft={{
+                            kind: "collection",
+                            tokenId: item.id,
+                            contract: deployment.contracts.genesis,
+                            name: `Genesis #${item.id}`,
+                            summary: "Owned Genesis NFT",
+                            carries: [],
+                            blockedReason: item.creditActive
+                              ? "Repay secured credit before redeeming."
+                              : null,
+                          }}
+                        />
+                        <span>#{item.id.toString()}</span>
+                        <small>{item.creditActive ? "Credit active" : "Redeemable"}</small>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {selectedLocked ? (
+                  <p className="vault-notice is-error">
+                    <b>Genesis #{selected?.id.toString()} has active secured credit.</b> Repay it in{" "}
+                    <Link href="/app/genesis">My Genesis</Link> before this NFT can be redeemed.
+                  </p>
+                ) : (
+                  <ul className="vault-legs">
+                    <li>
+                      <span>You receive</span>
+                      <strong>{statics(redemptionQuote?.staticsPayout)}</strong>
+                      <small>The full fixed backing</small>
+                    </li>
+                    <li>
+                      <span>Reserve share</span>
+                      <strong>{eth(redemptionQuote?.reservePayout)}</strong>
+                      <small>
+                        {accounting?.epochActive
+                          ? "No reserve share is paid until the Genesis Epoch ends"
+                          : `1 / ${accounting?.maximumSupply.toString() ?? "5,555"} of the native reserve`}
+                      </small>
+                    </li>
+                  </ul>
+                )}
+
+                <button
+                  className="portal-primary-action"
+                  type="button"
+                  disabled={busy !== null || !selected || selectedLocked}
+                  onClick={() => void redeem()}
+                >
+                  {busy === "redeem"
+                    ? "Confirming…"
+                    : selectedLocked
+                      ? "Repay credit first"
+                      : `Redeem Genesis #${selected?.id ?? ""}`}
+                </button>
+              </>
+            )}
+          </>
+        )}
+
+        {error && (
+          <p className="portal-error" role="alert">
+            {error}
+          </p>
         )}
       </section>
-      {error && (
-        <p className="portal-error" role="alert">
-          {error}
-        </p>
-      )}
+
+      <p className="vault-strip">
+        <b>{accounting?.vaultInventory.toString() ?? "—"}</b> of{" "}
+        {accounting?.maximumSupply.toString() ?? "—"} left in the Vault
+        <Link href="/app">Vault detail →</Link>
+      </p>
     </div>
   );
 }

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -38,8 +38,8 @@ function describeError(error: unknown): string {
   if (message.includes("CreditAlreadyActive"))
     return "Repay or recover this Genesis credit before redeeming.";
   if (message.includes("GenesisLocked"))
-    return "This Genesis is currently locked and cannot be redeemed.";
-  return message || "The Genesis Vault transaction failed.";
+    return "This Operator is currently locked and cannot be redeemed.";
+  return message || "The Operators Vault transaction failed.";
 }
 
 export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeployment }) {
@@ -255,8 +255,8 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           wallet,
           chainId: deployment.descriptor.chainId,
           kind: "approve-genesis",
-          label: `Approve Genesis #${id} redemption`,
-          amount: `Genesis #${id}`,
+          label: `Approve Operator #${id} redemption`,
+          amount: `Operator #${id}`,
           to: deployment.contracts.genesis,
           data: encodeFunctionData({
             abi: staticsGenesisAbi,
@@ -272,7 +272,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         wallet,
         chainId: deployment.descriptor.chainId,
         kind: "redeem-genesis",
-        label: `Redeem Genesis #${id}`,
+        label: `Redeem Operator #${id}`,
         amount: `${formatEther(redemptionQuote.staticsPayout)} STATICS + ${formatEther(redemptionQuote.reservePayout)} ETH`,
         to: deployment.contracts.vault,
         data: buildRedeemGenesisCall(id, wallet),
@@ -289,10 +289,10 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     }
   };
 
-  if (vault.isLoading) return <p className="dapp-loading">Loading the Genesis Vault…</p>;
+  if (vault.isLoading) return <p className="dapp-loading">Loading the Operators Vault…</p>;
   if (vault.error)
     return (
-      <EmptyState title="Genesis Vault unavailable" description={describeError(vault.error)} />
+      <EmptyState title="Operators Vault unavailable" description={describeError(vault.error)} />
     );
 
   const nextId = vault.data?.nextId ?? null;
@@ -321,7 +321,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
 
   return (
     <div className="genesis-vault-swap">
-      <section className="portal-panel" aria-label="Genesis Vault">
+      <section className="portal-panel" aria-label="Operators Vault">
         <div className="portal-direction-tabs" role="tablist" aria-label="Vault direction">
           {(["acquire", "redeem"] as const).map((item) => (
             <button
@@ -356,14 +356,14 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                     kind: "collection",
                     tokenId: nextId,
                     contract: deployment.contracts.genesis,
-                    name: `Genesis #${nextId}`,
+                    name: `Operator #${nextId}`,
                     summary: "Next available Operator NFT",
                     carries: [],
                     blockedReason: null,
                   }}
                 />
                 <div className="vault-hero-copy">
-                  <h3>Genesis #{nextId.toString()}</h3>
+                  <h3>Operator #{nextId.toString()}</h3>
                   <p>Next from the Vault. Redeemable for its full backing at any time.</p>
                   <span className="ui-pill is-ready">Fully backed</span>
                 </div>
@@ -450,7 +450,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                             kind: "collection",
                             tokenId: item.id,
                             contract: deployment.contracts.genesis,
-                            name: `Genesis #${item.id}`,
+                            name: `Operator #${item.id}`,
                             summary: "Owned Operator NFT",
                             carries: [],
                             blockedReason: item.creditActive
@@ -467,7 +467,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
 
                 {selectedLocked ? (
                   <p className="vault-notice is-error">
-                    <b>Genesis #{selected?.id.toString()} has active secured credit.</b> Repay it in{" "}
+                    <b>Operator #{selected?.id.toString()} has active secured credit.</b> Repay it in{" "}
                     <Link href="/app/genesis">My Operators</Link> before this NFT can be redeemed.
                   </p>
                 ) : (
@@ -499,7 +499,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                     ? "Confirming…"
                     : selectedLocked
                       ? "Repay credit first"
-                      : `Redeem Genesis #${selected?.id ?? ""}`}
+                      : `Redeem Operator #${selected?.id ?? ""}`}
                 </button>
               </>
             )}

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -197,7 +197,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           wallet,
           chainId: deployment.descriptor.chainId,
           kind: "approve-staking-token",
-          label: "Enable Genesis NFT acquisition",
+          label: "Enable Operator NFT acquisition",
           amount: "Maximum STATICS",
           to: deployment.contracts.statics,
           data: encodeFunctionData({
@@ -215,7 +215,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
         wallet,
         chainId: deployment.descriptor.chainId,
         kind: "buy-genesis",
-        label: `Acquire Genesis #${id}`,
+        label: `Acquire Operators #${id}`,
         amount: `${formatEther(quote.staticsPrice)} STATICS + ${formatEther(quote.requiredNative)} ETH`,
         to: deployment.contracts.vault,
         data: purchase.data,
@@ -343,7 +343,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           nextId === null ? (
             <EmptyState
               title="Vault inventory is exhausted"
-              description="Every Genesis NFT has been acquired. They can still be bought from holders, and redeemed back into the Vault at any time."
+              description="Every Operator NFT has been acquired. They can still be bought from holders, and redeemed back into the Vault at any time."
             />
           ) : (
             <>
@@ -357,7 +357,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                     tokenId: nextId,
                     contract: deployment.contracts.genesis,
                     name: `Genesis #${nextId}`,
-                    summary: "Next available Genesis NFT",
+                    summary: "Next available Operator NFT",
                     carries: [],
                     blockedReason: null,
                   }}
@@ -413,7 +413,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                   ? "Confirming…"
                   : wallet && cannotAfford
                     ? "Not enough to acquire"
-                    : `Acquire Genesis #${nextId}`}
+                    : `Acquire Operators #${nextId}`}
               </button>
             </>
           )
@@ -421,13 +421,13 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
           <>
             {!wallet || owned.length === 0 ? (
               <EmptyState
-                title="No Genesis NFTs to redeem"
+                title="No Operators NFTs to redeem"
                 description="Redeeming returns a Genesis to the Vault in exchange for its full backing. Connect a wallet holding one to continue."
               />
             ) : (
               <>
                 <p className="portal-field-label">Choose a Genesis to redeem</p>
-                <div className="vault-owned" role="radiogroup" aria-label="Your Genesis NFTs">
+                <div className="vault-owned" role="radiogroup" aria-label="Your Operators NFTs">
                   {owned.map((item) => {
                     const isSelected = selected?.id === item.id;
                     return (
@@ -451,7 +451,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                             tokenId: item.id,
                             contract: deployment.contracts.genesis,
                             name: `Genesis #${item.id}`,
-                            summary: "Owned Genesis NFT",
+                            summary: "Owned Operator NFT",
                             carries: [],
                             blockedReason: item.creditActive
                               ? "Repay secured credit before redeeming."
@@ -468,7 +468,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
                 {selectedLocked ? (
                   <p className="vault-notice is-error">
                     <b>Genesis #{selected?.id.toString()} has active secured credit.</b> Repay it in{" "}
-                    <Link href="/app/genesis">My Genesis</Link> before this NFT can be redeemed.
+                    <Link href="/app/genesis">My Operators</Link> before this NFT can be redeemed.
                   </p>
                 ) : (
                   <ul className="vault-legs">

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -28,7 +28,7 @@ import {
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
 import type { LaunchDeployment } from "@/lib/deployments/types";
 import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
-import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
+import { genesisActivationCost, oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import {
   EMPTY_GENESIS_PORTFOLIO,
@@ -402,7 +402,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     ? (targetTiers[selected.id.toString()] ?? Math.min(GENESIS_MAX_TIER, selected.tier + 1))
     : 0;
   const activationCost = selected
-    ? cumulativeGenesisActivationCost(owned.data?.tierCosts ?? [], selected.tier, targetTier)
+    ? genesisActivationCost(owned.data?.tierCosts ?? [], selected.tier, targetTier)
     : 0n;
 
   return (

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -45,9 +45,9 @@ import { useWalletState } from "@/providers/wallet-context";
 function describeGenesisError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   if (/rejected/i.test(message)) return "The wallet request was rejected.";
-  if (message.includes("NotGenesisOwner")) return "This wallet no longer owns that Genesis NFT.";
+  if (message.includes("NotGenesisOwner")) return "This wallet no longer owns that Operator NFT.";
   if (message.includes("GenesisAlreadyRegistered"))
-    return "That Genesis NFT is already registered for rewards.";
+    return "That Operator NFT is already registered for rewards.";
   if (message.includes("NoRewards")) return "There is nothing to claim for that asset yet.";
   return message || "The Genesis transaction failed.";
 }
@@ -310,12 +310,12 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         {recoveriesLink}
         <EmptyState
           title="Connect your wallet"
-          description="Connect to view and manage your Genesis NFTs."
+          description="Connect to view and manage your Operators NFTs."
         />
       </div>
     );
   }
-  if (owned.isLoading) return <p className="dapp-loading">Loading Genesis NFTs…</p>;
+  if (owned.isLoading) return <p className="dapp-loading">Loading Operators NFTs…</p>;
   if (owned.error) {
     return (
       <div className="genesis-page">
@@ -332,13 +332,13 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
       <div className="genesis-page">
         {recoveriesLink}
         <EmptyState
-          title="No Genesis NFTs yet"
+          title="No Operators NFTs yet"
           description={
             vault.data
-              ? `${vault.data.circulatingGenesis} of ${vault.data.maximumSupply} Genesis NFTs are in circulation, each backed by ${formatTokenAmountGrouped(vault.data.vaultPrice, 18, 0)} STATICS.`
-              : "Acquire a fully backed Genesis NFT through the Vault."
+              ? `${vault.data.circulatingGenesis} of ${vault.data.maximumSupply} Operators NFTs are in circulation, each backed by ${formatTokenAmountGrouped(vault.data.vaultPrice, 18, 0)} STATICS.`
+              : "Acquire a fully backed Operator NFT through the Vault."
           }
-          action={{ label: "Acquire a Genesis NFT", href: "/app/swap?mode=nft" }}
+          action={{ label: "Acquire a Operator NFT", href: "/app/swap?mode=nft" }}
         />
         {/* Rewards earned before a Genesis changed hands stay claimable by the
             previous owner, so a wallet holding none of them still has somewhere
@@ -348,7 +348,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
             <div className="genesis-panel-head">
               <h3>Rewards from past ownership</h3>
               <p>
-                These accrued while you held a Genesis NFT that has since moved on. They remain
+                These accrued while you held a Operator NFT that has since moved on. They remain
                 yours to claim.
               </p>
             </div>
@@ -408,7 +408,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
   return (
     <div className="genesis-page">
       {recoveriesLink}
-      <section className="genesis-summary ui-card" aria-label="Your Genesis holdings">
+      <section className="genesis-summary ui-card" aria-label="Your Operators holdings">
         <div className="ui-stat">
           <span className="ui-stat__label">Genesis held</span>
           <strong className="ui-stat__value">{items.length}</strong>
@@ -621,7 +621,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                 <div className="genesis-panel-head">
                   <h3>Launch rewards</h3>
                   <p>
-                    Registered Genesis NFTs split {Number(owned.data?.rewardShareBps ?? 0) / 100}%
+                    Registered Operators NFTs split {Number(owned.data?.rewardShareBps ?? 0) / 100}%
                     of market fees, weighted by activation tier.
                   </p>
                 </div>
@@ -762,7 +762,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                       void act("accrue", () =>
                         send(
                           "accrue-genesis-rewards",
-                          "Update Genesis launch rewards",
+                          "Update Operators launch rewards",
                           deployment.contracts.launchDistributor,
                           buildAccrueGenesisLaunchRewardsCall(),
                           "Current market fees"
@@ -788,7 +788,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         <AddressDisplay
           address={deployment.contracts.genesis}
           chainId={deployment.descriptor.chainId}
-          label="Genesis NFT"
+          label="Operator NFT"
         />
         <AddressDisplay
           address={deployment.contracts.launchDistributor}

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -629,9 +629,9 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                 {!selected.registered ? (
                   <>
                     <p className="genesis-note is-warning">
-                      <b>This Operator is earning nothing.</b> Register it to start taking a share of
-                      market fees at its current {genesisTierMultiplier(selected.tier).toFixed(2)}×
-                      weight.
+                      <b>This Operator is earning nothing.</b> Register it to start taking a share
+                      of market fees at its current{" "}
+                      {genesisTierMultiplier(selected.tier).toFixed(2)}× weight.
                     </p>
                     <dl className="genesis-figures">
                       <div>

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -244,7 +244,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     }
     await send(
       "activate-genesis",
-      `Activate Genesis #${item.id} to tier ${targetTier}`,
+      `Activate Operator #${item.id} to tier ${targetTier}`,
       deployment.contracts.activationRegistry,
       buildActivateGenesisCall(item.id, targetTier),
       `${formatEther(cost)} STATICS activation payment`
@@ -256,14 +256,14 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
     for (const item of items) {
       if (item.pendingStatics > 0n) {
         jobs.push({
-          label: `Claim Genesis #${item.id} STATICS rewards`,
+          label: `Claim Operator #${item.id} STATICS rewards`,
           data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.statics, wallet!),
           amount: `${formatEther(item.pendingStatics)} STATICS`,
         });
       }
       if (item.pendingWeth > 0n) {
         jobs.push({
-          label: `Claim Genesis #${item.id} WETH rewards`,
+          label: `Claim Operator #${item.id} WETH rewards`,
           data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.weth, wallet!),
           amount: `${formatEther(item.pendingWeth)} WETH`,
         });
@@ -300,7 +300,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
   const recoveriesLink =
     vault.data?.epochActive === false ? (
       <Link className="genesis-recoveries-link" href="/app/genesis/recoveries">
-        Recover matured Genesis credit <span aria-hidden="true">→</span>
+        Recover matured Operator credit <span aria-hidden="true">→</span>
       </Link>
     ) : null;
 
@@ -321,7 +321,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
       <div className="genesis-page">
         {recoveriesLink}
         <EmptyState
-          title="Genesis data unavailable"
+          title="Operators data unavailable"
           description={describeGenesisError(owned.error)}
         />
       </div>
@@ -338,7 +338,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
               ? `${vault.data.circulatingGenesis} of ${vault.data.maximumSupply} Operators NFTs are in circulation, each backed by ${formatTokenAmountGrouped(vault.data.vaultPrice, 18, 0)} STATICS.`
               : "Acquire a fully backed Operator NFT through the Vault."
           }
-          action={{ label: "Acquire a Operator NFT", href: "/app/swap?mode=nft" }}
+          action={{ label: "Acquire an Operator NFT", href: "/app/swap?mode=nft" }}
         />
         {/* Rewards earned before a Genesis changed hands stay claimable by the
             previous owner, so a wallet holding none of them still has somewhere
@@ -348,7 +348,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
             <div className="genesis-panel-head">
               <h3>Rewards from past ownership</h3>
               <p>
-                These accrued while you held a Operator NFT that has since moved on. They remain
+                These accrued while you held an Operator NFT that has since moved on. They remain
                 yours to claim.
               </p>
             </div>
@@ -410,7 +410,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
       {recoveriesLink}
       <section className="genesis-summary ui-card" aria-label="Your Operators holdings">
         <div className="ui-stat">
-          <span className="ui-stat__label">Genesis held</span>
+          <span className="ui-stat__label">Operators held</span>
           <strong className="ui-stat__value">{items.length}</strong>
           <small>
             {summary.activated} activated · {summary.unregistered} not registered
@@ -504,7 +504,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
           />
 
           <div className="genesis-actions">
-            <div className="genesis-tabs" role="tablist" aria-label="Genesis actions">
+            <div className="genesis-tabs" role="tablist" aria-label="Operator actions">
               <button
                 type="button"
                 role="tab"
@@ -610,7 +610,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                   </>
                 ) : (
                   <p className="genesis-note">
-                    <b>Tier 4 reached.</b> This Genesis earns the maximum 1.25× reward weight.
+                    <b>Tier 4 reached.</b> This Operator earns the maximum 1.25× reward weight.
                   </p>
                 )}
               </section>
@@ -629,7 +629,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                 {!selected.registered ? (
                   <>
                     <p className="genesis-note is-warning">
-                      <b>This Genesis is earning nothing.</b> Register it to start taking a share of
+                      <b>This Operator is earning nothing.</b> Register it to start taking a share of
                       market fees at its current {genesisTierMultiplier(selected.tier).toFixed(2)}×
                       weight.
                     </p>
@@ -651,17 +651,17 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                         void act(`register-${selected.id}`, () =>
                           send(
                             "claim-rewards",
-                            `Register Genesis #${selected.id}`,
+                            `Register Operator #${selected.id}`,
                             deployment.contracts.launchDistributor,
                             buildRegisterGenesisCall(selected.id),
-                            `Genesis #${selected.id}`
+                            `Operator #${selected.id}`
                           )
                         )
                       }
                     >
                       {busy === `register-${selected.id}`
                         ? "Registering…"
-                        : `Register Genesis #${selected.id} for rewards`}
+                        : `Register Operator #${selected.id} for rewards`}
                     </button>
                   </>
                 ) : (
@@ -702,7 +702,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                               void act(`claim-${selected.id}-${symbol}`, () =>
                                 send(
                                   "claim-rewards",
-                                  `Claim Genesis #${selected.id} ${symbol} rewards`,
+                                  `Claim Operator #${selected.id} ${symbol} rewards`,
                                   deployment.contracts.launchDistributor,
                                   buildClaimGenesisLaunchRewardsCall(selected.id, asset, wallet),
                                   symbol
@@ -717,7 +717,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
                       {(summary.ownerStatics > 0n || summary.ownerWeth > 0n) && (
                         <li>
                           <div>
-                            <span>From Genesis you no longer own</span>
+                            <span>From Operators you no longer own</span>
                             <strong>
                               {formatTokenAmountGrouped(summary.ownerStatics, 18, 2)} STATICS
                             </strong>
@@ -803,7 +803,7 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
         <AddressDisplay
           address={deployment.contracts.vault}
           chainId={deployment.descriptor.chainId}
-          label="Genesis Vault"
+          label="Operators Vault"
         />
       </section>
     </div>

--- a/components/overview/DeploymentOverview.tsx
+++ b/components/overview/DeploymentOverview.tsx
@@ -73,7 +73,7 @@ export function DeploymentOverview() {
           <p className="dapp-eyebrow">Selected network</p>
           <h2>{active.descriptor.network}</h2>
           <p>
-            The same Genesis launch application will be enabled here after its reviewed manifest is
+            The same Operators launch application will be enabled here after its reviewed manifest is
             published.
           </p>
         </section>
@@ -136,7 +136,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
     },
   });
 
-  // Same key and fetcher My Genesis mounts, so the two surfaces share one walk
+  // Same key and fetcher My Operators mounts, so the two surfaces share one walk
   // of the wallet rather than each paying for it.
   const portfolio = useQuery({
     queryKey: ownedGenesisQueryKey(deployment.descriptor.deploymentId, wallet),
@@ -208,7 +208,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
 
       <div className="launch-actions">
         <Link className="ui-button ui-button--primary" href="/app/swap?mode=nft">
-          Acquire Genesis
+          Acquire Operators
           <small>
             {metrics.data
               ? `${formatTokenAmountGrouped(metrics.data.purchase.staticsPrice, 18, 0)} STATICS + ${formatTokenAmountGrouped(metrics.data.purchase.requiredNative, 18, 5)} ETH`
@@ -239,7 +239,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
             </strong>
           </div>
           <div className="ui-stat">
-            <span className="ui-stat__label">Your Genesis</span>
+            <span className="ui-stat__label">Your Operators</span>
             <strong className="ui-stat__value">{portfolio.isLoading ? "—" : genesisHeld}</strong>
             <small>
               {genesisHeld > 0 && vault
@@ -255,10 +255,10 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
             <small>{formatTokenAmountGrouped(rewards.claimableWeth, 18, 4)} WETH</small>
           </div>
           {/* Names its destination, not an action: claiming is one transaction
-              per NFT and asset, and My Genesis is where that sequence is priced
+              per NFT and asset, and My Operators is where that sequence is priced
               honestly. Revisit when the batch claim entry point lands. */}
           <Link className="ui-button ui-button--secondary" href="/app/genesis">
-            Open My Genesis
+            Open My Operators
           </Link>
         </section>
       ) : (
@@ -279,7 +279,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
       )}
 
       <div className="launch-duo">
-        <section className="ui-card overview-panel" aria-label="Genesis supply">
+        <section className="ui-card overview-panel" aria-label="Operators supply">
           <div className="overview-panel-head">
             <h3>Supply</h3>
             <span>Fixed at {count(supply)}</span>
@@ -297,7 +297,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
             <div>
               <dt>
                 <i className="is-treasury" aria-hidden="true" />
-                Treasury at genesis
+                Treasury at launch
               </dt>
               <dd>{count(TREASURY_GENESIS)}</dd>
             </div>
@@ -339,7 +339,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
               </dd>
             </div>
             <div>
-              <dt>Reserve share per Genesis</dt>
+              <dt>Reserve share per Operator</dt>
               <dd>
                 {vault
                   ? `${formatTokenAmountGrouped(vault.reserveBackingPerGenesis, 18, 6)} ETH`
@@ -353,7 +353,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
               <dd>{`${formatTokenAmountGrouped(projectedBuyIn, 18, 5)} ETH`}</dd>
             </div>
             <div className="is-total">
-              <dt>A Genesis costs you, all in</dt>
+              <dt>An Operator costs you, all in</dt>
               <dd>
                 {allInCost !== null ? `${formatTokenAmountGrouped(allInCost, 18, 4)} ETH` : "—"}
               </dd>

--- a/components/overview/DeploymentOverview.tsx
+++ b/components/overview/DeploymentOverview.tsx
@@ -73,8 +73,8 @@ export function DeploymentOverview() {
           <p className="dapp-eyebrow">Selected network</p>
           <h2>{active.descriptor.network}</h2>
           <p>
-            The same Operators launch application will be enabled here after its reviewed manifest is
-            published.
+            The same Operators launch application will be enabled here after its reviewed manifest
+            is published.
           </p>
         </section>
       </div>
@@ -201,6 +201,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
   return (
     <div className="launch-overview">
       <EpochBanner
+        chainId={deployment.descriptor.chainId}
         epochActive={vault?.epochActive ?? true}
         epochEnd={Number(vault?.genesisEpochEnd ?? 0n)}
         quotes={quotes}
@@ -334,7 +335,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
               </dt>
               <dd>
                 {backingAtMarket !== null
-                  ? `${formatTokenAmountGrouped(backingAtMarket, 18, 4)} ETH`
+                  ? `${formatTokenAmountGrouped(backingAtMarket, 18, 4)} WETH`
                   : "—"}
               </dd>
             </div>
@@ -342,7 +343,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
               <dt>Reserve share per Operator</dt>
               <dd>
                 {vault
-                  ? `${formatTokenAmountGrouped(vault.reserveBackingPerGenesis, 18, 6)} ETH`
+                  ? `${formatTokenAmountGrouped(vault.reserveBackingPerGenesis, 18, 6)} WETH`
                   : "—"}
               </dd>
             </div>
@@ -350,12 +351,14 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
               <dt>
                 {vault?.epochActive ? "Buy-in if the Epoch ended now" : "Buy-in charged today"}
               </dt>
-              <dd>{`${formatTokenAmountGrouped(projectedBuyIn, 18, 5)} ETH`}</dd>
+              <dd>{`${formatTokenAmountGrouped(projectedBuyIn, 18, 5)} WETH`}</dd>
             </div>
             <div className="is-total">
-              <dt>An Operator costs you, all in</dt>
+              <dt>An Operator costs you, all in (WETH-equivalent)</dt>
               <dd>
-                {allInCost !== null ? `${formatTokenAmountGrouped(allInCost, 18, 4)} ETH` : "—"}
+                {allInCost !== null
+                  ? `${formatTokenAmountGrouped(allInCost, 18, 4)} WETH-equivalent`
+                  : "—"}
               </dd>
             </div>
           </dl>

--- a/components/overview/EpochBanner.tsx
+++ b/components/overview/EpochBanner.tsx
@@ -149,14 +149,14 @@ export function EpochBanner({
 
       <div className="epoch-changes">
         <Change
-          label="Acquiring a Genesis"
+          label="Acquiring an Operator"
           current={`${statics} STATICS + ${feeOnly} ETH`}
           other={`${statics} STATICS + ${feePlusBuyIn} ETH`}
           caveat="Buy-in shown at today's reserve. Every acquisition fee accretes to it, so the amount owed rises with each sale."
           complete={!epochActive}
         />
         <Change
-          label="Redeeming a Genesis"
+          label="Redeeming an Operator"
           current={`${statics} STATICS, no ETH`}
           other={`${statics} STATICS + ${payout} ETH`}
           caveat="Reserve share at today's reserve. It rises for the same reason."

--- a/components/overview/EpochBanner.tsx
+++ b/components/overview/EpochBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useBlock } from "wagmi";
 
 import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
 
@@ -27,16 +27,6 @@ export type EpochQuotes = Readonly<{
   /** GENESIS_MAX_CREDIT_PRINCIPAL. */
   maxCredit: bigint;
 }>;
-
-function useNow(active: boolean): number {
-  const [now, setNow] = useState(() => Math.floor(Date.now() / 1_000));
-  useEffect(() => {
-    if (!active) return;
-    const timer = window.setInterval(() => setNow(Math.floor(Date.now() / 1_000)), 1_000);
-    return () => window.clearInterval(timer);
-  }, [active]);
-  return now;
-}
 
 function CountdownUnit({ value, label }: { value: number; label: string }) {
   return (
@@ -83,16 +73,19 @@ function Change({
  * that as "Active until <locale timestamp>", and afterwards as "Complete".
  */
 export function EpochBanner({
+  chainId,
   epochActive,
   epochEnd,
   quotes,
 }: Readonly<{
+  chainId: number;
   epochActive: boolean;
   /** Unix seconds. */
   epochEnd: number;
   quotes: EpochQuotes | null;
 }>) {
-  const now = useNow(epochActive);
+  const { data: block } = useBlock({ chainId, watch: true });
+  const now = block ? Number(block.timestamp) : 0;
   const remaining = Math.max(0, epochEnd - now);
   const days = Math.floor(remaining / 86_400);
   const hours = Math.floor((remaining % 86_400) / 3_600);

--- a/components/overview/VaultSolvency.tsx
+++ b/components/overview/VaultSolvency.tsx
@@ -42,7 +42,7 @@ function invariants(figures: VaultSolvencyFigures): readonly Invariant[] {
 
   return [
     {
-      label: "Backing covers every circulating Genesis",
+      label: "Backing covers every circulating Operators",
       left: statics(figures.tokenBacking),
       right: statics(figures.requiredBacking),
       holds: figures.tokenBacking >= figures.requiredBacking,

--- a/components/portal/EvmSwapPanel.tsx
+++ b/components/portal/EvmSwapPanel.tsx
@@ -45,6 +45,7 @@ import {
   maximumTokenApproval,
   poolKeyForLaunch,
   settlementForTrade,
+  swapDeadlineBase,
   tokenAddress,
   zeroForTrade,
 } from "@/lib/trade/canonical-market";
@@ -407,7 +408,16 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
           transport: custom(provider),
         });
         await verifyLaunchDeployment(publicClient, launch);
-        const block = await publicClient.getBlock();
+        const [block, pendingBlock] = await Promise.all([
+          publicClient.getBlock(),
+          // Not every node serves a pending block; the fallbacks cover it.
+          publicClient.getBlock({ blockTag: "pending" }).catch(() => null),
+        ]);
+        const deadlineBase = swapDeadlineBase(
+          block.timestamp,
+          pendingBlock?.timestamp ?? null,
+          BigInt(Math.floor(Date.now() / 1_000))
+        );
         const inputToken = tokenAddress(launch, directDirection.input);
         if (directDirection.input !== "eth") {
           const tokenAllowance = await publicClient.readContract({
@@ -443,7 +453,9 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
               permit2[0],
               permit2[1],
               parsedAmount,
-              Number(block.timestamp)
+              // Execution time, not last-block time: a stale latest block makes
+              // an expired Permit2 allowance look usable.
+              Number(deadlineBase)
             )
           ) {
             await executeProtocolTransaction({
@@ -478,7 +490,7 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
           zeroForOne: zeroForTrade(launch, directDirection.input),
           amountIn: parsedAmount,
           amountOutMinimum: reviewedMinimum,
-          deadline: block.timestamp + PERMIT_TTL,
+          deadline: deadlineBase + PERMIT_TTL,
           settlement: settlementForTrade(launch, directDirection),
         });
         await executeProtocolTransaction({
@@ -620,6 +632,16 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
         excluded={destination?.address}
         amount={amount}
         balance={balance === null || !source ? "--" : displayAmount(balance.toString(), source)}
+        onMax={
+          balance === null || balance === 0n || !source
+            ? undefined
+            : () => {
+                setAmount(displayAmount(balance.toString(), source));
+                setQuote(null);
+                setReviewing(false);
+                setError(null);
+              }
+        }
         onAmount={(value) => {
           setAmount(value);
           setQuote(null);
@@ -663,28 +685,31 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
           setError(null);
         }}
       />
-      <dl className="portal-quote-grid">
-        <QuoteDatum
-          label={t("minimumReceived")}
-          value={
-            minimumRaw && destination
-              ? `${displayAmount(minimumRaw, destination)} ${destination.symbol}`
-              : "--"
-          }
-        />
-        <QuoteDatum
-          label={t("priceImpact")}
-          value={
-            quote?.quote?.priceImpact === undefined
-              ? "--"
-              : `${quote.quote.priceImpact.toFixed(2)}%`
-          }
-        />
-        <QuoteDatum
-          label={t("networkCost")}
-          value={quote?.quote?.gasFeeUSD ? `$${quote.quote.gasFeeUSD}` : "--"}
-        />
-      </dl>
+      {quote?.quote && (
+        <dl className="portal-quote-grid">
+          <QuoteDatum
+            label={t("minimumReceived")}
+            value={
+              minimumRaw && destination
+                ? `${displayAmount(minimumRaw, destination)} ${destination.symbol}`
+                : "--"
+            }
+          />
+          <QuoteDatum
+            label={t("priceImpact")}
+            value={
+              quote.quote.priceImpact === undefined
+                ? "--"
+                : `${quote.quote.priceImpact.toFixed(2)}%`
+            }
+            tone={priceImpactTone(quote.quote.priceImpact)}
+          />
+          <QuoteDatum
+            label={t("networkCost")}
+            value={quote.quote.gasFeeUSD ? `$${quote.quote.gasFeeUSD}` : "--"}
+          />
+        </dl>
+      )}
       {error && (
         <p className="portal-error" role="alert">
           {error}
@@ -738,6 +763,7 @@ function SwapAssetField({
   readOnly = false,
   onAmount,
   onToken,
+  onMax,
   slippage,
   onEditSlippage,
 }: {
@@ -750,6 +776,7 @@ function SwapAssetField({
   readOnly?: boolean;
   onAmount?: (value: string) => void;
   onToken: (address: string) => void;
+  onMax?: () => void;
   slippage?: number;
   onEditSlippage?: () => void;
 }) {
@@ -759,7 +786,7 @@ function SwapAssetField({
     // card and a button inside a label would also activate the amount input.
     <div className="portal-field portal-asset-field">
       <div className="portal-asset-field-head">
-        <span>{label}</span>
+        <span className="portal-field-label">{label}</span>
         {slippage !== undefined && onEditSlippage && (
           <SlippageInlineControl value={slippage} onEdit={onEditSlippage} />
         )}
@@ -788,16 +815,44 @@ function SwapAssetField({
             ))}
         </select>
       </div>
-      <small>{readOnly ? "--" : t("balance", { balance })}</small>
+      <div className="portal-asset-field-foot">
+        <small>{readOnly ? "--" : t("balance", { balance })}</small>
+        {onMax && (
+          <button className="portal-asset-max" type="button" onClick={onMax}>
+            {t("max")}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
 
-function QuoteDatum({ label, value }: { label: string; value: string }) {
+/**
+ * Price impact is the one figure here that carries a warning, so it is the one
+ * that earns colour. Semantic, and separate from the accent.
+ */
+function priceImpactTone(impact: number | undefined): QuoteTone {
+  if (impact === undefined) return "neutral";
+  if (impact >= 5) return "negative";
+  if (impact >= 1) return "warning";
+  return "positive";
+}
+
+type QuoteTone = "neutral" | "positive" | "warning" | "negative";
+
+function QuoteDatum({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: QuoteTone;
+}) {
   return (
     <div>
       <dt>{label}</dt>
-      <dd>{value}</dd>
+      <dd className={tone === "neutral" ? undefined : `is-${tone}`}>{value}</dd>
     </div>
   );
 }

--- a/components/portal/EvmSwapPanel.tsx
+++ b/components/portal/EvmSwapPanel.tsx
@@ -633,7 +633,7 @@ export function EvmSwapPanel({ canonicalOnly = false }: { canonicalOnly?: boolea
         amount={amount}
         balance={balance === null || !source ? "--" : displayAmount(balance.toString(), source)}
         onMax={
-          balance === null || balance === 0n || !source
+          balance === null || balance === 0n || !source || source.kind === "native"
             ? undefined
             : () => {
                 setAmount(displayAmount(balance.toString(), source));

--- a/components/protocol/AddressInput.tsx
+++ b/components/protocol/AddressInput.tsx
@@ -46,12 +46,13 @@ export function AddressInput({
         <button
           type="button"
           disabled={disabled}
-          onClick={() =>
+          onClick={() => {
+            if (!navigator.clipboard?.readText) return;
             void navigator.clipboard
               .readText()
               .then((text) => onChange(text.trim()))
-              .catch(() => undefined)
-          }
+              .catch(() => undefined);
+          }}
         >
           {t("paste")}
         </button>

--- a/components/swap/SwapPage.tsx
+++ b/components/swap/SwapPage.tsx
@@ -39,7 +39,7 @@ export function SwapPage() {
             aria-selected={mode === item}
             onClick={() => setMode(item)}
           >
-            {item === "token" ? "Token" : "Genesis NFT"}
+            {item === "token" ? "Token" : "Operator NFT"}
           </button>
         ))}
       </div>

--- a/components/swap/SwapPage.tsx
+++ b/components/swap/SwapPage.tsx
@@ -39,7 +39,7 @@ export function SwapPage() {
             aria-selected={mode === item}
             onClick={() => setMode(item)}
           >
-            {item === "token" ? "Token" : "NFT"}
+            {item === "token" ? "Token" : "Genesis NFT"}
           </button>
         ))}
       </div>

--- a/components/wallet/WalletNftPanel.tsx
+++ b/components/wallet/WalletNftPanel.tsx
@@ -87,10 +87,10 @@ export function WalletNftPanel({
           tokenId,
           contract: deployment.contracts.genesis,
           name: `Genesis #${tokenId.toString()}`,
-          summary: "Statics Genesis",
+          summary: "Statics Operators",
           carries: [] as readonly string[],
           transferWarning:
-            "Transferring this Genesis NFT resets activation to Tier 0. Rewards earned before transfer remain claimable by the previous owner.",
+            "Transferring this Operator NFT resets activation to Tier 0. Rewards earned before transfer remain claimable by the previous owner.",
           blockedReason: null,
         }));
         const collectionNfts: readonly WalletNft[] = collectionResults.flatMap((result) =>

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -10,6 +10,7 @@ import {
   getAddress,
   isAddress,
   parseAbi,
+  parseEther,
   zeroAddress,
   type Address,
   type Hex,
@@ -761,6 +762,7 @@ type TransferAsset = {
 const erc1155TransferAbi = parseAbi([
   "function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes data)",
 ]);
+const NATIVE_TRANSFER_FEE_RESERVE = parseEther("0.001");
 
 function SendDialog({
   assets,
@@ -906,13 +908,23 @@ function SendDialog({
                 amount={amountRaw}
                 maximum={asset.balance}
                 maximumSelection={
-                  asset.kind === "native" ? applyPercent(asset.balance, 99) : asset.balance
+                  asset.kind === "native"
+                    ? asset.balance > NATIVE_TRANSFER_FEE_RESERVE
+                      ? asset.balance - NATIVE_TRANSFER_FEE_RESERVE
+                      : 0n
+                    : asset.balance
                 }
                 label={t("amountShortcuts")}
                 disabled={pending}
                 onSelect={(percent) => {
-                  const safePercent = asset.kind === "native" && percent === 100 ? 99 : percent;
-                  setAmount(formatUnits(applyPercent(asset.balance!, safePercent), asset.decimals));
+                  const selected = applyPercent(asset.balance!, percent);
+                  const max =
+                    asset.kind === "native"
+                      ? asset.balance! > NATIVE_TRANSFER_FEE_RESERVE
+                        ? asset.balance! - NATIVE_TRANSFER_FEE_RESERVE
+                        : 0n
+                      : asset.balance!;
+                  setAmount(formatUnits(selected > max ? max : selected, asset.decimals));
                   setReviewing(false);
                   setError(null);
                 }}

--- a/docs/adr/network-aware-genesis-launch-application.md
+++ b/docs/adr/network-aware-genesis-launch-application.md
@@ -1,4 +1,4 @@
-# ADR: Network-aware Statics Genesis launch application
+# ADR: Network-aware Statics Operators launch application
 
 - Status: Accepted
 - Date: 2026-08-19

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -63,9 +63,9 @@ const routePresentations = {
   swap: {
     label: "Swap",
     status: "STATICS market",
-    title: "Swap tokens and Genesis NFTs",
+    title: "Swap tokens and Operators NFTs",
     description:
-      "Buy or sell STATICS through its official pool, then exchange STATICS for a fully backed Genesis NFT.",
+      "Buy or sell STATICS through its official pool, then exchange STATICS for a fully backed Operator NFT.",
   },
   dollar: {
     label: "Dollar",
@@ -124,18 +124,18 @@ const routePresentations = {
       "Stake a position to earn a share of protocol fees. Pick which assets to earn in and claim what you have built up.",
   },
   genesis: {
-    label: "Genesis NFT",
-    status: "Genesis NFT",
-    title: "Manage your Genesis NFTs",
+    label: "Operator NFT",
+    status: "Operator NFT",
+    title: "Manage your Operators NFTs",
     description:
-      "Activate a Genesis NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
+      "Activate a Operator NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
   },
   genesisRecoveries: {
     label: "Recoveries",
-    status: "Genesis recoveries",
+    status: "Operator recoveries",
     title: "Recover matured Genesis credit",
     description:
-      "Find Genesis NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive.",
+      "Find Operators NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive.",
   },
   liquidity: {
     label: "Liquidity",

--- a/lib/dapp-navigation.ts
+++ b/lib/dapp-navigation.ts
@@ -128,14 +128,14 @@ const routePresentations = {
     status: "Operator NFT",
     title: "Manage your Operators NFTs",
     description:
-      "Activate a Operator NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
+      "Activate an Operator NFT with a STATICS treasury payment, manage secured credit, and later link it to a Position for additional reward weight.",
   },
   genesisRecoveries: {
     label: "Recoveries",
     status: "Operator recoveries",
-    title: "Recover matured Genesis credit",
+    title: "Recover matured Operator credit",
     description:
-      "Find Operators NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive.",
+      "Find Operator NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive.",
   },
   liquidity: {
     label: "Liquidity",

--- a/lib/deployments/launch-manifest.ts
+++ b/lib/deployments/launch-manifest.ts
@@ -118,7 +118,7 @@ export function parseLaunchDeploymentManifest(
 
   const descriptor: DeploymentDescriptor = {
     deploymentId: manifest.deploymentId,
-    label: "Statics Genesis",
+    label: "Statics Operators",
     network: manifest.network,
     chainId: manifest.chainId,
     stage: "launch",

--- a/lib/deployments/registry.ts
+++ b/lib/deployments/registry.ts
@@ -61,7 +61,7 @@ function target(
   );
   const descriptor: DeploymentDescriptor = {
     deploymentId,
-    label: protocol ? "Statics Protocol" : "Statics Genesis launch",
+    label: protocol ? "Statics Protocol" : "Statics Operators launch",
     network,
     chainId,
     stage: protocol ? "full-protocol" : "launch",

--- a/lib/genesis/activation-costs.ts
+++ b/lib/genesis/activation-costs.ts
@@ -1,6 +1,18 @@
+import { cumulativeGenesisActivationCost } from "@statics-protocol/sdk";
+
 export function oneIndexedGenesisTierCosts(tierCosts: readonly bigint[]): readonly bigint[] {
   if (tierCosts.length !== 4) {
     throw new Error("Genesis activation requires exactly four tier costs.");
   }
   return [0n, ...tierCosts];
+}
+
+/** A Tier 4 Genesis is already fully activated and has no next payment. */
+export function genesisActivationCost(
+  tierCosts: readonly bigint[],
+  currentTier: number,
+  targetTier: number
+): bigint {
+  if (currentTier >= 4) return 0n;
+  return cumulativeGenesisActivationCost(tierCosts, currentTier, targetTier);
 }

--- a/lib/genesis/market-value.ts
+++ b/lib/genesis/market-value.ts
@@ -3,7 +3,7 @@ import type { Address } from "viem";
 const Q192 = 1n << 192n;
 
 /**
- * What a Genesis NFT's STATICS backing is worth at the current market price,
+ * What a Operator NFT's STATICS backing is worth at the current market price,
  * denominated in the pool's numeraire (WETH), in wei.
  *
  * This is the figure the Overview was missing: a raw `WETH per STATICS` ratio

--- a/lib/genesis/owned.ts
+++ b/lib/genesis/owned.ts
@@ -40,10 +40,10 @@ export const EMPTY_GENESIS_PORTFOLIO: OwnedGenesisPortfolio = {
 };
 
 /**
- * The query key both My Genesis and the Overview mount.
+ * The query key both My Operators and the Overview mount.
  *
  * Sharing the key is the point: this walk is one discovery call plus seven
- * reads per NFT, and the Overview needs the same totals My Genesis already
+ * reads per NFT, and the Overview needs the same totals My Operators already
  * fetched. Same key, same fetcher, one request.
  */
 export function ownedGenesisQueryKey(deploymentId: string, wallet: `0x${string}` | null) {

--- a/lib/liquidity/liquidity.ts
+++ b/lib/liquidity/liquidity.ts
@@ -239,7 +239,7 @@ export function borrowedLiquidityReadiness(
   if (unavailable) {
     return "Every canonical pool must be live and synced to the liquidity manager.";
   }
-  return plan ? null : "Enter collateral shares to calculate an executable liquidity plan.";
+  return plan ? null : "The current loan cannot fund a positive amount in every pool.";
 }
 
 /**
@@ -291,7 +291,7 @@ export function calculateBorrowLiquidityPlan({
     const weightPercent = weights[pool.poolId] ?? 100;
     if (!Number.isInteger(weightPercent) || weightPercent < 1 || weightPercent > 100) return null;
     const [tickLower, tickUpper] = canonicalFullRange(pool.key.tickSpacing);
-    const assetIsCurrency0 = pool.key.currency0 === pool.asset.address;
+    const assetIsCurrency0 = pool.key.currency0.toLowerCase() === pool.asset.address.toLowerCase();
     const maximum = maximumLiquidityForAmounts(
       pool.sqrtPriceX96,
       tickLower,
@@ -321,8 +321,16 @@ export function calculateBorrowLiquidityPlan({
     const inputs = inputsAt(scale);
     if (inputs.some((input) => input.liquidity <= 0n)) return false;
     try {
-      quoteBorrowAndProvideLiquidity(snapshot, sharesIn, inputs, slippageBps);
-      return true;
+      const quote = quoteBorrowAndProvideLiquidity(snapshot, sharesIn, inputs, slippageBps);
+      const headroom = BPS + slippageBps;
+      return quote.totalPrincipalRequirements.every((requirement) => {
+        const principal =
+          borrow.principals.find(
+            (item) => item.asset.toLowerCase() === requirement.asset.toLowerCase()
+          )?.amount ?? 0n;
+        const withHeadroom = (requirement.amount * headroom + BPS - 1n) / BPS;
+        return withHeadroom <= principal;
+      });
     } catch {
       return false;
     }
@@ -477,58 +485,74 @@ async function loadPool(
   ) {
     throw new Error("Canonical pool configuration does not match its verified deployment.");
   }
-  const [assetToken, slot0, decommissioned, globalFees, poolFees, pending0, pending1, locked] =
-    await Promise.all([
-      loadTokenMetadata(publicClient, asset, undefined, blockNumber),
-      publicClient.readContract({
-        address: liquidity.contracts.stateView,
-        abi: v4StateViewReadAbi,
-        functionName: "getSlot0",
-        args: [configured.poolId],
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "poolDecommissioned",
-        args: [configured.poolId],
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "feeConfiguration",
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "poolFeeConfiguration",
-        args: [configured.poolId],
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "pendingPermanentLiquidity",
-        args: [configured.poolId, getAddress(configured.currency0)],
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "pendingPermanentLiquidity",
-        args: [configured.poolId, getAddress(configured.currency1)],
-        blockNumber,
-      }),
-      publicClient.readContract({
-        address: liquidity.contracts.swapFeeHook,
-        abi: staticsSwapFeeHookAbi,
-        functionName: "lockedLiquidity",
-        args: [configured.poolId],
-        blockNumber,
-      }),
-    ]);
+  const [
+    assetToken,
+    slot0,
+    decommissioned,
+    managerSynced,
+    globalFees,
+    poolFees,
+    pending0,
+    pending1,
+    locked,
+  ] = await Promise.all([
+    loadTokenMetadata(publicClient, asset, undefined, blockNumber),
+    publicClient.readContract({
+      address: liquidity.contracts.stateView,
+      abi: v4StateViewReadAbi,
+      functionName: "getSlot0",
+      args: [configured.poolId],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "poolDecommissioned",
+      args: [configured.poolId],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: deployment.contracts.diamond,
+      abi: staticsAbi,
+      functionName: "isProtocolPool",
+      args: [configured.poolId],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "feeConfiguration",
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "poolFeeConfiguration",
+      args: [configured.poolId],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "pendingPermanentLiquidity",
+      args: [configured.poolId, getAddress(configured.currency0)],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "pendingPermanentLiquidity",
+      args: [configured.poolId, getAddress(configured.currency1)],
+      blockNumber,
+    }),
+    publicClient.readContract({
+      address: liquidity.contracts.swapFeeHook,
+      abi: staticsSwapFeeHookAbi,
+      functionName: "lockedLiquidity",
+      args: [configured.poolId],
+      blockNumber,
+    }),
+  ]);
   const effective = poolFees.overridden ? poolFees : { ...globalFees, overridden: false };
   return {
     basketId: basket.basketId,
@@ -539,7 +563,7 @@ async function loadPool(
     poolId: configured.poolId,
     key,
     decommissioned,
-    managerSynced: true,
+    managerSynced,
     sqrtPriceX96: slot0[0],
     currentTick: slot0[1],
     lpFee: slot0[3],

--- a/lib/protocol/approval-inventory.ts
+++ b/lib/protocol/approval-inventory.ts
@@ -118,7 +118,7 @@ export function launchApprovalDefinitions(
       purpose,
     });
 
-  addErc20(statics, deployment.contracts.vault, "Genesis Vault", "Acquire Genesis NFTs");
+  addErc20(statics, deployment.contracts.vault, "Genesis Vault", "Acquire Operators NFTs");
   addErc20(
     statics,
     deployment.contracts.activationRegistry,

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -187,7 +187,7 @@ export const appNavigationGroups: readonly AppNavigationGroup[] = [
         capability: "positions",
       },
       {
-        label: "Genesis NFT",
+        label: "Operator NFT",
         messageKey: "genesis",
         enabled: true,
         href: "/app/genesis",

--- a/lib/trade/canonical-market.ts
+++ b/lib/trade/canonical-market.ts
@@ -93,3 +93,32 @@ export function maximumTokenApproval(spender: Address): Hex {
     args: [getAddress(spender), MAX_ERC20_ALLOWANCE],
   });
 }
+
+/**
+ * The timestamp a swap deadline should be measured from.
+ *
+ * A deadline has to outlive the block the transaction actually lands in, not
+ * the last one that happened to be mined. Three clocks can disagree, and each
+ * is the right answer in some situation:
+ *
+ *   - `latest` leads on a fork whose time has been advanced past wall clock,
+ *     which is how the Genesis Epoch gets tested.
+ *   - `pending` leads where the node exposes the block being assembled.
+ *   - wall clock leads on a fork sitting idle: Anvil mines only on activity, so
+ *     the latest block can be arbitrarily stale while the next one jumps to
+ *     real time. Anchoring to `latest` alone made every swap after a quiet
+ *     period longer than the TTL revert with TransactionDeadlinePassed.
+ *
+ * Taking the greatest is correct in all three: a deadline that is further out
+ * than necessary costs nothing, while one that is short reverts.
+ */
+export function swapDeadlineBase(
+  latestTimestamp: bigint,
+  pendingTimestamp: bigint | null,
+  wallClockSeconds: bigint
+): bigint {
+  let base = latestTimestamp;
+  if (pendingTimestamp !== null && pendingTimestamp > base) base = pendingTimestamp;
+  if (wallClockSeconds > base) base = wallClockSeconds;
+  return base;
+}

--- a/lib/wallet/nft-contracts.ts
+++ b/lib/wallet/nft-contracts.ts
@@ -121,7 +121,7 @@ function defaultNftCollections(
       ? deployment.contracts.genesis
       : deployment.protocol.genesis?.collection;
   return address
-    ? [{ address, name: "Statics Genesis", symbol: "GENESIS", standard: "erc721" }]
+    ? [{ address, name: "Statics Operators", symbol: "GENESIS", standard: "erc721" }]
     : [];
 }
 

--- a/lib/wallet/nft-image.ts
+++ b/lib/wallet/nft-image.ts
@@ -5,7 +5,7 @@ import { parseAbi, type Address, type PublicClient } from "viem";
 /**
  * Resolves the artwork for an NFT, when it has any.
  *
- * Statics Genesis NFTs return self-contained onchain JSON and SVG metadata.
+ * Statics Operators NFTs return self-contained onchain JSON and SVG metadata.
  * PositionNFT metadata is intentionally text-only, while other collections can
  * omit metadata or depend on an unavailable gateway, so no resolution step
  * throws and callers retain a deliberate placeholder.
@@ -67,7 +67,7 @@ const EMPTY_METADATA: NftMetadata = { image: null, traits: [] };
 /**
  * Reads the `attributes` array, tolerating every shape a collection might use.
  *
- * Statics Genesis returns eight string traits plus a numeric Activation Tier
+ * Statics Operators returns eight string traits plus a numeric Activation Tier
  * carrying a `max_value`. Arbitrary collections return anything at all, so a
  * malformed entry is skipped rather than failing the whole list -- artwork must
  * still render when the traits beside it are unusable.

--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,7 @@
     "genesis": {
       "label": "My Operators",
       "status": "Operators NFTs",
-      "title": "Manage my Genesis",
+      "title": "Manage my Operators",
       "description": "View Operator artwork, activate reward tiers, register for launch rewards, and manage secured credit after the Genesis Epoch."
     }
   },
@@ -164,7 +164,7 @@
       "label": "Recoveries",
       "status": "Operator recoveries",
       "title": "Recover matured Genesis credit",
-      "description": "Find Operators NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive."
+      "description": "Find Operator NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive."
     },
     "liquidity": {
       "label": "Liquidity",

--- a/messages/en.json
+++ b/messages/en.json
@@ -51,7 +51,7 @@
       "overview": "Overview",
       "swap": "Swap",
       "earn": "Earn",
-      "genesis": "Genesis NFT",
+      "genesis": "Operator NFT",
       "liquidity": "Liquidity",
       "baskets": "Baskets",
       "create": "Create basket",
@@ -76,21 +76,21 @@
   "launchRoutes": {
     "overview": {
       "label": "Overview",
-      "status": "Genesis launch",
-      "title": "Statics Genesis launch",
-      "description": "Trade STATICS, acquire fully backed Genesis NFTs, and follow the Genesis Epoch on Robinhood Chain."
+      "status": "Operators launch",
+      "title": "Statics Operators launch",
+      "description": "Trade STATICS, acquire fully backed Operators NFTs, and follow the Genesis Epoch on Robinhood Chain."
     },
     "swap": {
       "label": "Trade",
       "status": "STATICS market",
-      "title": "Trade STATICS and Genesis NFTs",
-      "description": "Buy or sell STATICS through its canonical market, or acquire a fully backed Genesis NFT through the Vault."
+      "title": "Trade STATICS and Operators NFTs",
+      "description": "Buy or sell STATICS through its canonical market, or acquire a fully backed Operator NFT through the Vault."
     },
     "genesis": {
-      "label": "My Genesis",
-      "status": "Genesis NFTs",
+      "label": "My Operators",
+      "status": "Operators NFTs",
       "title": "Manage my Genesis",
-      "description": "View Genesis artwork, activate reward tiers, register for launch rewards, and manage secured credit after the Genesis Epoch."
+      "description": "View Operator artwork, activate reward tiers, register for launch rewards, and manage secured credit after the Genesis Epoch."
     }
   },
   "routes": {
@@ -103,8 +103,8 @@
     "swap": {
       "label": "Swap",
       "status": "STATICS market",
-      "title": "Swap tokens and Genesis NFTs",
-      "description": "Buy or sell STATICS through its official pool, then exchange STATICS for a fully backed Genesis NFT."
+      "title": "Swap tokens and Operators NFTs",
+      "description": "Buy or sell STATICS through its official pool, then exchange STATICS for a fully backed Operator NFT."
     },
     "dollar": {
       "label": "Dollar",
@@ -155,16 +155,16 @@
       "description": "Stake a position to earn a share of protocol fees. Pick which assets to earn in and claim what you have built up."
     },
     "genesis": {
-      "label": "Genesis NFT",
-      "status": "Genesis NFT",
-      "title": "Manage your Genesis NFTs",
-      "description": "View Genesis artwork, activate reward tiers with STATICS payments, and manage each NFT's protocol features."
+      "label": "Operator NFT",
+      "status": "Operator NFT",
+      "title": "Manage your Operators NFTs",
+      "description": "View Operator artwork, activate reward tiers with STATICS payments, and manage each NFT's protocol features."
     },
     "genesisRecoveries": {
       "label": "Recoveries",
-      "status": "Genesis recoveries",
+      "status": "Operator recoveries",
       "title": "Recover matured Genesis credit",
-      "description": "Find Genesis NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive."
+      "description": "Find Operators NFTs whose secured credit has run past its deadline, and recover one to earn the caller incentive."
     },
     "liquidity": {
       "label": "Liquidity",

--- a/messages/en.json
+++ b/messages/en.json
@@ -450,6 +450,7 @@
     "confirmSwap": "Confirm swap",
     "selectAsset": "Select asset",
     "balance": "Balance {balance}",
+    "max": "MAX",
     "createSolanaWallet": "Create Solana wallet",
     "submitting": "Submitting…",
     "connectWallet": "Connect wallet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -450,6 +450,7 @@
     "confirmSwap": "Confirmar intercambio",
     "selectAsset": "Seleccionar activo",
     "balance": "Saldo {balance}",
+    "max": "MÁX",
     "createSolanaWallet": "Crear cartera de Solana",
     "submitting": "Enviando…",
     "connectWallet": "Conectar cartera",

--- a/messages/es.json
+++ b/messages/es.json
@@ -51,7 +51,7 @@
       "overview": "Resumen",
       "swap": "Intercambiar",
       "earn": "Ganar",
-      "genesis": "Genesis NFT",
+      "genesis": "Operator NFT",
       "liquidity": "Liquidez",
       "baskets": "Cestas",
       "create": "Crear cesta",
@@ -77,7 +77,7 @@
     "overview": {
       "label": "Resumen",
       "status": "Lanzamiento Genesis",
-      "title": "Lanzamiento de Statics Genesis",
+      "title": "Lanzamiento de Statics Operators",
       "description": "Intercambia STATICS, adquiere NFT Genesis con respaldo total y sigue la Época Genesis en Robinhood Chain."
     },
     "swap": {
@@ -155,9 +155,9 @@
       "description": "Haz staking de una posición para obtener una parte de las comisiones del protocolo. Elige en qué activos quieres ganar y reclama lo acumulado."
     },
     "genesis": {
-      "label": "Genesis NFT",
-      "status": "Genesis NFT",
-      "title": "Gestiona tus Genesis NFTs",
+      "label": "Operator NFT",
+      "status": "Operator NFT",
+      "title": "Gestiona tus Operators NFTs",
       "description": "Consulta el arte de Genesis, activa niveles de recompensa mediante pagos en STATICS y gestiona las funciones de cada NFT."
     },
     "genesisRecoveries": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -450,6 +450,7 @@
     "confirmSwap": "确认兑换",
     "selectAsset": "选择资产",
     "balance": "余额 {balance}",
+    "max": "最大",
     "createSolanaWallet": "创建 Solana 钱包",
     "submitting": "正在提交…",
     "connectWallet": "连接钱包",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -51,7 +51,7 @@
       "overview": "概览",
       "swap": "兑换",
       "earn": "赚取",
-      "genesis": "Genesis NFT",
+      "genesis": "Operator NFT",
       "liquidity": "流动性",
       "baskets": "篮子",
       "create": "创建篮子",
@@ -77,18 +77,18 @@
     "overview": {
       "label": "概览",
       "status": "Genesis 启动",
-      "title": "Statics Genesis 启动",
-      "description": "在 Robinhood Chain 上交易 STATICS、获取有完全储备支持的 Genesis NFT，并关注 Genesis 纪元。"
+      "title": "Statics Operators 启动",
+      "description": "在 Robinhood Chain 上交易 STATICS、获取有完全储备支持的 Operator NFT，并关注 Genesis 纪元。"
     },
     "swap": {
       "label": "交易",
       "status": "STATICS 市场",
-      "title": "交易 STATICS 和 Genesis NFT",
-      "description": "通过规范市场买卖 STATICS，或通过金库获取有完全储备支持的 Genesis NFT。"
+      "title": "交易 STATICS 和 Operator NFT",
+      "description": "通过规范市场买卖 STATICS，或通过金库获取有完全储备支持的 Operator NFT。"
     },
     "genesis": {
       "label": "我的 Genesis",
-      "status": "Genesis NFT",
+      "status": "Operator NFT",
       "title": "管理我的 Genesis",
       "description": "查看 Genesis 艺术作品、激活奖励等级、注册以获取启动奖励，并在 Genesis 纪元结束后管理担保信贷。"
     }
@@ -103,8 +103,8 @@
     "swap": {
       "label": "兑换",
       "status": "STATICS 市场",
-      "title": "兑换代币和 Genesis NFT",
-      "description": "通过官方池买卖 STATICS，然后用 STATICS 兑换有完全储备支持的 Genesis NFT。"
+      "title": "兑换代币和 Operator NFT",
+      "description": "通过官方池买卖 STATICS，然后用 STATICS 兑换有完全储备支持的 Operator NFT。"
     },
     "dollar": {
       "label": "美元",
@@ -155,16 +155,16 @@
       "description": "质押一个头寸以获得协议费用分成。选择希望赚取的资产并领取累积奖励。"
     },
     "genesis": {
-      "label": "Genesis NFT",
-      "status": "Genesis NFT",
-      "title": "管理你的 Genesis NFTs",
+      "label": "Operator NFT",
+      "status": "Operator NFT",
+      "title": "管理你的 Operators NFTs",
       "description": "查看 Genesis 艺术作品，通过支付 STATICS 激活奖励等级，并管理每个 NFT 的协议功能。"
     },
     "genesisRecoveries": {
       "label": "回收",
       "status": "Genesis 回收",
       "title": "回收已到期的 Genesis 信贷",
-      "description": "查找担保信贷已超过期限的 Genesis NFT，回收其中一个即可获得执行者奖励。"
+      "description": "查找担保信贷已超过期限的 Operator NFT，回收其中一个即可获得执行者奖励。"
     },
     "liquidity": {
       "label": "流动性",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit --incremental false",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "NEXT_PUBLIC_STATICS_CHAIN_ID= npm run build && playwright test",
+    "test:e2e": "node scripts/without-statics-env.mjs npm run build && playwright test",
     "verify:connected:local": "node scripts/verify-connected-local.mjs",
     "test:integration:local": "node test/integration/local-dollar.mjs",
     "verify": "npm run lint && npm run lint:css && npm run format:check && npm run typecheck && npm test && npm run test:e2e"

--- a/scripts/vendor-statics-sdk.mjs
+++ b/scripts/vendor-statics-sdk.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -36,13 +36,21 @@ const protocolCommit = execFileSync("git", ["rev-parse", "HEAD"], {
   cwd: protocolRoot,
   encoding: "utf8",
 }).trim();
-const sdkTreeState = [sdkRoot, sdkExtensionRoot]
-  .filter(Boolean)
-  .some((root) =>
-    execFileSync("git", ["status", "--porcelain"], { cwd: root, encoding: "utf8" }).trim()
-  )
-  ? "dirty"
-  : "clean";
+function sdkTreeDirty(root) {
+  if (!root) return false;
+  const gitRoot = execFileSync("git", ["-C", root, "rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).trim();
+  const relativeRoot = relative(gitRoot, root) || ".";
+  return Boolean(
+    execFileSync(
+      "git",
+      ["-C", gitRoot, "status", "--porcelain", "--untracked-files=all", "--", relativeRoot],
+      { encoding: "utf8" }
+    ).trim()
+  );
+}
+const sdkTreeState = sdkTreeDirty(sdkRoot) || sdkTreeDirty(sdkExtensionRoot) ? "dirty" : "clean";
 
 execFileSync("npm", ["run", "build"], { cwd: sdkRoot, stdio: "inherit" });
 if (sdkExtensionRoot) {

--- a/scripts/without-statics-env.mjs
+++ b/scripts/without-statics-env.mjs
@@ -1,0 +1,11 @@
+import { spawnSync } from "node:child_process";
+
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("NEXT_PUBLIC_STATICS_")) delete process.env[key];
+}
+
+const [command, ...args] = process.argv.slice(2);
+if (!command) throw new Error("A command is required.");
+const result = spawnSync(command, args, { stdio: "inherit", shell: process.platform === "win32" });
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);

--- a/test/components/app-shell.test.tsx
+++ b/test/components/app-shell.test.tsx
@@ -47,7 +47,7 @@ describe("DApp wallet shell", () => {
   it("places Wallet in launch navigation and Add funds in the navbar", () => {
     const descriptor = {
       deploymentId: "launch-fixture",
-      label: "Genesis launch",
+      label: "Operators launch",
       network: "Robinhood Chain",
       chainId: 4_663,
       stage: "launch",

--- a/test/components/dapp-route-guard.test.tsx
+++ b/test/components/dapp-route-guard.test.tsx
@@ -15,7 +15,7 @@ vi.mock("next/navigation", () => ({
 
 const launchDescriptor = {
   deploymentId: "launch",
-  label: "Genesis launch",
+  label: "Operators launch",
   network: "Robinhood Chain",
   chainId: 4_663,
   stage: "launch",

--- a/test/components/genesis-vault-swap.test.tsx
+++ b/test/components/genesis-vault-swap.test.tsx
@@ -1,0 +1,240 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@/test/render";
+import { getAddress, parseEther, zeroAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GenesisVaultSwapPanel } from "@/components/genesis/GenesisVaultSwapPanel";
+import type { DeploymentOption, LaunchDeployment } from "@/lib/deployments/types";
+import { DeploymentContext } from "@/providers/deployment-context";
+import { WalletContext, defaultWalletState } from "@/providers/wallet-context";
+
+const readContract = vi.fn();
+const getBalance = vi.fn();
+const discoverNextAvailableGenesisId = vi.fn();
+const discoverWalletGenesisIds = vi.fn();
+
+vi.mock("wagmi", () => ({
+  usePublicClient: () => ({ readContract, getBalance }),
+}));
+vi.mock("@/lib/deployments/verify-launch", () => ({
+  verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/genesis/discovery", () => ({
+  discoverNextAvailableGenesisId: (...args: unknown[]) => discoverNextAvailableGenesisId(...args),
+  discoverWalletGenesisIds: (...args: unknown[]) => discoverWalletGenesisIds(...args),
+}));
+vi.mock("@/lib/wallet/nft-image", () => ({
+  resolveNftImage: vi.fn().mockResolvedValue(null),
+  resolveNftMetadata: vi.fn().mockResolvedValue({ image: null, traits: [] }),
+}));
+
+const statics = getAddress("0x1111111111111111111111111111111111111111");
+const weth = getAddress("0x7777777777777777777777777777777777777777");
+const wallet = getAddress("0x2222222222222222222222222222222222222222");
+const descriptor = {
+  deploymentId: "launch-fixture",
+  label: "Statics Genesis",
+  network: "Robinhood Chain",
+  chainId: 4_663,
+  stage: "launch",
+  capabilities: ["overview", "canonical-statics-market", "genesis-vault"],
+  available: true,
+} as const;
+const deployment = {
+  kind: "launch",
+  descriptor,
+  deploymentStartBlock: 1n,
+  protocolCommit: "fixture",
+  source: "development-fixture",
+  contracts: {
+    statics,
+    weth,
+    genesis: zeroAddress,
+    vault: zeroAddress,
+    activationRegistry: zeroAddress,
+    feeReceiver: zeroAddress,
+    launchDistributor: zeroAddress,
+    poolManager: zeroAddress,
+    stateView: zeroAddress,
+    quoter: zeroAddress,
+    universalRouter: zeroAddress,
+    permit2: zeroAddress,
+  },
+  runtimeCodeHashes: {},
+  market: {
+    poolId: `0x${"1".repeat(64)}`,
+    poolKey: {
+      currency0: statics,
+      currency1: weth,
+      fee: 10_000,
+      tickSpacing: 8,
+      hooks: zeroAddress,
+    },
+  },
+} as const satisfies LaunchDeployment;
+const option = {
+  networkId: "robinhood",
+  descriptor,
+  launch: deployment,
+  protocol: null,
+} satisfies DeploymentOption;
+
+function reads({ credits = new Map<string, boolean>() }: { credits?: Map<string, boolean> } = {}) {
+  readContract.mockImplementation(
+    async ({ functionName, args }: { functionName: string; args?: readonly unknown[] }) => {
+      if (functionName === "quoteGenesisPurchase") {
+        return {
+          staticsPrice: parseEther("180000"),
+          reserveBuyIn: 0n,
+          nativeFee: parseEther("0.003"),
+          requiredNative: parseEther("0.003"),
+          epochActive: true,
+        };
+      }
+      if (functionName === "quoteGenesisRedemption") {
+        return {
+          staticsPayout: parseEther("180000"),
+          reservePayout: 0n,
+          epochActive: true,
+        };
+      }
+      if (functionName === "vaultAccounting") {
+        return {
+          vaultPrice: parseEther("180000"),
+          maximumSupply: 5_555n,
+          vaultInventory: 4_900n,
+          circulatingGenesis: 655n,
+          epochActive: true,
+        };
+      }
+      if (functionName === "credit") {
+        return { active: credits.get(String(args?.[0])) ?? false, principal: 0n };
+      }
+      if (functionName === "balanceOf") return parseEther("84120.55");
+      throw new Error(`Unexpected read ${functionName}`);
+    }
+  );
+  getBalance.mockResolvedValue(parseEther("2.418"));
+  discoverNextAvailableGenesisId.mockResolvedValue(4_913n);
+  discoverWalletGenesisIds.mockResolvedValue([]);
+}
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DeploymentContext.Provider
+        value={{ active: option, options: [option], selectNetwork: vi.fn() }}
+      >
+        <WalletContext.Provider
+          value={{
+            ...defaultWalletState,
+            status: "ready",
+            authenticated: true,
+            address: wallet,
+            chainId: descriptor.chainId,
+            isTargetChain: true,
+          }}
+        >
+          <GenesisVaultSwapPanel deployment={deployment} />
+        </WalletContext.Provider>
+      </DeploymentContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  readContract.mockReset();
+  getBalance.mockReset();
+  discoverNextAvailableGenesisId.mockReset();
+  discoverWalletGenesisIds.mockReset();
+});
+
+describe("Genesis Vault trade card", () => {
+  it("names the shortfall instead of failing after the click", async () => {
+    // The wallet holds 84,120.55 against a 180,000 price. Previously the button
+    // was enabled and buy() threw once the transaction was already in flight.
+    reads();
+    renderPanel();
+
+    expect(await screen.findByText(/You need 95,879.45 more STATICS/)).toBeInTheDocument();
+    const action = screen.getByRole("button", { name: "Not enough to acquire" });
+    expect(action).toBeDisabled();
+  });
+
+  it("checks the native leg as well as the STATICS leg", async () => {
+    reads();
+    getBalance.mockResolvedValue(parseEther("0.001"));
+    renderPanel();
+
+    expect(await screen.findByText(/more ETH/)).toBeInTheDocument();
+  });
+
+  it("enables the action once both legs are covered", async () => {
+    reads();
+    readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
+      if (functionName === "quoteGenesisPurchase") {
+        return {
+          staticsPrice: parseEther("180000"),
+          reserveBuyIn: 0n,
+          nativeFee: parseEther("0.003"),
+          requiredNative: parseEther("0.003"),
+          epochActive: true,
+        };
+      }
+      if (functionName === "quoteGenesisRedemption") {
+        return { staticsPayout: parseEther("180000"), reservePayout: 0n, epochActive: true };
+      }
+      if (functionName === "vaultAccounting") {
+        return {
+          vaultPrice: parseEther("180000"),
+          maximumSupply: 5_555n,
+          vaultInventory: 4_900n,
+          circulatingGenesis: 655n,
+          epochActive: true,
+        };
+      }
+      if (functionName === "balanceOf") return parseEther("264120.55");
+      throw new Error(`Unexpected read ${functionName}`);
+    });
+    renderPanel();
+
+    expect(await screen.findByRole("button", { name: "Acquire Genesis #4913" })).not.toBeDisabled();
+  });
+
+  it("marks a credit-locked Genesis before it can be chosen to redeem", async () => {
+    reads({ credits: new Map([["4419", true]]) });
+    discoverWalletGenesisIds.mockResolvedValue([1204n, 4419n]);
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Redeem" }));
+
+    const locked = await screen.findByRole("radio", { name: /4419/ });
+    expect(locked).toBeDisabled();
+    expect(screen.getByRole("radio", { name: /1204/ })).not.toBeDisabled();
+  });
+
+  it("states what redemption returns", async () => {
+    reads();
+    discoverWalletGenesisIds.mockResolvedValue([1204n]);
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Redeem" }));
+
+    expect(await screen.findByText("You receive")).toBeInTheDocument();
+    expect(screen.getByText("180,000 STATICS")).toBeInTheDocument();
+    // No reserve share is paid while the Epoch runs, and the panel says so.
+    expect(
+      screen.getByText(/No reserve share is paid until the Genesis Epoch ends/)
+    ).toBeInTheDocument();
+  });
+
+  it("reports what is left rather than repeating the Overview's accounting", async () => {
+    reads();
+    renderPanel();
+
+    expect(await screen.findByText(/left in the Vault/)).toBeInTheDocument();
+    expect(screen.queryByText("Outstanding credit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Native reserve")).not.toBeInTheDocument();
+  });
+});

--- a/test/components/genesis-vault-swap.test.tsx
+++ b/test/components/genesis-vault-swap.test.tsx
@@ -33,7 +33,7 @@ const weth = getAddress("0x7777777777777777777777777777777777777777");
 const wallet = getAddress("0x2222222222222222222222222222222222222222");
 const descriptor = {
   deploymentId: "launch-fixture",
-  label: "Statics Genesis",
+  label: "Statics Operators",
   network: "Robinhood Chain",
   chainId: 4_663,
   stage: "launch",
@@ -199,7 +199,7 @@ describe("Genesis Vault trade card", () => {
     });
     renderPanel();
 
-    expect(await screen.findByRole("button", { name: "Acquire Genesis #4913" })).not.toBeDisabled();
+    expect(await screen.findByRole("button", { name: "Acquire Operators #4913" })).not.toBeDisabled();
   });
 
   it("marks a credit-locked Genesis before it can be chosen to redeem", async () => {

--- a/test/components/genesis-vault-swap.test.tsx
+++ b/test/components/genesis-vault-swap.test.tsx
@@ -199,7 +199,9 @@ describe("Genesis Vault trade card", () => {
     });
     renderPanel();
 
-    expect(await screen.findByRole("button", { name: "Acquire Operators #4913" })).not.toBeDisabled();
+    expect(
+      await screen.findByRole("button", { name: "Acquire Operators #4913" })
+    ).not.toBeDisabled();
   });
 
   it("marks a credit-locked Genesis before it can be chosen to redeem", async () => {

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -46,7 +46,7 @@ const weth = getAddress("0x7777777777777777777777777777777777777777");
 const wallet = getAddress("0x2222222222222222222222222222222222222222");
 const descriptor = {
   deploymentId: "launch-fixture",
-  label: "Statics Genesis",
+  label: "Statics Operators",
   network: "Robinhood Chain",
   chainId: 4_663,
   stage: "launch",
@@ -188,7 +188,7 @@ describe("launch overview", () => {
     renderWithProviders(<DeploymentOverview />);
 
     expect(await screen.findByText("The Epoch ends in")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Acquire Genesis/ })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Acquire Operators/ })).toHaveAttribute(
       "href",
       "/app/swap?mode=nft"
     );
@@ -202,8 +202,8 @@ describe("launch overview", () => {
 
     // Await a figure rather than a static label, so the quotes have landed.
     expect(await screen.findByText("180,000 STATICS, no ETH")).toBeInTheDocument();
-    expect(screen.getByText("Acquiring a Genesis")).toBeInTheDocument();
-    expect(screen.getByText("Redeeming a Genesis")).toBeInTheDocument();
+    expect(screen.getByText("Acquiring an Operator")).toBeInTheDocument();
+    expect(screen.getByText("Redeeming an Operator")).toBeInTheDocument();
     expect(screen.getByText("Secured credit")).toBeInTheDocument();
     expect(screen.getByText("Closed")).toBeInTheDocument();
     expect(screen.getByText("Up to 171,000 STATICS")).toBeInTheDocument();
@@ -241,7 +241,7 @@ describe("launch overview", () => {
     renderWithProviders(<DeploymentOverview />);
 
     expect(await screen.findByText("All three hold")).toBeInTheDocument();
-    expect(screen.getByText("Backing covers every circulating Genesis")).toBeInTheDocument();
+    expect(screen.getByText("Backing covers every circulating Operators")).toBeInTheDocument();
     expect(screen.getByText("The Vault holds that STATICS")).toBeInTheDocument();
     expect(screen.getByText("The Vault holds the ETH reserve")).toBeInTheDocument();
     expect(screen.getByText("655 circulating × 180,000")).toBeInTheDocument();
@@ -252,7 +252,7 @@ describe("launch overview", () => {
     renderWithProviders(<DeploymentOverview />);
 
     expect(await screen.findByText("Fixed at 5,555")).toBeInTheDocument();
-    expect(screen.getByText("Treasury at genesis")).toBeInTheDocument();
+    expect(screen.getByText("Treasury at launch")).toBeInTheDocument();
     expect(screen.getByText("Vault inventory")).toBeInTheDocument();
   });
 
@@ -261,7 +261,7 @@ describe("launch overview", () => {
     renderWithProviders(<DeploymentOverview />, false);
 
     expect(await screen.findByText("Connect to see where you stand")).toBeInTheDocument();
-    expect(screen.queryByText("Your Genesis")).not.toBeInTheDocument();
+    expect(screen.queryByText("Your Operators")).not.toBeInTheDocument();
   });
 
   it("formats either canonical token ordering without floating-point input", () => {
@@ -454,7 +454,7 @@ describe("consolidated Genesis rewards surface", () => {
     discoverWalletGenesisIds.mockResolvedValue([]);
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
 
-    expect(await screen.findByText("No Genesis NFTs yet")).toBeInTheDocument();
+    expect(await screen.findByText("No Operators NFTs yet")).toBeInTheDocument();
     expect(screen.getByText("Rewards from past ownership")).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Claim" })).toHaveLength(2);
     expect(screen.queryByRole("tab", { name: /Genesis #1/ })).not.toBeInTheDocument();

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -15,10 +15,12 @@ import { WalletContext, defaultWalletState } from "@/providers/wallet-context";
 
 const readContract = vi.fn();
 const getBlock = vi.fn();
+const useBlock = vi.fn();
 const loadRecoverableGenesisCredits = vi.fn();
 
 vi.mock("wagmi", () => ({
   usePublicClient: () => ({ readContract, getBlock }),
+  useBlock: (...args: unknown[]) => useBlock(...args),
 }));
 vi.mock("@/lib/deployments/verify-launch", () => ({
   verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +164,7 @@ function renderWithProviders(ui: React.ReactNode, signedIn = true) {
 beforeEach(() => {
   readContract.mockReset();
   getBlock.mockReset();
+  useBlock.mockReturnValue({ data: { timestamp: 2_100_000_000n } });
   loadRecoverableGenesisCredits.mockReset();
   discoverWalletGenesisIds.mockReset();
 });
@@ -306,6 +309,31 @@ describe("Genesis credit presentation", () => {
     expect(screen.getByLabelText("Amount to borrow")).toBeInTheDocument();
   });
 
+  it("uses the latest chain timestamp for an advanced credit clock", async () => {
+    const maturity = 2_100_000_000n;
+    useBlock.mockReturnValue({ data: { timestamp: maturity + 30n * 86_400n + 86_401n } });
+    readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
+      if (functionName === "vaultAccounting") return vaultAccounting(false);
+      if (functionName === "creditOriginationsPaused") return false;
+      if (functionName === "credit") {
+        return {
+          owner: wallet,
+          principal: parseEther("1000"),
+          maturity: Number(maturity),
+          recoverableAt: Number(maturity + 3_600n),
+          active: true,
+        };
+      }
+      if (functionName === "creditLimit") return parseEther("171000");
+      throw new Error(`Unexpected read ${functionName}`);
+    });
+
+    renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
+
+    expect(await screen.findByText("Recoverable in")).toBeInTheDocument();
+    expect(screen.getByText("now")).toBeInTheDocument();
+  });
+
   it("states the recovery consequence before any borrow is confirmed", async () => {
     creditReads(false, false);
     renderWithProviders(<GenesisCreditPanel deployment={deployment} genesisId={1n} />);
@@ -398,7 +426,7 @@ describe("consolidated Genesis rewards surface", () => {
     rewardsReads();
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
 
-    expect(await screen.findByText("Genesis held")).toBeInTheDocument();
+    expect(await screen.findByText("Operators held")).toBeInTheDocument();
     // Two NFTs at 2 STATICS each, plus 5 STATICS retained from past ownership.
     expect(screen.getByText("Claimable now").closest(".ui-stat")).toHaveTextContent("9 STATICS");
     expect(screen.getByText("Credit outstanding").closest(".ui-stat")).toHaveTextContent(
@@ -424,9 +452,9 @@ describe("consolidated Genesis rewards surface", () => {
     expect(await screen.findByText("Your weight")).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Claim" }).length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("tab", { name: /Genesis #2/ }));
+    fireEvent.click(screen.getByRole("tab", { name: /Operator #2/ }));
     expect(
-      await screen.findByRole("button", { name: "Register Genesis #2 for rewards" })
+      await screen.findByRole("button", { name: "Register Operator #2 for rewards" })
     ).toBeInTheDocument();
   });
 
@@ -457,6 +485,6 @@ describe("consolidated Genesis rewards surface", () => {
     expect(await screen.findByText("No Operators NFTs yet")).toBeInTheDocument();
     expect(screen.getByText("Rewards from past ownership")).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Claim" })).toHaveLength(2);
-    expect(screen.queryByRole("tab", { name: /Genesis #1/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: /Operator #1/ })).not.toBeInTheDocument();
   });
 });

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -223,7 +223,7 @@ describe("launch overview", () => {
     // this precision, which is the asymmetry working as designed.
     await screen.findByText("180,000 STATICS, no ETH");
     const row = screen.getByText("Buy-in if the Epoch ended now").closest("div");
-    expect(row).toHaveTextContent("0.0009 ETH");
+    expect(row).toHaveTextContent("0.0009 WETH");
     expect(screen.getByText(/already accruing/)).toBeInTheDocument();
   });
 

--- a/test/components/standalone-genesis.test.tsx
+++ b/test/components/standalone-genesis.test.tsx
@@ -14,7 +14,7 @@ const statics = getAddress("0x1111111111111111111111111111111111111111");
 const weth = getAddress("0x7777777777777777777777777777777777777777");
 const descriptor = {
   deploymentId: "launch-fixture",
-  label: "Statics Genesis",
+  label: "Statics Operators",
   network: "Robinhood Chain",
   chainId: 4_663,
   stage: "launch",

--- a/test/components/swap-page.test.tsx
+++ b/test/components/swap-page.test.tsx
@@ -16,14 +16,14 @@ vi.mock("@/components/portal/EvmSwapPanel", () => ({
   ),
 }));
 vi.mock("@/components/genesis/GenesisVaultSwapPanel", () => ({
-  GenesisVaultSwapPanel: () => <div>Next available Genesis NFT</div>,
+  GenesisVaultSwapPanel: () => <div>Next available Operator NFT</div>,
 }));
 
 const statics = getAddress("0x1111111111111111111111111111111111111111");
 const weth = getAddress("0x7777777777777777777777777777777777777777");
 const descriptor = {
   deploymentId: "launch-fixture",
-  label: "Statics Genesis",
+  label: "Statics Operators",
   network: "Robinhood Chain",
   chainId: 4_663,
   stage: "launch",
@@ -80,8 +80,8 @@ describe("Swap page", () => {
     );
 
     expect(screen.getByText("Token swap canonical")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "Genesis NFT" }));
-    expect(screen.getByText("Next available Genesis NFT")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Operator NFT" }));
+    expect(screen.getByText("Next available Operator NFT")).toBeInTheDocument();
     expect(screen.queryByText("Token swap canonical")).not.toBeInTheDocument();
   });
 
@@ -95,7 +95,7 @@ describe("Swap page", () => {
       </DeploymentContext.Provider>
     );
 
-    expect(screen.getByText("Next available Genesis NFT")).toBeInTheDocument();
+    expect(screen.getByText("Next available Operator NFT")).toBeInTheDocument();
     expect(screen.queryByText("Token swap canonical")).not.toBeInTheDocument();
     searchParams.delete("mode");
   });

--- a/test/components/swap-page.test.tsx
+++ b/test/components/swap-page.test.tsx
@@ -80,7 +80,7 @@ describe("Swap page", () => {
     );
 
     expect(screen.getByText("Token swap canonical")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "NFT" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Genesis NFT" }));
     expect(screen.getByText("Next available Genesis NFT")).toBeInTheDocument();
     expect(screen.queryByText("Token swap canonical")).not.toBeInTheDocument();
   });

--- a/test/e2e/genesis-launch-fork.spec.ts
+++ b/test/e2e/genesis-launch-fork.spec.ts
@@ -20,10 +20,10 @@ function monitorBrowserFailures(page: Page): () => void {
 async function selectLocalDeployment(page: Page) {
   await page.goto("/app");
   await expect(page.getByRole("combobox", { name: "Statics network" })).toHaveValue("anvil");
-  await expect(page.getByRole("heading", { name: "Statics Genesis" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Statics Operators" })).toBeVisible();
 }
 
-test("renders the Genesis launch-only surface and contextual utilities on the local fork", async ({
+test("renders the Operators launch-only surface and contextual utilities on the local fork", async ({
   page,
 }) => {
   const expectNoBrowserFailures = monitorBrowserFailures(page);
@@ -32,12 +32,12 @@ test("renders the Genesis launch-only surface and contextual utilities on the lo
   await expect(page.locator(".dapp-nav-item")).toHaveText([
     "Overview",
     "Trade",
-    "My Genesis",
+    "My Operators",
     "Wallet",
   ]);
   await expect(page.locator(".dapp-tabbar .dapp-tab:not(.dapp-nav-toggle)")).toHaveText([
     "Trade",
-    "My Genesis",
+    "My Operators",
     "Wallet",
   ]);
   await expect(page.getByRole("link", { name: "Add funds" })).toHaveAttribute(
@@ -74,7 +74,7 @@ test("renders the Genesis launch-only surface and contextual utilities on the lo
 test("does not expose a fake browser transfer path", async ({ page }) => {
   await page.goto("/app/genesis");
   await expect(page.getByRole("button", { name: /transfer genesis|send genesis/i })).toHaveCount(0);
-  await expect(page.getByText(/Transferring this Genesis NFT resets its activation/i)).toHaveCount(
+  await expect(page.getByText(/Transferring this Operator NFT resets its activation/i)).toHaveCount(
     0
   );
 });

--- a/test/foundation/dapp-navigation.test.ts
+++ b/test/foundation/dapp-navigation.test.ts
@@ -12,7 +12,7 @@ describe("DApp route presentation", () => {
 
   it.each([
     ["/app", "Overview", "Your portfolio"],
-    ["/app/swap", "Swap", "Swap tokens and Genesis NFTs"],
+    ["/app/swap", "Swap", "Swap tokens and Operators NFTs"],
     ["/app/wallet", "Wallet", "Your wallet"],
     ["/app/faucet", "Faucet", "Get testnet assets"],
     ["/app/portal", "Add funds", "Add funds to Statics"],
@@ -22,7 +22,7 @@ describe("DApp route presentation", () => {
     ["/app/positions", "Position NFT", "Your Position NFTs"],
     ["/app/loans", "Loans", "Your loans"],
     ["/app/rewards", "Rewards", "Your rewards"],
-    ["/app/genesis", "Genesis NFT", "Manage your Genesis NFTs"],
+    ["/app/genesis", "Operator NFT", "Manage your Operators NFTs"],
     ["/app/liquidity", "Liquidity", "Provide liquidity"],
     ["/app/activity", "Activity", "Your activity"],
     ["/app/tools", "Tools", "Approval tools"],

--- a/test/foundation/route-copy.test.ts
+++ b/test/foundation/route-copy.test.ts
@@ -89,7 +89,7 @@ describe("dapp route copy", () => {
 describe("stage-aware dapp navigation", () => {
   const launch = {
     deploymentId: "launch",
-    label: "Genesis launch",
+    label: "Operators launch",
     network: "Robinhood Chain",
     chainId: 4663,
     stage: "launch" as const,
@@ -180,7 +180,7 @@ describe("sidebar completeness", () => {
       "Create basket",
       "Dollar",
       "Position NFT",
-      "Genesis NFT",
+      "Operator NFT",
       "Loans",
       "Wallet",
       "Faucet",
@@ -201,7 +201,7 @@ describe("sidebar completeness", () => {
   it("uses the exact NFT product labels in every locale", () => {
     for (const messages of [english, spanish, chinese]) {
       expect(messages.navigation.items.positions).toBe("Position NFT");
-      expect(messages.navigation.items.genesis).toBe("Genesis NFT");
+      expect(messages.navigation.items.genesis).toBe("Operator NFT");
     }
   });
 

--- a/test/foundation/style-primitives.test.ts
+++ b/test/foundation/style-primitives.test.ts
@@ -22,4 +22,14 @@ describe("DApp style primitives", () => {
       expect(source).toContain(primitive);
     }
   });
+
+  it("keeps the centred trade card layout scoped away from Wallet", () => {
+    const source = readFileSync("app/(dapp)/app/app.css", "utf8");
+
+    expect(source).toContain(".wallet-surface,\n.portal-workspace {");
+    expect(source).toContain(
+      ".swap-page {\n  display: grid;\n  grid-template-columns: minmax(0, 1fr);"
+    );
+    expect(source).not.toContain(".wallet-surface,\n.portal-workspace,\n.swap-page {");
+  });
 });

--- a/test/genesis/activation-costs.test.ts
+++ b/test/genesis/activation-costs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { cumulativeGenesisActivationCost } from "@statics-protocol/sdk";
 
-import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
+import { genesisActivationCost, oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
 
 describe("Genesis activation tier costs", () => {
   it("aligns RPC tier reads with the SDK's one-indexed cost lookup", () => {
@@ -15,5 +15,9 @@ describe("Genesis activation tier costs", () => {
 
   it("rejects incomplete tier-cost reads", () => {
     expect(() => oneIndexedGenesisTierCosts([10n, 20n, 30n])).toThrow("exactly four tier costs");
+  });
+
+  it("does not ask the SDK to price an already-maxed Tier 4 Genesis", () => {
+    expect(genesisActivationCost([10n, 20n, 30n, 40n], 4, 4)).toBe(0n);
   });
 });

--- a/test/liquidity/liquidity.test.tsx
+++ b/test/liquidity/liquidity.test.tsx
@@ -180,7 +180,7 @@ describe("canonical liquidity identifiers", () => {
 
     expect(borrowedLiquidityReadiness(basket, [readyPool], null)).toMatch(/Every basket/);
     expect(borrowedLiquidityReadiness(basket, [readyPool, secondPool], null)).toMatch(
-      /calculate an executable liquidity plan/
+      /cannot fund a positive amount in every pool/
     );
     expect(
       borrowedLiquidityReadiness(basket, [{ ...readyPool, managerSynced: false }, secondPool], null)

--- a/test/trade/swap-deadline.test.ts
+++ b/test/trade/swap-deadline.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { swapDeadlineBase } from "@/lib/trade/canonical-market";
+
+/**
+ * Regression cover for a UniversalRouter revert with TransactionDeadlinePassed
+ * (0x5bf6f916) on a local fork: the deadline was anchored to the last mined
+ * block, but the swap executes in the next one.
+ */
+describe("swap deadline base", () => {
+  it("uses wall clock when the latest block is stale", () => {
+    // Anvil mines only on activity. After a quiet period the latest block can
+    // be far behind, while the block this transaction lands in jumps to real
+    // time -- which is what made every swap after 20 idle minutes revert.
+    const latest = 1_787_681_161n; // 18:06:01
+    const now = 1_787_682_706n; // 18:31:46
+    expect(swapDeadlineBase(latest, null, now)).toBe(now);
+  });
+
+  it("uses the chain when a fork has been advanced past wall clock", () => {
+    // Advancing time is how the Genesis Epoch gets tested, and it puts the
+    // chain ahead of the machine running the browser.
+    const latest = 1_790_000_000n;
+    const now = 1_787_682_706n;
+    expect(swapDeadlineBase(latest, null, now)).toBe(latest);
+  });
+
+  it("prefers the pending block when the node exposes one", () => {
+    const latest = 1_787_681_161n;
+    const pending = 1_787_684_000n;
+    const now = 1_787_682_706n;
+    expect(swapDeadlineBase(latest, pending, now)).toBe(pending);
+  });
+
+  it("ignores a pending block that trails the chain", () => {
+    const latest = 1_790_000_000n;
+    expect(swapDeadlineBase(latest, 1_787_684_000n, 1_787_682_706n)).toBe(latest);
+  });
+
+  it("is never earlier than any clock it was given", () => {
+    const clocks: [bigint, bigint | null, bigint][] = [
+      [5n, 9n, 7n],
+      [9n, 5n, 7n],
+      [7n, null, 9n],
+      [1n, 1n, 1n],
+    ];
+    for (const [latest, pending, now] of clocks) {
+      const base = swapDeadlineBase(latest, pending, now);
+      expect(base).toBeGreaterThanOrEqual(latest);
+      expect(base).toBeGreaterThanOrEqual(now);
+      if (pending !== null) expect(base).toBeGreaterThanOrEqual(pending);
+    }
+  });
+});

--- a/test/wallet/nfts.test.ts
+++ b/test/wallet/nfts.test.ts
@@ -88,7 +88,7 @@ describe("position NFT description", () => {
     expect(describePositionNft(position(), diamond).contract).toBe(diamond);
   });
 
-  it("blocks transfer until a linked Genesis NFT is unlinked", () => {
+  it("blocks transfer until a linked Operator NFT is unlinked", () => {
     const nft = describePositionNft(position({ linkedGenesisId: 42n }), diamond);
     expect(nft.blockedReason).toMatch(/Unlink Genesis #42/);
   });


### PR DESCRIPTION
Stacked on #32 → #31 → #30. Review bottom-up.

## The bug hit

`0x5bf6f916` is `TransactionDeadlinePassed()`. Decoding your calldata:

| | |
|---|---|
| Deadline in the transaction | `18:26:01` |
| `PERMIT_TTL` | 20 min |
| ⇒ latest block timestamp | **`18:06:01`** |
| Wall clock at submission | `18:31` |

The deadline was anchored to `block.timestamp` of the **last mined block**, but the swap executes in the **next** one. Anvil mines only on activity, so after ~25 idle minutes `latest` was 25 minutes stale while the block the transaction landed in jumped forward to real time — straight past a 20-minute deadline. Any quiet period longer than `PERMIT_TTL` broke every canonical swap.

This is pre-existing: `6ff2022` moved the deadline from `Date.now()` to `block.timestamp`, which fixed the *advanced-forward* fork case and left the *idle* case.

`swapDeadlineBase` takes the greatest of latest block, pending block, and wall clock — each leads where the others are wrong. The chain leads on a fork advanced past wall clock (how the Epoch gets tested); wall clock leads on an idle fork. Five unit tests cover the cases, including the exact timestamps from your revert. The Permit2 expiry check moves to the same clock, since a stale block makes an expired allowance look usable.

## Why the card looked wrong

Three specific things, all visible in the specimen strip of the [mockup](https://claude.ai/code/artifact/5d4f22b7-db66-4ca2-8454-1f4c8ab122a4):

- **`.portal-primary-action`** was `background: var(--accent-wash)` — accent at 12% opacity with a square border — while `.ui-button--primary`, used everywhere else, is a solid `--accent` fill on `--accent-ink`.
- **`border-radius: 0`** on the shared control rule, so square controls sat inside `--radius-lg` cards. A few consumers re-rounded themselves; the primary action and tabs never did.
- **`.portal-field`** set the label's `text-transform: uppercase` and `letter-spacing: 0.08em` on the *container*, and the `<input>` inherited both — `font: inherit` resets neither, since neither belongs to the `font` shorthand. Every typed digit was tracked out, on the one field that is nothing but digits.

Also fixed: quote cells carried `border-radius: var(--radius-lg)` inside an `overflow: hidden` parent using the 1px-gap-as-divider trick, notching the interior corners; the grid rendered three em-dashes before you typed. Rows now appear only with a quote, price impact takes semantic colour, the balance row gains **Max**, and the direction control is a circle centred on the seam rather than a rectangle beside it.

## NFT tab

**You could not tell whether you could afford a Genesis until the transaction failed.** `buy()` read the STATICS balance inside the click handler and threw *"Buy STATICS first, then switch back to NFT"*; the ETH leg was never checked. Both legs are now read with the vault query, shown against your balances, and the button disables naming the shortfall.

Three hairline-separated panels become one card with an Acquire/Redeem control mirroring the token side. Artwork uses the `size="lg"` variant from #31. Redemption is picked by artwork with credit-locked NFTs disabled *before* selection instead of reverting. The six vault statistics drop to a one-line strip, since they now lead the redesigned Overview.

## Requested separately

Removed the **"How approvals work"** disclosure. ⚠️ One consequence worth a decision: it appeared on eight routes and was the only in-app link to `/app/tools`. At launch stage `approval-tools` is not in `launchPrimaryCapabilities`, so the page is now reachable only by typing the URL. If you want approvals discoverable, the natural homes are the Wallet page or the account dialog — say the word and I will add it.

## Blast radius beyond /app/swap

`EvmSwapPanel` is shared with `/app/portal`, and the shared CSS rules reach further:

- Dropping `border-radius: 0` also affects `.wallet-network-row` and `.wallet-quick-actions` on `/app/wallet`.
- `.portal-asset-field input` grows from `--text-lg` to `--text-3xl`, which also lands on `SolanaSwapPanel`, `AcrossBridgePanel` and `PeggedDollarPanel`. Consistent, and I think right, but it is a visual change on four more surfaces.
- Moving the label styling off `.portal-field` needed a second selector for `SolanaSwapPanel` and `AcrossBridgePanel`, which nest their label inside `.portal-asset-field-head` rather than as a direct child. Verified every consumer still gets a styled label.

Worth a look at `/app/portal` and `/app/wallet` on the fork before merge.

## Validation

- `npm test` — 106 files, 573 tests passed (was 567; 11 new across the deadline logic and the vault card).
- `npm run typecheck`, `lint`, `lint:css`, `format:check`, `build` — all passed; one pre-existing simulator warning.
- Layout verified with a Playwright overflow probe across token / acquire / redeem at 1440, 1024, 820, 640 and 420px — no child escaping its container, no horizontal page scroll. That probe caught a real grid-overflow bug in the mockup (an implicit `auto` track sizing to the amount input's 20-character intrinsic width), which is why `.portal-panel`, `.portal-asset-field` and `.swap-page` all pin `grid-template-columns: minmax(0, 1fr)`.

Not run: `npm run verify:genesis-launch-fork`. This one touches the swap execution path, so that gate matters more here than on #31 or #32 — worth driving before merge.
