### PR TITLE
Fix Genesis indexer event ordering

### DIFF
--- a/ponder/src/genesis.ts
+++ b/ponder/src/genesis.ts
@@ -1,4 +1,100 @@
+import { getAddress, zeroAddress, type Address } from "viem";
+
 const GENESIS_SUPPLY = 5_555n;
+
+export type GenesisNftRow = {
+  key: string;
+  deploymentId: string;
+  id: bigint;
+  owner: Address;
+  tier: number;
+  multiplierBps: number;
+  linkedPositionId: bigint;
+  registered: boolean;
+  effectiveWeight: bigint;
+  updatedAtBlock: bigint;
+};
+
+type GenesisNftUpsertMutation = {
+  type: "upsert";
+  row: GenesisNftRow;
+  update: Partial<GenesisNftRow>;
+};
+
+export type GenesisNftMutation = { type: "delete"; key: string } | GenesisNftUpsertMutation;
+
+const genesisKey = (deploymentId: string, genesisId: bigint) => `${deploymentId}:${genesisId}`;
+
+export function genesisTransferMutation(input: {
+  deploymentId: string;
+  genesisId: bigint;
+  to: Address;
+  vault?: Address;
+  blockNumber: bigint;
+}): GenesisNftMutation {
+  const key = genesisKey(input.deploymentId, input.genesisId);
+  if (
+    input.to === zeroAddress ||
+    (input.vault !== undefined && input.to.toLowerCase() === input.vault.toLowerCase())
+  ) {
+    return { type: "delete", key };
+  }
+
+  const owner = getAddress(input.to);
+  return {
+    type: "upsert",
+    row: {
+      key,
+      deploymentId: input.deploymentId,
+      id: input.genesisId,
+      owner,
+      tier: 0,
+      multiplierBps: 10_000,
+      linkedPositionId: 0n,
+      registered: false,
+      effectiveWeight: 0n,
+      updatedAtBlock: input.blockNumber,
+    },
+    update: {
+      owner,
+      tier: 0,
+      multiplierBps: 10_000,
+      linkedPositionId: 0n,
+      updatedAtBlock: input.blockNumber,
+    },
+  };
+}
+
+export function genesisWeightChangedMutation(input: {
+  deploymentId: string;
+  genesisId: bigint;
+  vault: Address;
+  newWeight: bigint;
+  blockNumber: bigint;
+}): GenesisNftUpsertMutation {
+  // StaticsGenesis notifies the activation registry before ERC-721 emits Transfer. A vault exit
+  // therefore changes distributor weight one log before the ownership row becomes circulating.
+  return {
+    type: "upsert",
+    row: {
+      key: genesisKey(input.deploymentId, input.genesisId),
+      deploymentId: input.deploymentId,
+      id: input.genesisId,
+      owner: getAddress(input.vault),
+      tier: 0,
+      multiplierBps: 10_000,
+      linkedPositionId: 0n,
+      registered: true,
+      effectiveWeight: input.newWeight,
+      updatedAtBlock: input.blockNumber,
+    },
+    update: {
+      registered: true,
+      effectiveWeight: input.newWeight,
+      updatedAtBlock: input.blockNumber,
+    },
+  };
+}
 
 export function nextAvailableGenesisId(circulatingIds: readonly bigint[]): bigint | null {
   const circulating = new Set(circulatingIds.map(String));

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -3,6 +3,7 @@ import { genesisActivationRegistryAbi, staticsAbi } from "@statics-protocol/sdk"
 import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
 import { getAddress, zeroAddress } from "viem";
 import { activeGenesisCreditMutation } from "./genesis-credit";
+import { genesisTransferMutation, genesisWeightChangedMutation } from "./genesis";
 
 import {
   activeGenesisCredit,
@@ -20,7 +21,8 @@ const entityKey = (id: bigint) => `${deploymentId}:${id}`;
 const eventKey = (transactionHash: string, logIndex: number) =>
   `${deploymentId}:${transactionHash}:${logIndex}`;
 const canonicalPoolId = process.env.PONDER_CANONICAL_POOL_ID?.trim().toLowerCase();
-const genesisVault = process.env.PONDER_GENESIS_VAULT_ADDRESS?.trim().toLowerCase();
+const genesisVaultValue = process.env.PONDER_GENESIS_VAULT_ADDRESS?.trim();
+const genesisVault = genesisVaultValue ? getAddress(genesisVaultValue) : undefined;
 
 ponder.on("Statics:LoanOriginated", async ({ event, context }) => {
   const maturity = BigInt(event.args.maturity);
@@ -149,32 +151,18 @@ ponder.on("PositionManager:Transfer", async ({ event, context }) => {
 });
 
 ponder.on("StaticsGenesis:Transfer", async ({ event, context }) => {
-  const key = entityKey(event.args.tokenId);
-  if (event.args.to === zeroAddress || event.args.to.toLowerCase() === genesisVault) {
-    await context.db.delete(genesisNft, { key });
+  const mutation = genesisTransferMutation({
+    deploymentId,
+    genesisId: event.args.tokenId,
+    to: event.args.to,
+    vault: genesisVault,
+    blockNumber: event.block.number,
+  });
+  if (mutation.type === "delete") {
+    await context.db.delete(genesisNft, { key: mutation.key });
     return;
   }
-  await context.db
-    .insert(genesisNft)
-    .values({
-      key,
-      deploymentId,
-      id: event.args.tokenId,
-      owner: getAddress(event.args.to),
-      tier: 0,
-      multiplierBps: 10_000,
-      linkedPositionId: 0n,
-      registered: false,
-      effectiveWeight: 0n,
-      updatedAtBlock: event.block.number,
-    })
-    .onConflictDoUpdate({
-      owner: getAddress(event.args.to),
-      tier: 0,
-      multiplierBps: 10_000,
-      linkedPositionId: 0n,
-      updatedAtBlock: event.block.number,
-    });
+  await context.db.insert(genesisNft).values(mutation.row).onConflictDoUpdate(mutation.update);
 });
 
 ponder.on("Statics:GenesisActivated", async ({ event, context }) => {
@@ -240,10 +228,16 @@ ponder.on("GenesisLaunchDistributor:GenesisRegistered", async ({ event, context 
 });
 
 ponder.on("GenesisLaunchDistributor:GenesisWeightChanged", async ({ event, context }) => {
-  await context.db.update(genesisNft, { key: entityKey(event.args.genesisId) }).set({
-    effectiveWeight: event.args.newWeight,
-    updatedAtBlock: event.block.number,
+  if (!genesisVault)
+    throw new Error("PONDER_GENESIS_VAULT_ADDRESS is required for Genesis weights.");
+  const mutation = genesisWeightChangedMutation({
+    deploymentId,
+    genesisId: event.args.genesisId,
+    vault: genesisVault,
+    newWeight: event.args.newWeight,
+    blockNumber: event.block.number,
   });
+  await context.db.insert(genesisNft).values(mutation.row).onConflictDoUpdate(mutation.update);
 });
 
 ponder.on("GenesisLaunchDistributor:GenesisRewardsClaimed", async ({ event, context }) => {

--- a/ponder/test/genesis.test.ts
+++ b/ponder/test/genesis.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { nextAvailableGenesisId } from "../src/genesis";
+import {
+  genesisTransferMutation,
+  genesisWeightChangedMutation,
+  nextAvailableGenesisId,
+  type GenesisNftMutation,
+  type GenesisNftRow,
+} from "../src/genesis";
 import { activeGenesisCreditMutation } from "../src/genesis-credit";
+
+function applyGenesisMutation(
+  current: GenesisNftRow | undefined,
+  mutation: GenesisNftMutation
+): GenesisNftRow | undefined {
+  if (mutation.type === "delete") return undefined;
+  return current ? { ...current, ...mutation.update } : mutation.row;
+}
 
 describe("nextAvailableGenesisId", () => {
   it("returns the first token still owned by the vault", () => {
@@ -15,6 +29,80 @@ describe("nextAvailableGenesisId", () => {
   it("returns null only when every Genesis NFT is circulating", () => {
     const circulating = Array.from({ length: 5_555 }, (_, index) => BigInt(index + 1));
     expect(nextAvailableGenesisId(circulating)).toBeNull();
+  });
+});
+
+describe("Genesis NFT event ordering", () => {
+  const deploymentId = "robinhood-genesis";
+  const vault = "0x8AAAF9a22f439589987B8f1e69d79ca4f648C297" as const;
+  const buyer = "0x1111111111111111111111111111111111111111" as const;
+
+  it("materializes weight before a vault-to-owner Transfer and preserves it", () => {
+    const blockNumber = 50_132_467n;
+    let row = applyGenesisMutation(
+      undefined,
+      genesisWeightChangedMutation({
+        deploymentId,
+        genesisId: 29n,
+        vault,
+        newWeight: 10_000n,
+        blockNumber,
+      })
+    );
+
+    expect(row).toMatchObject({
+      key: `${deploymentId}:29`,
+      owner: vault,
+      registered: true,
+      effectiveWeight: 10_000n,
+    });
+
+    row = applyGenesisMutation(
+      row,
+      genesisTransferMutation({
+        deploymentId,
+        genesisId: 29n,
+        to: buyer,
+        vault,
+        blockNumber,
+      })
+    );
+
+    expect(row).toEqual({
+      key: `${deploymentId}:29`,
+      deploymentId,
+      id: 29n,
+      owner: buyer,
+      tier: 0,
+      multiplierBps: 10_000,
+      linkedPositionId: 0n,
+      registered: true,
+      effectiveWeight: 10_000n,
+      updatedAtBlock: blockNumber,
+    });
+  });
+
+  it("removes circulating state when Genesis returns to the vault", () => {
+    const row = genesisWeightChangedMutation({
+      deploymentId,
+      genesisId: 29n,
+      vault,
+      newWeight: 10_000n,
+      blockNumber: 50_132_467n,
+    }).row;
+
+    expect(
+      applyGenesisMutation(
+        row,
+        genesisTransferMutation({
+          deploymentId,
+          genesisId: 29n,
+          to: vault,
+          vault,
+          blockNumber: 50_132_468n,
+        })
+      )
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- make Genesis weight changes upsert registered state when the distributor event precedes circulating ownership
- preserve effective weight when the following ERC-721 Transfer materializes the buyer's ownership row
- retain implicit vault inventory by deleting rows transferred back to the Genesis vault
- cover the production block ordering with a synthetic-address regression fixture

## Root cause

`StaticsGenesis` calls the activation registry before ERC-721 emits `Transfer`. For a vault exit, `GenesisWeightChanged` is therefore indexed one log before the ownership row exists. The strict update raised `RecordNotFoundError`, terminated Ponder, and left Nginx returning 502 for `/indexer/`.

## Validation

- `npm --prefix ponder test` (19 passed)
- `npm --prefix ponder run typecheck`
- focused Prettier check
- committed diff check

Staging replay through the failing production block is the deployment gate and will be recorded before merge.
