### PR TITLE
feat(genesis): batch launch reward claims

### DIFF
--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -43,7 +43,7 @@ function describeCreditError(error: unknown, copy: CreditErrorCopy): string {
   const message = error instanceof Error ? error.message : String(error);
   if (/rejected/i.test(message)) return copy.walletRejected;
   if (message.includes("CreditUnavailableDuringEpoch")) return copy.afterEpoch;
-  if (message.includes("CreditOriginationsPaused")) return copy.paused;
+  if (message.includes("CreditIncreasesPaused")) return copy.paused;
   if (message.includes("CreditExpired")) return copy.expired;
   if (message.includes("CreditNotRecoverable")) return copy.notRecoverable;
   return message || copy.transactionFailed;
@@ -215,7 +215,7 @@ export function GenesisCreditPanel({
     queryFn: async () => {
       if (!publicClient || !wallet) throw new Error(t("connect"));
       await verifyLaunchDeploymentCached(publicClient, deployment);
-      const [vault, originationsPaused, credit, limit] = await Promise.all([
+      const [vault, creditIncreasesPaused, credit, limit] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: currentGenesisVaultAbi,
@@ -224,7 +224,7 @@ export function GenesisCreditPanel({
         publicClient.readContract({
           address: deployment.contracts.vault,
           abi: staticsGenesisCreditAbi,
-          functionName: "creditOriginationsPaused",
+          functionName: "creditIncreasesPaused",
         }) as Promise<boolean>,
         publicClient.readContract({
           address: deployment.contracts.vault,
@@ -243,7 +243,7 @@ export function GenesisCreditPanel({
         epochActive: vault.epochActive,
         genesisEpochEnd: Number(vault.genesisEpochEnd),
         vaultPrice: vault.vaultPrice,
-        originationsPaused,
+        creditIncreasesPaused,
         credit,
         limit,
       };
@@ -437,7 +437,7 @@ export function GenesisCreditPanel({
                 await send(
                   "repay-genesis-credit",
                   t("repayLabel", { id: genesisId.toString() }),
-                  buildRepayGenesisCreditCall(genesisId),
+                  buildRepayGenesisCreditCall(genesisId, credit.principal),
                   `${formatEther(credit.principal)} STATICS`
                 );
               })
@@ -481,7 +481,7 @@ export function GenesisCreditPanel({
     );
   }
 
-  if (state.data.originationsPaused) {
+  if (state.data.creditIncreasesPaused) {
     return (
       <section
         className="ui-card genesis-panel"

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -10,6 +10,7 @@ import {
   buildAccrueGenesisLaunchRewardsCall,
   buildActivateGenesisCall,
   buildClaimAllGenesisLaunchRewardsCall,
+  buildClaimAllGenesisLaunchTreasuryRewardsCall,
   buildClaimGenesisLaunchRewardsCall,
   buildClaimOwnerGenesisLaunchRewardsCall,
   buildRegisterGenesisCall,
@@ -273,19 +274,24 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
 
   const claimEverything = async () => {
     const batches = batchGenesisIds(claimableGenesisIds(items));
-    if (batches.length === 0 && (summary.ownerStatics > 0n || summary.ownerWeth > 0n)) {
-      batches.push([]);
-    }
     for (const [index, genesisIds] of batches.entries()) {
-      setClaimProgress(`${index + 1} of ${batches.length}`);
+      setClaimProgress(`${index + 1} of ${summary.claimCount}`);
       await send(
         "claim-rewards",
-        genesisIds.length > 0
-          ? t("claimBatch", { count: genesisIds.length })
-          : t("claimPreviousRewards"),
+        t("claimBatch", { count: genesisIds.length }),
         deployment.contracts.launchDistributor,
         buildClaimAllGenesisLaunchRewardsCall(genesisIds, wallet!),
-        genesisIds.length > 0 ? `${genesisIds.length} Operator NFTs` : "Previous-owner rewards"
+        `${genesisIds.length} Operator NFTs`
+      );
+    }
+    if (summary.ownerStatics > 0n || summary.ownerWeth > 0n) {
+      setClaimProgress(`${batches.length + 1} of ${summary.claimCount}`);
+      await send(
+        "claim-rewards",
+        t("claimPreviousRewards"),
+        deployment.contracts.launchDistributor,
+        buildClaimAllGenesisLaunchTreasuryRewardsCall(wallet!),
+        "Previous-owner rewards"
       );
     }
   };

--- a/components/genesis/StandaloneGenesisPage.tsx
+++ b/components/genesis/StandaloneGenesisPage.tsx
@@ -9,6 +9,7 @@ import { usePublicClient } from "wagmi";
 import {
   buildAccrueGenesisLaunchRewardsCall,
   buildActivateGenesisCall,
+  buildClaimAllGenesisLaunchRewardsCall,
   buildClaimGenesisLaunchRewardsCall,
   buildClaimOwnerGenesisLaunchRewardsCall,
   buildRegisterGenesisCall,
@@ -33,6 +34,8 @@ import { genesisActivationCost, oneIndexedGenesisTierCosts } from "@/lib/genesis
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import {
   EMPTY_GENESIS_PORTFOLIO,
+  batchGenesisIds,
+  claimableGenesisIds,
   loadOwnedGenesis,
   ownedGenesisQueryKey,
   summariseGenesisRewards,
@@ -269,45 +272,20 @@ export function StandaloneGenesisPage({ deployment }: { deployment: LaunchDeploy
   };
 
   const claimEverything = async () => {
-    const jobs: { label: string; data: `0x${string}`; amount: string }[] = [];
-    for (const item of items) {
-      if (item.pendingStatics > 0n) {
-        jobs.push({
-          label: t("claimOperatorAsset", { id: item.id.toString(), asset: "STATICS" }),
-          data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.statics, wallet!),
-          amount: `${formatEther(item.pendingStatics)} STATICS`,
-        });
-      }
-      if (item.pendingWeth > 0n) {
-        jobs.push({
-          label: t("claimOperatorAsset", { id: item.id.toString(), asset: "WETH" }),
-          data: buildClaimGenesisLaunchRewardsCall(item.id, deployment.contracts.weth, wallet!),
-          amount: `${formatEther(item.pendingWeth)} WETH`,
-        });
-      }
+    const batches = batchGenesisIds(claimableGenesisIds(items));
+    if (batches.length === 0 && (summary.ownerStatics > 0n || summary.ownerWeth > 0n)) {
+      batches.push([]);
     }
-    if (summary.ownerStatics > 0n) {
-      jobs.push({
-        label: t("claimPrevious", { asset: "STATICS" }),
-        data: buildClaimOwnerGenesisLaunchRewardsCall(deployment.contracts.statics, wallet!),
-        amount: `${formatEther(summary.ownerStatics)} STATICS`,
-      });
-    }
-    if (summary.ownerWeth > 0n) {
-      jobs.push({
-        label: t("claimPrevious", { asset: "WETH" }),
-        data: buildClaimOwnerGenesisLaunchRewardsCall(deployment.contracts.weth, wallet!),
-        amount: `${formatEther(summary.ownerWeth)} WETH`,
-      });
-    }
-    for (const [index, job] of jobs.entries()) {
-      setClaimProgress(`${index + 1} of ${jobs.length}`);
+    for (const [index, genesisIds] of batches.entries()) {
+      setClaimProgress(`${index + 1} of ${batches.length}`);
       await send(
         "claim-rewards",
-        job.label,
+        genesisIds.length > 0
+          ? t("claimBatch", { count: genesisIds.length })
+          : t("claimPreviousRewards"),
         deployment.contracts.launchDistributor,
-        job.data,
-        job.amount
+        buildClaimAllGenesisLaunchRewardsCall(genesisIds, wallet!),
+        genesisIds.length > 0 ? `${genesisIds.length} Operator NFTs` : "Previous-owner rewards"
       );
     }
   };

--- a/lib/genesis/owned.ts
+++ b/lib/genesis/owned.ts
@@ -45,6 +45,32 @@ export const EMPTY_GENESIS_PORTFOLIO: OwnedGenesisPortfolio = {
   stale: false,
 };
 
+/** Maximum number of Genesis IDs accepted by one batch claim transaction. */
+export const GENESIS_CLAIM_BATCH_SIZE = 64;
+
+/** IDs with at least one pending reward, in wallet discovery order and without duplicates. */
+export function claimableGenesisIds(items: readonly OwnedGenesis[]): bigint[] {
+  const seen = new Set<string>();
+  const ids: bigint[] = [];
+  for (const item of items) {
+    if (item.pendingStatics === 0n && item.pendingWeth === 0n) continue;
+    const key = item.id.toString();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ids.push(item.id);
+  }
+  return ids;
+}
+
+/** Split claimable Genesis IDs into deterministic, bounded transaction batches. */
+export function batchGenesisIds(ids: readonly bigint[]): bigint[][] {
+  const batches: bigint[][] = [];
+  for (let offset = 0; offset < ids.length; offset += GENESIS_CLAIM_BATCH_SIZE) {
+    batches.push(ids.slice(offset, offset + GENESIS_CLAIM_BATCH_SIZE));
+  }
+  return batches;
+}
+
 /**
  * The query key both My Operators and the Overview mount.
  *
@@ -203,14 +229,7 @@ export type GenesisRewardSummary = Readonly<{
   claimableWeth: bigint;
   ownerStatics: bigint;
   ownerWeth: bigint;
-  /**
-   * How many wallet signatures a full claim currently takes.
-   *
-   * `GenesisLaunchDistributor` exposes `claimGenesis` and `claimOwnerRewards`
-   * one asset at a time, so this is the honest count to put in front of anyone
-   * about to start the sequence. It collapses to 1 when the batch entry point
-   * lands.
-   */
+  /** How many bounded batch transactions a full claim requires. */
   claimTransactionCount: number;
 }>;
 
@@ -218,12 +237,8 @@ export function summariseGenesisRewards(portfolio: OwnedGenesisPortfolio): Genes
   const pendingStatics = portfolio.items.reduce((total, item) => total + item.pendingStatics, 0n);
   const pendingWeth = portfolio.items.reduce((total, item) => total + item.pendingWeth, 0n);
   const claimTransactionCount =
-    portfolio.items.reduce(
-      (total, item) => total + (item.pendingStatics > 0n ? 1 : 0) + (item.pendingWeth > 0n ? 1 : 0),
-      0
-    ) +
-    (portfolio.ownerStatics > 0n ? 1 : 0) +
-    (portfolio.ownerWeth > 0n ? 1 : 0);
+    batchGenesisIds(claimableGenesisIds(portfolio.items)).length ||
+    (portfolio.ownerStatics > 0n || portfolio.ownerWeth > 0n ? 1 : 0);
   return {
     claimableStatics: pendingStatics + portfolio.ownerStatics,
     claimableWeth: pendingWeth + portfolio.ownerWeth,

--- a/lib/genesis/owned.ts
+++ b/lib/genesis/owned.ts
@@ -236,9 +236,9 @@ export type GenesisRewardSummary = Readonly<{
 export function summariseGenesisRewards(portfolio: OwnedGenesisPortfolio): GenesisRewardSummary {
   const pendingStatics = portfolio.items.reduce((total, item) => total + item.pendingStatics, 0n);
   const pendingWeth = portfolio.items.reduce((total, item) => total + item.pendingWeth, 0n);
-  const claimTransactionCount =
-    batchGenesisIds(claimableGenesisIds(portfolio.items)).length ||
-    (portfolio.ownerStatics > 0n || portfolio.ownerWeth > 0n ? 1 : 0);
+  const operatorBatchCount = batchGenesisIds(claimableGenesisIds(portfolio.items)).length;
+  const ownerClaimCount = portfolio.ownerStatics > 0n || portfolio.ownerWeth > 0n ? 1 : 0;
+  const claimTransactionCount = operatorBatchCount + ownerClaimCount;
   return {
     claimableStatics: pendingStatics + portfolio.ownerStatics,
     claimableWeth: pendingWeth + portfolio.ownerWeth,

--- a/messages/en.json
+++ b/messages/en.json
@@ -289,6 +289,8 @@
     "claimProgress": "Claiming {progress}…",
     "claimAllSimple": "Claim all",
     "claimAllTransactions": "Claim all · {count} transactions",
+    "claimBatch": "Claim rewards for {count} Operator NFTs",
+    "claimPreviousRewards": "Claim previous-owner rewards",
     "claimPrevious": "Claim previous-owner {asset} rewards",
     "holdingsAria": "Your Operators holdings",
     "held": "Operators held",

--- a/messages/es.json
+++ b/messages/es.json
@@ -289,6 +289,8 @@
     "claimProgress": "Reclamando {progress}…",
     "claimAllSimple": "Reclamar todo",
     "claimAllTransactions": "Reclamar todo · {count} transacciones",
+    "claimBatch": "Reclamar recompensas de {count} NFT de Operator",
+    "claimPreviousRewards": "Reclamar recompensas de titulares anteriores",
     "claimPrevious": "Reclamar recompensas de {asset} de titulares anteriores",
     "holdingsAria": "Tus Operators",
     "held": "Operators en propiedad",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -289,6 +289,8 @@
     "claimProgress": "正在领取 {progress}…",
     "claimAllSimple": "全部领取",
     "claimAllTransactions": "全部领取 · {count} 笔交易",
+    "claimBatch": "领取 {count} 个 Operator NFT 的奖励",
+    "claimPreviousRewards": "领取过往持有者的奖励",
     "claimPrevious": "领取过往持有者的 {asset} 奖励",
     "holdingsAria": "你的 Operators 持仓",
     "held": "持有的 Operators",

--- a/scripts/lib/launch-fork.mjs
+++ b/scripts/lib/launch-fork.mjs
@@ -100,7 +100,7 @@ export async function deployLaunchFork({ protocolRoot, rpcUrl, privateKey, publi
         WETH_ADDRESS: dependencies.weth,
         STATICS_DOPPLER_SALT: salt,
         STATICS_DOPPLER_FEE: String(fee),
-        STATICS_GENESIS_REWARD_SHARE_BPS: "5000",
+        STATICS_GENESIS_REWARD_SHARE_BPS: "4000",
         ETH_RPC_TIMEOUT: process.env.ETH_RPC_TIMEOUT?.trim() || "300",
       },
       maxBuffer: 32 * 1024 * 1024,

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -459,9 +459,9 @@ describe("consolidated Genesis rewards surface", () => {
     rewardsReads();
     renderWithProviders(<StandaloneGenesisPage deployment={deployment} />);
 
-    // Two assets on each of two NFTs, plus both past-ownership assets.
+    // One bounded Operator batch plus one previous-owner treasury claim.
     expect(
-      await screen.findByRole("button", { name: "Claim all · 6 transactions" })
+      await screen.findByRole("button", { name: "Claim all · 2 transactions" })
     ).toBeInTheDocument();
   });
 

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -302,7 +302,7 @@ describe("Genesis credit presentation", () => {
   function creditReads(epochActive: boolean, paused: boolean) {
     readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
       if (functionName === "vaultAccounting") return vaultAccounting(epochActive);
-      if (functionName === "creditOriginationsPaused") return paused;
+      if (functionName === "creditIncreasesPaused") return paused;
       if (functionName === "credit") {
         return { owner: zeroAddress, principal: 0n, maturity: 0, recoverableAt: 0, active: false };
       }
@@ -333,7 +333,7 @@ describe("Genesis credit presentation", () => {
     useBlock.mockReturnValue({ data: { timestamp: maturity + 30n * 86_400n + 86_401n } });
     readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
       if (functionName === "vaultAccounting") return vaultAccounting(false);
-      if (functionName === "creditOriginationsPaused") return false;
+      if (functionName === "creditIncreasesPaused") return false;
       if (functionName === "credit") {
         return {
           owner: wallet,
@@ -414,7 +414,7 @@ describe("consolidated Genesis rewards surface", () => {
     readContract.mockImplementation(
       async ({ functionName, args }: { functionName: string; args: readonly unknown[] }) => {
         if (functionName === "vaultAccounting") return vaultAccounting(true);
-        if (functionName === "creditOriginationsPaused") return false;
+        if (functionName === "creditIncreasesPaused") return false;
         if (functionName === "credit") {
           return {
             owner: zeroAddress,

--- a/test/components/standalone-genesis-claims.test.tsx
+++ b/test/components/standalone-genesis-claims.test.tsx
@@ -82,6 +82,31 @@ const option = {
   protocol: null,
 } satisfies DeploymentOption;
 
+function ownedPortfolio(ownerStatics = 0n, ownerWeth = 0n) {
+  return {
+    items: Array.from({ length: 65 }, (_, index) => ({
+      id: BigInt(index + 1),
+      tier: 0,
+      multiplierBps: 10_000,
+      registered: true,
+      rewardWeight: 10_000n,
+      pendingStatics: 1n,
+      pendingWeth: 0n,
+      creditActive: false,
+      creditPrincipal: 0n,
+      creditMaturity: 0,
+    })),
+    tierCosts: [0n, 0n, 0n, 0n, 0n],
+    rewardShareBps: 5_000,
+    totalWeight: 650_000n,
+    ownerStatics,
+    ownerWeth,
+    indexedBlock: 1n,
+    chainHead: 1n,
+    stale: false,
+  };
+}
+
 function renderPage() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -132,44 +157,29 @@ beforeEach(() => {
       }
       throw new Error(`Unexpected read ${functionName}`);
     });
-  mocks.loadOwnedGenesis.mockResolvedValue({
-    items: Array.from({ length: 65 }, (_, index) => ({
-      id: BigInt(index + 1),
-      tier: 0,
-      multiplierBps: 10_000,
-      registered: true,
-      rewardWeight: 10_000n,
-      pendingStatics: 1n,
-      pendingWeth: 0n,
-      creditActive: false,
-      creditPrincipal: 0n,
-      creditMaturity: 0,
-    })),
-    tierCosts: [0n, 0n, 0n, 0n, 0n],
-    rewardShareBps: 5_000,
-    totalWeight: 650_000n,
-    ownerStatics: 0n,
-    ownerWeth: 0n,
-    indexedBlock: 1n,
-    chainHead: 1n,
-    stale: false,
-  });
+  mocks.loadOwnedGenesis.mockResolvedValue(ownedPortfolio());
 });
 
 describe("Standalone Genesis batch claims", () => {
-  it("splits 65 claimable Operators into two sequential transactions", async () => {
+  it("splits 65 Operators and appends the previous-owner claim", async () => {
+    mocks.loadOwnedGenesis.mockResolvedValueOnce(ownedPortfolio(1n, 2n));
     renderPage();
 
-    const claimAll = await screen.findByRole("button", { name: "Claim all · 2 transactions" });
+    const claimAll = await screen.findByRole("button", { name: "Claim all · 3 transactions" });
     fireEvent.click(claimAll);
 
-    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(3));
     const calls = mocks.execute.mock.calls.map(([request]) => request as { data: `0x${string}` });
     const first = decodeFunctionData({ abi: genesisLaunchDistributorAbi, data: calls[0].data });
     const second = decodeFunctionData({ abi: genesisLaunchDistributorAbi, data: calls[1].data });
+    const third = decodeFunctionData({ abi: genesisLaunchDistributorAbi, data: calls[2].data });
 
     expect(first).toMatchObject({ functionName: "claimAllGenesisRewards" });
     expect(second).toMatchObject({ functionName: "claimAllGenesisRewards" });
+    expect(third).toEqual({
+      functionName: "claimAllGenesisTreasuryRewards",
+      args: [wallet],
+    });
     expect(first.args?.[0]).toHaveLength(64);
     expect(second.args?.[0]).toEqual([65n]);
     expect(first.args?.[1]).toBe(wallet);

--- a/test/components/standalone-genesis-claims.test.tsx
+++ b/test/components/standalone-genesis-claims.test.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@/test/render";
+import { decodeFunctionData, getAddress, zeroAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { genesisLaunchDistributorAbi } from "@statics-protocol/sdk";
+import { StandaloneGenesisPage } from "@/components/genesis/StandaloneGenesisPage";
+import type { DeploymentOption, LaunchDeployment } from "@/lib/deployments/types";
+import { DeploymentContext } from "@/providers/deployment-context";
+import { WalletContext, defaultWalletState } from "@/providers/wallet-context";
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  loadOwnedGenesis: vi.fn(),
+  readContract: vi.fn(),
+}));
+
+vi.mock("wagmi", () => ({ usePublicClient: () => ({ readContract: mocks.readContract }) }));
+vi.mock("@/lib/deployments/verify-launch", () => ({
+  verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
+  verifyLaunchDeploymentCached: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/protocol/transactions", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/protocol/transactions")>(
+    "@/lib/protocol/transactions"
+  );
+  return { ...actual, executeProtocolTransaction: mocks.execute };
+});
+vi.mock("@/lib/genesis/owned", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/genesis/owned")>("@/lib/genesis/owned");
+  return { ...actual, loadOwnedGenesis: mocks.loadOwnedGenesis };
+});
+
+const statics = getAddress("0x1111111111111111111111111111111111111111");
+const weth = getAddress("0x7777777777777777777777777777777777777777");
+const wallet = getAddress("0x2222222222222222222222222222222222222222");
+const descriptor = {
+  deploymentId: "launch-fixture",
+  label: "Statics Operators",
+  network: "Robinhood Chain",
+  chainId: 4_663,
+  stage: "launch",
+  capabilities: ["overview", "genesis-vault"],
+  available: true,
+} as const;
+const deployment = {
+  kind: "launch",
+  descriptor,
+  deploymentStartBlock: 1n,
+  protocolCommit: "fixture",
+  source: "development-fixture",
+  contracts: {
+    statics,
+    weth,
+    genesis: zeroAddress,
+    vault: zeroAddress,
+    activationRegistry: zeroAddress,
+    feeReceiver: zeroAddress,
+    launchDistributor: getAddress("0x3333333333333333333333333333333333333333"),
+    poolManager: zeroAddress,
+    stateView: zeroAddress,
+    quoter: zeroAddress,
+    universalRouter: zeroAddress,
+    permit2: zeroAddress,
+  },
+  runtimeCodeHashes: {},
+  market: {
+    poolId: `0x${"1".repeat(64)}`,
+    poolKey: {
+      currency0: statics,
+      currency1: weth,
+      fee: 10_000,
+      tickSpacing: 8,
+      hooks: zeroAddress,
+    },
+  },
+} as const satisfies LaunchDeployment;
+const option = {
+  networkId: "robinhood",
+  descriptor,
+  launch: deployment,
+  protocol: null,
+} satisfies DeploymentOption;
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DeploymentContext.Provider
+        value={{ active: option, options: [option], selectNetwork: vi.fn() }}
+      >
+        <WalletContext.Provider
+          value={{
+            ...defaultWalletState,
+            status: "ready",
+            authenticated: true,
+            address: wallet,
+            chainId: descriptor.chainId,
+            isTargetChain: true,
+          }}
+        >
+          <StandaloneGenesisPage deployment={deployment} />
+        </WalletContext.Provider>
+      </DeploymentContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  mocks.execute.mockReset().mockResolvedValue("0xabc");
+  mocks.readContract
+    .mockReset()
+    .mockImplementation(async ({ functionName }: { functionName: string }) => {
+      if (functionName === "vaultAccounting") {
+        return {
+          vaultPrice: 0n,
+          maximumSupply: 5_555n,
+          mintedSupply: 65n,
+          vaultInventory: 5_490n,
+          circulatingGenesis: 65n,
+          tokenBacking: 0n,
+          grossBacking: 0n,
+          outstandingGenesisCredit: 0n,
+          requiredBacking: 0n,
+          tokenCustody: 0n,
+          reserveETH: 0n,
+          nativeCustody: 0n,
+          genesisEpochEnd: 0n,
+          epochActive: true,
+          reserveBackingPerGenesis: 0n,
+        };
+      }
+      throw new Error(`Unexpected read ${functionName}`);
+    });
+  mocks.loadOwnedGenesis.mockResolvedValue({
+    items: Array.from({ length: 65 }, (_, index) => ({
+      id: BigInt(index + 1),
+      tier: 0,
+      multiplierBps: 10_000,
+      registered: true,
+      rewardWeight: 10_000n,
+      pendingStatics: 1n,
+      pendingWeth: 0n,
+      creditActive: false,
+      creditPrincipal: 0n,
+      creditMaturity: 0,
+    })),
+    tierCosts: [0n, 0n, 0n, 0n, 0n],
+    rewardShareBps: 5_000,
+    totalWeight: 650_000n,
+    ownerStatics: 0n,
+    ownerWeth: 0n,
+    indexedBlock: 1n,
+    chainHead: 1n,
+    stale: false,
+  });
+});
+
+describe("Standalone Genesis batch claims", () => {
+  it("splits 65 claimable Operators into two sequential transactions", async () => {
+    renderPage();
+
+    const claimAll = await screen.findByRole("button", { name: "Claim all · 2 transactions" });
+    fireEvent.click(claimAll);
+
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(2));
+    const calls = mocks.execute.mock.calls.map(([request]) => request as { data: `0x${string}` });
+    const first = decodeFunctionData({ abi: genesisLaunchDistributorAbi, data: calls[0].data });
+    const second = decodeFunctionData({ abi: genesisLaunchDistributorAbi, data: calls[1].data });
+
+    expect(first).toMatchObject({ functionName: "claimAllGenesisRewards" });
+    expect(second).toMatchObject({ functionName: "claimAllGenesisRewards" });
+    expect(first.args?.[0]).toHaveLength(64);
+    expect(second.args?.[0]).toEqual([65n]);
+    expect(first.args?.[1]).toBe(wallet);
+    expect(second.args?.[1]).toBe(wallet);
+  });
+
+  it("stops after a failed batch and surfaces the error", async () => {
+    mocks.execute
+      .mockResolvedValueOnce("0xabc")
+      .mockRejectedValueOnce(new Error("second batch failed"));
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Claim all · 2 transactions" }));
+
+    await waitFor(() => expect(mocks.execute).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("alert")).toHaveTextContent("second batch failed");
+  });
+});

--- a/test/components/standalone-genesis-claims.test.tsx
+++ b/test/components/standalone-genesis-claims.test.tsx
@@ -97,7 +97,7 @@ function ownedPortfolio(ownerStatics = 0n, ownerWeth = 0n) {
       creditMaturity: 0,
     })),
     tierCosts: [0n, 0n, 0n, 0n, 0n],
-    rewardShareBps: 5_000,
+    rewardShareBps: 4_000,
     totalWeight: 650_000n,
     ownerStatics,
     ownerWeth,

--- a/test/genesis/owned.test.ts
+++ b/test/genesis/owned.test.ts
@@ -37,7 +37,7 @@ function portfolio(
   return {
     items,
     tierCosts: [],
-    rewardShareBps: 5_000,
+    rewardShareBps: 4_000,
     totalWeight: items.reduce((total, entry) => total + entry.rewardWeight, 0n),
     ownerStatics,
     ownerWeth,

--- a/test/genesis/owned.test.ts
+++ b/test/genesis/owned.test.ts
@@ -71,6 +71,7 @@ describe("Genesis reward batching", () => {
     expect(summariseGenesisRewards(portfolio(sixtyFour)).claimTransactionCount).toBe(1);
     expect(summariseGenesisRewards(portfolio(sixtyFive)).claimTransactionCount).toBe(2);
     expect(summariseGenesisRewards(portfolio([], 1n)).claimTransactionCount).toBe(1);
+    expect(summariseGenesisRewards(portfolio(sixtyFive, 1n, 1n)).claimTransactionCount).toBe(3);
     expect(summariseGenesisRewards(portfolio([])).claimTransactionCount).toBe(0);
   });
 

--- a/test/genesis/owned.test.ts
+++ b/test/genesis/owned.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { decodeFunctionData, getAddress } from "viem";
+import {
+  buildClaimAllGenesisLaunchRewardsCall,
+  genesisLaunchDistributorAbi,
+} from "@statics-protocol/sdk";
+
+import {
+  GENESIS_CLAIM_BATCH_SIZE,
+  batchGenesisIds,
+  claimableGenesisIds,
+  summariseGenesisRewards,
+  type OwnedGenesis,
+  type OwnedGenesisPortfolio,
+} from "@/lib/genesis/owned";
+
+function item(id: bigint, pendingStatics = 0n, pendingWeth = 0n): OwnedGenesis {
+  return {
+    id,
+    tier: 0,
+    multiplierBps: 10_000,
+    registered: true,
+    rewardWeight: 10_000n,
+    pendingStatics,
+    pendingWeth,
+    creditActive: false,
+    creditPrincipal: 0n,
+    creditMaturity: 0,
+  };
+}
+
+function portfolio(
+  items: readonly OwnedGenesis[],
+  ownerStatics = 0n,
+  ownerWeth = 0n
+): OwnedGenesisPortfolio {
+  return {
+    items,
+    tierCosts: [],
+    rewardShareBps: 5_000,
+    totalWeight: items.reduce((total, entry) => total + entry.rewardWeight, 0n),
+    ownerStatics,
+    ownerWeth,
+    indexedBlock: 1n,
+    chainHead: 1n,
+    stale: false,
+  };
+}
+
+describe("Genesis reward batching", () => {
+  it("filters zero-reward NFTs and deduplicates IDs", () => {
+    expect(
+      claimableGenesisIds([item(4n), item(7n, 1n), item(7n, 2n, 3n), item(9n, 0n, 4n)])
+    ).toEqual([7n, 9n]);
+  });
+
+  it("splits IDs at the 64-NFT transaction boundary", () => {
+    const ids = Array.from({ length: GENESIS_CLAIM_BATCH_SIZE * 2 + 1 }, (_, index) =>
+      BigInt(index + 1)
+    );
+    const batches = batchGenesisIds(ids);
+
+    expect(batches.map((batch) => batch.length)).toEqual([64, 64, 1]);
+    expect(batches.flat()).toEqual(ids);
+  });
+
+  it("counts batch transactions, including owner-only rewards", () => {
+    const sixtyFour = Array.from({ length: 64 }, (_, index) => item(BigInt(index + 1), 1n));
+    const sixtyFive = [...sixtyFour, item(65n, 1n)];
+
+    expect(summariseGenesisRewards(portfolio(sixtyFour)).claimTransactionCount).toBe(1);
+    expect(summariseGenesisRewards(portfolio(sixtyFive)).claimTransactionCount).toBe(2);
+    expect(summariseGenesisRewards(portfolio([], 1n)).claimTransactionCount).toBe(1);
+    expect(summariseGenesisRewards(portfolio([])).claimTransactionCount).toBe(0);
+  });
+
+  it("encodes the launch distributor batch entry point", () => {
+    const receiver = getAddress("0x1111111111111111111111111111111111111111");
+    expect(
+      decodeFunctionData({
+        abi: genesisLaunchDistributorAbi,
+        data: buildClaimAllGenesisLaunchRewardsCall([41n, 42n], receiver),
+      })
+    ).toEqual({ functionName: "claimAllGenesisRewards", args: [[41n, 42n], receiver] });
+  });
+});

--- a/vendor/statics-sdk/dist/genesis-credit.d.ts
+++ b/vendor/statics-sdk/dist/genesis-credit.d.ts
@@ -16,6 +16,18 @@ export declare const staticsGenesisCreditAbi: readonly [{
     }];
     readonly outputs: readonly [];
 }, {
+    readonly name: "drawGenesisCredit";
+    readonly type: "function";
+    readonly stateMutability: "payable";
+    readonly inputs: readonly [{
+        readonly type: "uint256";
+        readonly name: "genesisId";
+    }, {
+        readonly type: "uint256";
+        readonly name: "amount";
+    }];
+    readonly outputs: readonly [];
+}, {
     readonly name: "extendGenesisCredit";
     readonly type: "function";
     readonly stateMutability: "payable";
@@ -31,6 +43,9 @@ export declare const staticsGenesisCreditAbi: readonly [{
     readonly inputs: readonly [{
         readonly type: "uint256";
         readonly name: "genesisId";
+    }, {
+        readonly type: "uint256";
+        readonly name: "amount";
     }];
     readonly outputs: readonly [];
 }, {
@@ -52,6 +67,17 @@ export declare const staticsGenesisCreditAbi: readonly [{
     }];
 }, {
     readonly name: "creditLimit";
+    readonly type: "function";
+    readonly stateMutability: "view";
+    readonly inputs: readonly [{
+        readonly type: "uint256";
+        readonly name: "genesisId";
+    }];
+    readonly outputs: readonly [{
+        readonly type: "uint256";
+    }];
+}, {
+    readonly name: "creditAvailable";
     readonly type: "function";
     readonly stateMutability: "view";
     readonly inputs: readonly [{
@@ -244,12 +270,28 @@ export declare const staticsGenesisCreditAbi: readonly [{
         readonly type: "uint16";
     }];
 }, {
-    readonly name: "creditOriginationsPaused";
+    readonly name: "creditIncreasesPaused";
     readonly type: "function";
     readonly stateMutability: "view";
     readonly inputs: readonly [];
     readonly outputs: readonly [{
         readonly type: "bool";
+    }];
+}, {
+    readonly name: "setCreditIncreasesPaused";
+    readonly type: "function";
+    readonly stateMutability: "nonpayable";
+    readonly inputs: readonly [{
+        readonly type: "bool";
+        readonly name: "paused";
+    }];
+    readonly outputs: readonly [];
+}, {
+    readonly name: "CreditIncreasesPausedSet";
+    readonly type: "event";
+    readonly inputs: readonly [{
+        readonly type: "bool";
+        readonly name: "paused";
     }];
 }, {
     readonly name: "GenesisCreditOpened";
@@ -294,6 +336,27 @@ export declare const staticsGenesisCreditAbi: readonly [{
         readonly name: "nativeFee";
     }];
 }, {
+    readonly name: "GenesisCreditDrawn";
+    readonly type: "event";
+    readonly inputs: readonly [{
+        readonly type: "uint256";
+        readonly name: "genesisId";
+        readonly indexed: true;
+    }, {
+        readonly type: "address";
+        readonly name: "owner";
+        readonly indexed: true;
+    }, {
+        readonly type: "uint256";
+        readonly name: "amount";
+    }, {
+        readonly type: "uint256";
+        readonly name: "newPrincipal";
+    }, {
+        readonly type: "uint256";
+        readonly name: "nativeFee";
+    }];
+}, {
     readonly name: "GenesisCreditRepaid";
     readonly type: "event";
     readonly inputs: readonly [{
@@ -310,7 +373,10 @@ export declare const staticsGenesisCreditAbi: readonly [{
         readonly indexed: true;
     }, {
         readonly type: "uint256";
-        readonly name: "principal";
+        readonly name: "amount";
+    }, {
+        readonly type: "uint256";
+        readonly name: "remainingPrincipal";
     }];
 }, {
     readonly name: "GenesisCreditRecovered";
@@ -346,7 +412,8 @@ export type GenesisCreditTransaction = Readonly<{
     value: bigint;
 }>;
 export declare function buildOpenGenesisCreditTransaction(genesisId: bigint, principal: bigint, nativeFee: bigint): GenesisCreditTransaction;
+export declare function buildDrawGenesisCreditTransaction(genesisId: bigint, amount: bigint, nativeFee: bigint): GenesisCreditTransaction;
 export declare function buildExtendGenesisCreditTransaction(genesisId: bigint, nativeFee: bigint): GenesisCreditTransaction;
-export declare function buildRepayGenesisCreditCall(genesisId: bigint): Hex;
+export declare function buildRepayGenesisCreditCall(genesisId: bigint, amount: bigint): Hex;
 export declare function buildRecoverGenesisCreditCall(genesisId: bigint): Hex;
 export type GenesisCreditContract = Address;

--- a/vendor/statics-sdk/dist/genesis-credit.js
+++ b/vendor/statics-sdk/dist/genesis-credit.js
@@ -5,11 +5,13 @@ export const GENESIS_CREDIT_TERM = 30n * 24n * 60n * 60n;
 export const GENESIS_CREDIT_RECOVERY_GRACE = 60n * 60n;
 export const staticsGenesisCreditAbi = parseAbi([
     "function openGenesisCredit(uint256 genesisId, uint256 principal) payable",
+    "function drawGenesisCredit(uint256 genesisId, uint256 amount) payable",
     "function extendGenesisCredit(uint256 genesisId) payable",
-    "function repayGenesisCredit(uint256 genesisId)",
+    "function repayGenesisCredit(uint256 genesisId, uint256 amount)",
     "function recoverGenesisCredit(uint256 genesisId)",
     "function epochActive() view returns (bool)",
     "function creditLimit(uint256 genesisId) view returns (uint256)",
+    "function creditAvailable(uint256 genesisId) view returns (uint256)",
     "function credit(uint256 genesisId) view returns ((address owner, uint256 principal, uint40 maturity, uint40 recoverableAt, bool active) state)",
     "function creditActive(uint256 genesisId) view returns (bool)",
     "function creditRecoverableAt(uint256 genesisId) view returns (uint40)",
@@ -22,10 +24,13 @@ export const staticsGenesisCreditAbi = parseAbi([
     "function recoveryCallerShareBps() view returns (uint16)",
     "function creditServiceReserveShareBps() view returns (uint16)",
     "function creditServiceTreasuryShareBps() view returns (uint16)",
-    "function creditOriginationsPaused() view returns (bool)",
+    "function creditIncreasesPaused() view returns (bool)",
+    "function setCreditIncreasesPaused(bool paused)",
+    "event CreditIncreasesPausedSet(bool paused)",
     "event GenesisCreditOpened(uint256 indexed genesisId, address indexed owner, uint256 principal, uint40 maturity, uint256 nativeFee)",
     "event GenesisCreditExtended(uint256 indexed genesisId, address indexed owner, uint40 previousMaturity, uint40 newMaturity, uint256 nativeFee)",
-    "event GenesisCreditRepaid(uint256 indexed genesisId, address indexed payer, address indexed owner, uint256 principal)",
+    "event GenesisCreditDrawn(uint256 indexed genesisId, address indexed owner, uint256 amount, uint256 newPrincipal, uint256 nativeFee)",
+    "event GenesisCreditRepaid(uint256 indexed genesisId, address indexed payer, address indexed owner, uint256 amount, uint256 remainingPrincipal)",
     "event GenesisCreditRecovered(uint256 indexed genesisId, address indexed formerOwner, address indexed caller, uint256 principal, uint256 unusedCredit, uint256 callerIncentive, uint256 genesisDistribution)",
 ]);
 export function buildOpenGenesisCreditTransaction(genesisId, principal, nativeFee) {
@@ -34,6 +39,16 @@ export function buildOpenGenesisCreditTransaction(genesisId, principal, nativeFe
             abi: staticsGenesisCreditAbi,
             functionName: "openGenesisCredit",
             args: [genesisId, principal],
+        }),
+        value: nativeFee,
+    };
+}
+export function buildDrawGenesisCreditTransaction(genesisId, amount, nativeFee) {
+    return {
+        data: encodeFunctionData({
+            abi: staticsGenesisCreditAbi,
+            functionName: "drawGenesisCredit",
+            args: [genesisId, amount],
         }),
         value: nativeFee,
     };
@@ -48,11 +63,11 @@ export function buildExtendGenesisCreditTransaction(genesisId, nativeFee) {
         value: nativeFee,
     };
 }
-export function buildRepayGenesisCreditCall(genesisId) {
+export function buildRepayGenesisCreditCall(genesisId, amount) {
     return encodeFunctionData({
         abi: staticsGenesisCreditAbi,
         functionName: "repayGenesisCredit",
-        args: [genesisId],
+        args: [genesisId, amount],
     });
 }
 export function buildRecoverGenesisCreditCall(genesisId) {

--- a/vendor/statics-sdk/dist/index.d.ts
+++ b/vendor/statics-sdk/dist/index.d.ts
@@ -1113,6 +1113,39 @@ export declare const genesisLaunchDistributorAbi: readonly [{
         readonly name: "amount";
     }];
 }, {
+    readonly name: "claimAllGenesisRewards";
+    readonly type: "function";
+    readonly stateMutability: "nonpayable";
+    readonly inputs: readonly [{
+        readonly type: "uint256[]";
+        readonly name: "genesisIds";
+    }, {
+        readonly type: "address";
+        readonly name: "receiver";
+    }];
+    readonly outputs: readonly [{
+        readonly type: "uint256";
+        readonly name: "staticsAmount";
+    }, {
+        readonly type: "uint256";
+        readonly name: "numeraireAmount";
+    }];
+}, {
+    readonly name: "claimAllGenesisTreasuryRewards";
+    readonly type: "function";
+    readonly stateMutability: "nonpayable";
+    readonly inputs: readonly [{
+        readonly type: "address";
+        readonly name: "receiver";
+    }];
+    readonly outputs: readonly [{
+        readonly type: "uint256";
+        readonly name: "staticsAmount";
+    }, {
+        readonly type: "uint256";
+        readonly name: "numeraireAmount";
+    }];
+}, {
     readonly name: "pendingGenesis";
     readonly type: "function";
     readonly stateMutability: "view";
@@ -11260,6 +11293,8 @@ export declare function buildActivateGenesisCall(genesisId: bigint, targetTier: 
 export declare function buildRegisterGenesisCall(genesisId: bigint): Hex;
 export declare function buildClaimGenesisLaunchRewardsCall(genesisId: bigint, asset: Address, receiver: Address): Hex;
 export declare function buildClaimOwnerGenesisLaunchRewardsCall(asset: Address, receiver: Address): Hex;
+export declare function buildClaimAllGenesisLaunchRewardsCall(genesisIds: readonly bigint[], receiver: Address): Hex;
+export declare function buildClaimAllGenesisLaunchTreasuryRewardsCall(receiver: Address): Hex;
 export declare function buildAccrueGenesisLaunchRewardsCall(): Hex;
 export declare function cumulativeGenesisActivationCost(tierCosts: readonly bigint[], currentTier: number, targetTier: number): bigint;
 export declare function buildCreateBasketTransaction(params: CreateBasketParams, pools: readonly PoolLaunchParams[], maxAmountsIn: readonly bigint[], launchDeadline: bigint, creationFee: bigint): PreparedTransaction;

--- a/vendor/statics-sdk/dist/index.js
+++ b/vendor/statics-sdk/dist/index.js
@@ -156,6 +156,8 @@ export const genesisLaunchDistributorAbi = parseAbi([
     "function accrue() returns (uint256 staticsAmount, uint256 numeraireAmount)",
     "function claimGenesis(uint256 genesisId, address asset, address receiver) returns (uint256 amount)",
     "function claimOwnerRewards(address asset, address receiver) returns (uint256 amount)",
+    "function claimAllGenesisRewards(uint256[] genesisIds, address receiver) returns (uint256 staticsAmount, uint256 numeraireAmount)",
+    "function claimAllGenesisTreasuryRewards(address receiver) returns (uint256 staticsAmount, uint256 numeraireAmount)",
     "function pendingGenesis(uint256 genesisId, address asset) view returns (uint256 amount)",
     "function registered(uint256 genesisId) view returns (bool)",
     "function effectiveWeight(uint256 genesisId) view returns (uint256)",
@@ -1296,6 +1298,20 @@ export function buildClaimOwnerGenesisLaunchRewardsCall(asset, receiver) {
         abi: genesisLaunchDistributorAbi,
         functionName: "claimOwnerRewards",
         args: [asset, receiver],
+    });
+}
+export function buildClaimAllGenesisLaunchRewardsCall(genesisIds, receiver) {
+    return encodeFunctionData({
+        abi: genesisLaunchDistributorAbi,
+        functionName: "claimAllGenesisRewards",
+        args: [genesisIds, receiver],
+    });
+}
+export function buildClaimAllGenesisLaunchTreasuryRewardsCall(receiver) {
+    return encodeFunctionData({
+        abi: genesisLaunchDistributorAbi,
+        functionName: "claimAllGenesisTreasuryRewards",
+        args: [receiver],
     });
 }
 export function buildAccrueGenesisLaunchRewardsCall() {

--- a/vendor/statics-sdk/provenance.json
+++ b/vendor/statics-sdk/provenance.json
@@ -1,9 +1,9 @@
 {
-  "protocolCommit": "92bb9bcb046c67d6b6a6f5762e013df8fb171c1b",
+  "protocolCommit": "730c613af14464965c2254f75f415b3c506bc8fc",
   "source": {
     "repository": "https://github.com/EqualFiLabs/statics-sdk",
     "path": ".",
-    "commit": "c6b7e4efed2a6997e5a1810c76e68f0371f5b5cc"
+    "commit": "fd3c4c0849afeb51e7cac0547cbd9d28676c0c74"
   },
   "sdkTreeState": "clean",
   "extensionSource": {
@@ -16,12 +16,12 @@
     "package.json": "b8204badc86e111eb0d4bf3545ee4f60b989784698d8a96136f5cde409375bdd"
   },
   "sourceChecksums": {
-    "src/index.ts": "31e6302955545a2d4a95cb2bfbb4e59564a9dded861b6414b90bf8dcc9aa7457",
+    "src/index.ts": "2a2bfd64b94a02f34e40ee88fb2abc766576bd6d0343c731270a360ad53e897d",
     "package.json": "047657d558934ac444d1d1d5b6e816593b9200cddb62e64703462033b54cb66e"
   },
   "checksums": {
-    "dist/index.js": "35454a2abb3afd2d446a21942586d480f379c5fddd0cd51f6fa7b67b63382c3d",
-    "dist/index.d.ts": "804ede2bdf40c831e072f0dba7ebc73ed40c9997e4d435155b52edae35664c0e",
+    "dist/index.js": "649132730b0769e7debdf7b25cb361c5e486eb7f10360e9ee7c9e73a5379ab55",
+    "dist/index.d.ts": "f72c1f2e40c1ab44b8e591cbda8f9c4ceb328d0227a55f0db68f992e6b0823b9",
     "dist/genesis-credit.js": "7a647a67b3d53515d567a329849e48ba4f969eb2afae38a462cd59ec05befaf2",
     "dist/genesis-credit.d.ts": "60da3633f77a7ee935f95efab04624126516cf4a2b2a82e9f38baee22f4ca138",
     "dist/generated/robinhoodChain.js": "69b5dbcb88d4f77e435c2ceaa7176ab51b727065dc12eb44200748922b48afec",

--- a/vendor/statics-sdk/provenance.json
+++ b/vendor/statics-sdk/provenance.json
@@ -9,10 +9,10 @@
   "extensionSource": {
     "repository": "https://github.com/EqualFiLabs/statics-sdk",
     "path": ".",
-    "commit": "e10f7306a27d100695571ae97d56a6e5c1a8b5d3"
+    "commit": "cf6166565a884c972f53ec1d07e2793472d5b831"
   },
   "extensionSourceChecksums": {
-    "src/genesis-credit.ts": "379a6892970444f8ea8d87f06a937b9a0e68d2b624ec8676d0af5248b4e4382e",
+    "src/genesis-credit.ts": "868718ea20417287dd9daf994e97f14ca9b9d32a9a10d795d3f9e65e32f860d2",
     "package.json": "b8204badc86e111eb0d4bf3545ee4f60b989784698d8a96136f5cde409375bdd"
   },
   "sourceChecksums": {
@@ -22,8 +22,8 @@
   "checksums": {
     "dist/index.js": "649132730b0769e7debdf7b25cb361c5e486eb7f10360e9ee7c9e73a5379ab55",
     "dist/index.d.ts": "f72c1f2e40c1ab44b8e591cbda8f9c4ceb328d0227a55f0db68f992e6b0823b9",
-    "dist/genesis-credit.js": "7a647a67b3d53515d567a329849e48ba4f969eb2afae38a462cd59ec05befaf2",
-    "dist/genesis-credit.d.ts": "60da3633f77a7ee935f95efab04624126516cf4a2b2a82e9f38baee22f4ca138",
+    "dist/genesis-credit.js": "9b9be92463d34e6f18354c96064ad2f43365078945a13e9df0df7c8dd852e42d",
+    "dist/genesis-credit.d.ts": "ffef22c37b79e975da48093ce8e572db6bcdd5d8f0b34617f4fbc6cfbd60a779",
     "dist/generated/robinhoodChain.js": "69b5dbcb88d4f77e435c2ceaa7176ab51b727065dc12eb44200748922b48afec",
     "dist/generated/robinhoodChain.d.ts": "f6a12b08c2b8cd85c769583f8ffcc632719c75d638803c17a83f51bcc2984337"
   }


### PR DESCRIPTION
## Summary
- Replace the launch My Operators claim-all loop with `claimAllGenesisRewards`.
- Bound calls to 64 claimable Operator IDs, deduplicate IDs, and submit larger claims sequentially.
- Submit the separate `claimAllGenesisTreasuryRewards` call for previous-owner rewards.
- Sync the vendored launch-distributor ABI/calldata builders and localize batch claim copy.

## Validation
- Full app suite: 596 tests passed across 109 files.
- Ponder suite: 17 tests passed across 3 files.
- `npm run lint`, `npm run lint:css`, `npm run format:check`, `npm run typecheck`.
- `npm --prefix ponder run typecheck`.
- `npm run build`.
- Foundry measurement: approximately 7.15m gas for 64 IDs, with approximately 100.2k gas per additional ID.
- Local Anvil launch fork: protocol `2fe8776`, Ponder ready, runtime code hashes verified, indexed fixture ID 1.

## Review remediation
- Copilot comments addressed in `2da92ec`: treasury claims are submitted after Operator batches, transaction counts include both paths, and mixed-case regression coverage was added.