### PR TITLE
fix(navigation): link docs and developer resources

### DIFF
--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -56,8 +56,18 @@ export const primaryNavigation: readonly SiteNavigationItem[] = [
   { label: "Baskets", messageKey: "baskets", kind: "anchor", href: "#baskets" },
   { label: "Dollar", messageKey: "dollar", kind: "anchor", href: "#dollar" },
   { label: "Liquidity", messageKey: "liquidity", kind: "anchor", href: "#liquidity" },
-  { label: "Docs", messageKey: "docs", kind: "placeholder" },
-  { label: "Dev", messageKey: "dev", kind: "placeholder" },
+  {
+    label: "Docs",
+    messageKey: "docs",
+    kind: "route",
+    href: "https://docs.staticsprotocol.com",
+  },
+  {
+    label: "Dev",
+    messageKey: "dev",
+    kind: "route",
+    href: "https://github.com/EqualFiLabs/statics",
+  },
 ] as const;
 
 export const protocolStatus = {

--- a/test/components/landing-page.test.tsx
+++ b/test/components/landing-page.test.tsx
@@ -114,15 +114,21 @@ describe("landing page", () => {
     expect(page).not.toMatch(/timelocked/i);
   });
 
-  it("routes launch controls to the app and keeps future destinations visible but inert", async () => {
+  it("routes launch controls, docs, and developer navigation", async () => {
     await renderLanding();
 
     const launchLinks = screen.getAllByRole("link", { name: /launch app/i });
     expect(launchLinks).toHaveLength(2);
     for (const link of launchLinks) expect(link).toHaveAttribute("href", "/app");
 
-    expect(screen.getAllByText("Docs").length).toBeGreaterThan(0);
-    expect(screen.queryByRole("link", { name: "Docs" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://docs.staticsprotocol.com"
+    );
+    expect(screen.getByRole("link", { name: "Dev" })).toHaveAttribute(
+      "href",
+      "https://github.com/EqualFiLabs/statics"
+    );
     expect(screen.queryByRole("link", { name: "GitHub" })).not.toBeInTheDocument();
     expect(screen.getByText("GitHub")).toHaveAttribute("aria-disabled", "true");
   });


### PR DESCRIPTION
## Summary

- link the Docs navbar item to https://docs.staticsprotocol.com
- link the Dev navbar item to https://github.com/EqualFiLabs/statics
- retain the current master environment and Genesis deployment-test configuration

This replaces the remaining relevant navigation change from #36; its deployment changes are already superseded on master.

## Validation

- `npm test -- test/components/landing-page.test.tsx`
- `npx eslint lib/site-config.ts test/components/landing-page.test.tsx`
- `npx prettier --check lib/site-config.ts test/components/landing-page.test.tsx`
- `git diff --check origin/master..HEAD`