### PR TITLE
perf: reduce Robinhood RPC consumption

### DIFF
--- a/app/api/deployments/launch-verification/route.ts
+++ b/app/api/deployments/launch-verification/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+
+import { deploymentRegistry } from "@/lib/deployments/registry";
+import { verifyLaunchDeploymentOnServer } from "@/lib/server/launch-verification";
+
+export const runtime = "nodejs";
+
+type VerificationRequest = Readonly<{
+  chainId?: unknown;
+  deploymentId?: unknown;
+}>;
+
+function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  const host = request.headers.get("host");
+  if (!origin || !host) return true;
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (!sameOrigin(request)) {
+    return NextResponse.json(
+      { error: "Cross-origin deployment verification is not allowed." },
+      { status: 403 }
+    );
+  }
+
+  let payload: VerificationRequest;
+  try {
+    payload = (await request.json()) as VerificationRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid verification request." }, { status: 400 });
+  }
+  if (!Number.isSafeInteger(payload.chainId) || typeof payload.deploymentId !== "string") {
+    return NextResponse.json({ error: "Invalid verification request." }, { status: 400 });
+  }
+
+  const deployment = deploymentRegistry()
+    .map((option) => option.launch)
+    .find(
+      (launch) =>
+        launch?.descriptor.deploymentId === payload.deploymentId &&
+        launch?.descriptor.chainId === payload.chainId
+    );
+  if (!deployment || deployment.source !== "checked-in-manifest") {
+    return NextResponse.json({ error: "Unknown launch deployment." }, { status: 404 });
+  }
+
+  const verification = verifyLaunchDeploymentOnServer(deployment);
+  try {
+    await verification.verification;
+    return NextResponse.json(
+      {
+        chainId: deployment.descriptor.chainId,
+        deploymentId: deployment.descriptor.deploymentId,
+        verified: true,
+      },
+      {
+        headers: {
+          "cache-control": "no-store",
+          "x-statics-verification-cache": verification.status,
+        },
+      }
+    );
+  } catch (error) {
+    console.warn("Launch deployment verification failed", {
+      chainId: deployment.descriptor.chainId,
+      deploymentId: deployment.descriptor.deploymentId,
+      error: error instanceof Error ? error.message : "Unknown verification failure",
+    });
+    return NextResponse.json(
+      { error: "Launch deployment verification failed." },
+      {
+        status: 502,
+        headers: {
+          "cache-control": "no-store",
+          "x-statics-verification-cache": verification.status,
+        },
+      }
+    );
+  }
+}

--- a/app/api/deployments/launch-verification/route.ts
+++ b/app/api/deployments/launch-verification/route.ts
@@ -13,7 +13,7 @@ type VerificationRequest = Readonly<{
 function sameOrigin(request: Request): boolean {
   const origin = request.headers.get("origin");
   const host = request.headers.get("host");
-  if (!origin || !host) return true;
+  if (!origin || !host) return false;
   try {
     return new URL(origin).host === host;
   } catch {

--- a/components/genesis/GenesisCreditPanel.tsx
+++ b/components/genesis/GenesisCreditPanel.tsx
@@ -19,10 +19,8 @@ import type { LaunchDeployment } from "@/lib/deployments/types";
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
-import {
-  verifyLaunchDeployment,
-  verifyLaunchDeploymentCached,
-} from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
 import { useWalletState } from "@/providers/wallet-context";
 
 /** StaticsGenesisVault.RECOVERY_GRACE. */
@@ -214,7 +212,7 @@ export function GenesisCreditPanel({
     enabled: Boolean(publicClient && wallet),
     queryFn: async () => {
       if (!publicClient || !wallet) throw new Error(t("connect"));
-      await verifyLaunchDeploymentCached(publicClient, deployment);
+      await verifyLaunchDeploymentForRead(publicClient, deployment);
       const [vault, creditIncreasesPaused, credit, limit] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,

--- a/components/genesis/GenesisRecoveriesPage.tsx
+++ b/components/genesis/GenesisRecoveriesPage.tsx
@@ -12,10 +12,8 @@ import {
 import { EmptyState, UnconfiguredSurface } from "@/components/common/EmptyState";
 import { AddressDisplay } from "@/components/protocol/AddressDisplay";
 import type { LaunchDeployment } from "@/lib/deployments/types";
-import {
-  verifyLaunchDeployment,
-  verifyLaunchDeploymentCached,
-} from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import { loadRecoverableGenesisCredits } from "@/lib/indexer/statics";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
@@ -126,7 +124,7 @@ function LaunchGenesisRecoveries({ deployment }: { deployment: LaunchDeployment 
     enabled: Boolean(publicClient && epoch.data === false),
     queryFn: async (): Promise<readonly RecoveryCredit[]> => {
       if (!publicClient) return [];
-      await verifyLaunchDeploymentCached(publicClient, deployment);
+      await verifyLaunchDeploymentForRead(publicClient, deployment);
       const block = await publicClient.getBlock({ blockTag: "latest" });
       let indexed: readonly { genesisId: bigint }[];
       try {

--- a/components/genesis/GenesisVaultSwapPanel.tsx
+++ b/components/genesis/GenesisVaultSwapPanel.tsx
@@ -26,10 +26,8 @@ import {
 import { MAX_ERC20_ALLOWANCE } from "@/lib/protocol/approvals";
 import { executeProtocolTransaction } from "@/lib/protocol/transactions";
 import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
-import {
-  verifyLaunchDeployment,
-  verifyLaunchDeploymentCached,
-} from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
 import { useWalletState } from "@/providers/wallet-context";
 
 type VaultDirection = "acquire" | "redeem";
@@ -86,7 +84,7 @@ export function GenesisVaultSwapPanel({ deployment }: { deployment: LaunchDeploy
     retry: false,
     queryFn: async () => {
       if (!publicClient) throw new Error("Robinhood RPC is unavailable.");
-      await verifyLaunchDeploymentCached(publicClient, deployment);
+      await verifyLaunchDeploymentForRead(publicClient, deployment);
       return true;
     },
   });

--- a/components/overview/DeploymentOverview.tsx
+++ b/components/overview/DeploymentOverview.tsx
@@ -14,7 +14,7 @@ import { DollarOverview } from "@/components/dollar/DollarPage";
 import { EpochBanner, type EpochQuotes } from "@/components/overview/EpochBanner";
 import { VaultSolvency } from "@/components/overview/VaultSolvency";
 import type { LaunchDeployment } from "@/lib/deployments/types";
-import { verifyLaunchDeploymentCached } from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import { genesisAcquisitionCost, genesisBackingInNumeraire } from "@/lib/genesis/market-value";
 import {
@@ -94,7 +94,7 @@ function LaunchOverview({ deployment }: { deployment: LaunchDeployment }) {
     enabled: Boolean(publicClient),
     queryFn: async () => {
       if (!publicClient) throw new Error("The deployment RPC is unavailable.");
-      await verifyLaunchDeploymentCached(publicClient, deployment);
+      await verifyLaunchDeploymentForRead(publicClient, deployment);
       const [vault, purchase, redemption, slot0, liquidity] = await Promise.all([
         publicClient.readContract({
           address: deployment.contracts.vault,

--- a/lib/deployments/verify-launch-read.ts
+++ b/lib/deployments/verify-launch-read.ts
@@ -1,0 +1,40 @@
+import type { PublicClient } from "viem";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { verifyLaunchDeploymentCached } from "@/lib/deployments/verify-launch";
+
+type VerificationResponse = Readonly<{
+  verified?: boolean;
+  error?: string;
+}>;
+
+/**
+ * Verify immutable launch configuration for display-only reads.
+ *
+ * Checked-in deployments are verified once by the application server so a
+ * fresh browser session does not repeat the same runtime and binding calls.
+ * Local development fixtures stay on the caller's configured Anvil client.
+ * Transaction paths must keep calling verifyLaunchDeployment directly.
+ */
+export async function verifyLaunchDeploymentForRead(
+  publicClient: PublicClient,
+  deployment: LaunchDeployment
+): Promise<void> {
+  if (deployment.source === "development-fixture") {
+    await verifyLaunchDeploymentCached(publicClient, deployment);
+    return;
+  }
+
+  const response = await fetch("/api/deployments/launch-verification", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      chainId: deployment.descriptor.chainId,
+      deploymentId: deployment.descriptor.deploymentId,
+    }),
+  });
+  const payload = (await response.json().catch(() => ({}))) as VerificationResponse;
+  if (!response.ok || payload.verified !== true) {
+    throw new Error(payload.error ?? "Launch deployment verification failed.");
+  }
+}

--- a/lib/genesis/owned.ts
+++ b/lib/genesis/owned.ts
@@ -3,7 +3,7 @@ import { genesisActivationRegistryAbi, genesisLaunchDistributorAbi } from "@stat
 import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
 
 import type { LaunchDeployment } from "@/lib/deployments/types";
-import { verifyLaunchDeploymentCached } from "@/lib/deployments/verify-launch";
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
 import { oneIndexedGenesisTierCosts } from "@/lib/genesis/activation-costs";
 import { discoverWalletGenesisSnapshot } from "@/lib/genesis/discovery";
 
@@ -88,7 +88,7 @@ export async function loadOwnedGenesis(
   deployment: LaunchDeployment,
   wallet: `0x${string}`
 ): Promise<OwnedGenesisPortfolio> {
-  await verifyLaunchDeploymentCached(publicClient, deployment);
+  await verifyLaunchDeploymentForRead(publicClient, deployment);
   const [discovery, tierCosts, rewardShareBps, totalWeight, ownerStatics, ownerWeth] =
     await Promise.all([
       discoverWalletGenesisSnapshot(publicClient, deployment, wallet),

--- a/lib/server/launch-verification.ts
+++ b/lib/server/launch-verification.ts
@@ -1,0 +1,48 @@
+import { createPublicClient, http } from "viem";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { verifyLaunchDeployment } from "@/lib/deployments/verify-launch";
+import { robinhoodRpcUrl } from "@/lib/server/robinhood-rpc";
+
+export type LaunchVerificationCacheStatus = "hit" | "miss";
+
+const verificationCache = new Map<string, Promise<void>>();
+
+function cacheKey(deployment: LaunchDeployment): string {
+  return [
+    deployment.descriptor.deploymentId,
+    deployment.descriptor.chainId,
+    deployment.protocolCommit,
+    ...Object.entries(deployment.runtimeCodeHashes)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, hash]) => `${name}:${hash}`),
+  ].join(":");
+}
+
+export function verifyLaunchDeploymentOnServer(
+  deployment: LaunchDeployment
+): Readonly<{ status: LaunchVerificationCacheStatus; verification: Promise<void> }> {
+  const key = cacheKey(deployment);
+  const cached = verificationCache.get(key);
+  if (cached) return { status: "hit", verification: cached };
+
+  const verification = (async () => {
+    const publicClient = createPublicClient({
+      transport: http(robinhoodRpcUrl(deployment.descriptor.chainId)),
+    });
+    const chainId = await publicClient.getChainId();
+    if (chainId !== deployment.descriptor.chainId) {
+      throw new Error("The RPC chain does not match the selected Statics deployment.");
+    }
+    await verifyLaunchDeployment(publicClient, deployment);
+  })().catch((error) => {
+    verificationCache.delete(key);
+    throw error;
+  });
+  verificationCache.set(key, verification);
+  return { status: "miss", verification };
+}
+
+export function resetLaunchVerificationCacheForTests(): void {
+  verificationCache.clear();
+}

--- a/lib/server/launch-verification.ts
+++ b/lib/server/launch-verification.ts
@@ -13,9 +13,12 @@ function cacheKey(deployment: LaunchDeployment): string {
     deployment.descriptor.deploymentId,
     deployment.descriptor.chainId,
     deployment.protocolCommit,
+    ...Object.entries(deployment.contracts)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, address]) => `${name}:${address.toLowerCase()}`),
     ...Object.entries(deployment.runtimeCodeHashes)
       .sort(([left], [right]) => left.localeCompare(right))
-      .map(([name, hash]) => `${name}:${hash}`),
+      .flatMap(([name, hash]) => (hash ? [`${name}:${hash.toLowerCase()}`] : [])),
   ].join(":");
 }
 

--- a/ponder/README.md
+++ b/ponder/README.md
@@ -8,6 +8,11 @@ This Ponder service indexes discovery data that the UI cannot enumerate cheaply:
 - standalone launch fees harvested into the permanent fee receiver; and
 - canonical STATICS/WETH swap history from the selected PoolManager and PoolId.
 
+The PoolManager source requires `PONDER_CANONICAL_POOL_ID` and filters the indexed `id` topic at
+the RPC boundary. Never run the source without this filter: Robinhood Chain produces many unrelated
+PoolManager swaps per block. Full-protocol Statics and PositionManager sources are omitted entirely
+when their addresses are unset.
+
 Run a separate process and database schema for each network. Every process uses the same
 config, schema, handlers, and API; `PONDER_DEPLOYMENT_ID`, `PONDER_CHAIN_ID`, addresses, start
 blocks, RPC, and `DATABASE_SCHEMA` provide isolation. Numeric token IDs are never primary keys by

--- a/ponder/ponder.config.ts
+++ b/ponder/ponder.config.ts
@@ -1,5 +1,5 @@
 import { createConfig } from "ponder";
-import { getAddress, parseAbi, zeroAddress } from "viem";
+import { getAddress, parseAbi, zeroAddress, zeroHash } from "viem";
 
 import {
   genesisActivationRegistryAbi,
@@ -11,6 +11,8 @@ import {
 } from "@statics-protocol/sdk";
 
 import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
+
+import { configuredAddress, configuredCanonicalPool } from "./src/source-config";
 
 function required(name: string): string {
   const value = process.env[name]?.trim();
@@ -39,12 +41,23 @@ const deploymentStartBlock = optionalStartBlock("PONDER_DEPLOYMENT_START_BLOCK",
 const poolManagerEventsAbi = parseAbi([
   "event Swap(bytes32 indexed id,address indexed sender,int128 amount0,int128 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint24 fee)",
 ]);
+const staticsAddress = configuredAddress("PONDER_STATICS_DIAMOND_ADDRESS");
+const positionManagerAddress = configuredAddress("PONDER_POSITION_MANAGER_ADDRESS");
+const poolManagerAddress = configuredAddress("PONDER_POOL_MANAGER_ADDRESS");
+const canonicalPoolId = configuredCanonicalPool(poolManagerAddress);
+
+function activeContracts<T extends Record<string, unknown>>(contracts: T): T {
+  if (!staticsAddress) delete contracts.Statics;
+  if (!positionManagerAddress) delete contracts.PositionManager;
+  if (!poolManagerAddress) delete contracts.PoolManager;
+  return contracts;
+}
 
 /**
  * One network per process. Run separate mainnet, testnet, or local-fork
  * instances with different env files; the schema and handlers stay identical.
- * Contracts outside the selected deployment are the zero address and produce
- * no events, avoiding a second code path or cross-chain primary-key collision.
+ * Full-protocol sources are omitted when their addresses are not configured,
+ * avoiding unnecessary filters while preserving one schema and handler set.
  */
 export default createConfig({
   ...(process.env.PONDER_DATABASE_DIRECTORY?.trim()
@@ -61,17 +74,17 @@ export default createConfig({
       rpc: required(`PONDER_RPC_URL_${chainId}`),
     },
   },
-  contracts: {
+  contracts: activeContracts({
     Statics: {
       chain: "active",
       abi: staticsAbi,
-      address: optionalAddress("PONDER_STATICS_DIAMOND_ADDRESS"),
+      address: staticsAddress ?? zeroAddress,
       startBlock: optionalStartBlock("PONDER_STATICS_START_BLOCK", deploymentStartBlock),
     },
     PositionManager: {
       chain: "active",
       abi: v4PositionManagerReadAbi,
-      address: optionalAddress("PONDER_POSITION_MANAGER_ADDRESS"),
+      address: positionManagerAddress ?? zeroAddress,
       startBlock: optionalStartBlock("PONDER_POSITION_MANAGER_START_BLOCK", deploymentStartBlock),
     },
     StaticsGenesis: {
@@ -113,8 +126,9 @@ export default createConfig({
     PoolManager: {
       chain: "active",
       abi: poolManagerEventsAbi,
-      address: optionalAddress("PONDER_POOL_MANAGER_ADDRESS"),
+      address: poolManagerAddress ?? zeroAddress,
       startBlock: optionalStartBlock("PONDER_POOL_MANAGER_START_BLOCK", deploymentStartBlock),
+      filter: { event: "Swap", args: { id: canonicalPoolId ?? zeroHash } },
     },
-  },
+  } as const),
 });

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -4,6 +4,7 @@ import { staticsGenesisCreditAbi } from "@statics-protocol/sdk/genesis-credit";
 import { getAddress, zeroAddress } from "viem";
 import { activeGenesisCreditMutation } from "./genesis-credit";
 import { genesisTransferMutation, genesisWeightChangedMutation } from "./genesis";
+import { configuredAddress } from "./source-config";
 
 import {
   activeGenesisCredit,
@@ -20,11 +21,20 @@ if (!deploymentId) throw new Error("PONDER_DEPLOYMENT_ID is required.");
 const entityKey = (id: bigint) => `${deploymentId}:${id}`;
 const eventKey = (transactionHash: string, logIndex: number) =>
   `${deploymentId}:${transactionHash}:${logIndex}`;
-const canonicalPoolId = process.env.PONDER_CANONICAL_POOL_ID?.trim().toLowerCase();
 const genesisVaultValue = process.env.PONDER_GENESIS_VAULT_ADDRESS?.trim();
 const genesisVault = genesisVaultValue ? getAddress(genesisVaultValue) : undefined;
 
-ponder.on("Statics:LoanOriginated", async ({ event, context }) => {
+function sourceHandler(enabled: boolean): typeof ponder.on {
+  return enabled ? (ponder.on.bind(ponder) as typeof ponder.on) : () => undefined;
+}
+
+const onStatics = sourceHandler(Boolean(configuredAddress("PONDER_STATICS_DIAMOND_ADDRESS")));
+const onPositionManager = sourceHandler(
+  Boolean(configuredAddress("PONDER_POSITION_MANAGER_ADDRESS"))
+);
+const onPoolManager = sourceHandler(Boolean(configuredAddress("PONDER_POOL_MANAGER_ADDRESS")));
+
+onStatics("Statics:LoanOriginated", async ({ event, context }) => {
   const maturity = BigInt(event.args.maturity);
   const recoveryGracePeriod = await context.client.readContract({
     address: event.log.address,
@@ -44,7 +54,7 @@ ponder.on("Statics:LoanOriginated", async ({ event, context }) => {
   });
 });
 
-ponder.on("Statics:LoanExtended", async ({ event, context }) => {
+onStatics("Statics:LoanExtended", async ({ event, context }) => {
   const maturity = BigInt(event.args.maturity);
   const recoveryGracePeriod = await context.client.readContract({
     address: event.log.address,
@@ -59,11 +69,11 @@ ponder.on("Statics:LoanExtended", async ({ event, context }) => {
   });
 });
 
-ponder.on("Statics:LoanRepaid", async ({ event, context }) => {
+onStatics("Statics:LoanRepaid", async ({ event, context }) => {
   await context.db.delete(activeLoan, { key: entityKey(event.args.loanId) });
 });
 
-ponder.on("Statics:LoanRecovered", async ({ event, context }) => {
+onStatics("Statics:LoanRecovered", async ({ event, context }) => {
   await context.db.delete(activeLoan, { key: entityKey(event.args.loanId) });
 });
 
@@ -129,7 +139,7 @@ ponder.on("GenesisVault:GenesisCreditRecovered", async ({ event, context }) => {
     await context.db.delete(activeGenesisCredit, { key: mutation.key });
 });
 
-ponder.on("PositionManager:Transfer", async ({ event, context }) => {
+onPositionManager("PositionManager:Transfer", async ({ event, context }) => {
   const key = entityKey(event.args.tokenId);
   if (event.args.to === zeroAddress) {
     await context.db.delete(v4Position, { key });
@@ -165,7 +175,7 @@ ponder.on("StaticsGenesis:Transfer", async ({ event, context }) => {
   await context.db.insert(genesisNft).values(mutation.row).onConflictDoUpdate(mutation.update);
 });
 
-ponder.on("Statics:GenesisActivated", async ({ event, context }) => {
+onStatics("Statics:GenesisActivated", async ({ event, context }) => {
   await context.db.update(genesisNft, { key: entityKey(event.args.genesisId) }).set({
     tier: Number(event.args.newTier),
     multiplierBps: Number(event.args.multiplierBps),
@@ -173,21 +183,21 @@ ponder.on("Statics:GenesisActivated", async ({ event, context }) => {
   });
 });
 
-ponder.on("Statics:GenesisLinked", async ({ event, context }) => {
+onStatics("Statics:GenesisLinked", async ({ event, context }) => {
   await context.db.update(genesisNft, { key: entityKey(event.args.genesisId) }).set({
     linkedPositionId: event.args.positionId,
     updatedAtBlock: event.block.number,
   });
 });
 
-ponder.on("Statics:GenesisUnlinked", async ({ event, context }) => {
+onStatics("Statics:GenesisUnlinked", async ({ event, context }) => {
   await context.db.update(genesisNft, { key: entityKey(event.args.genesisId) }).set({
     linkedPositionId: 0n,
     updatedAtBlock: event.block.number,
   });
 });
 
-ponder.on("Statics:GenesisActivationReset", async ({ event, context }) => {
+onStatics("Statics:GenesisActivationReset", async ({ event, context }) => {
   await context.db.update(genesisNft, { key: entityKey(event.args.genesisId) }).set({
     tier: 0,
     multiplierBps: 10_000,
@@ -278,8 +288,7 @@ ponder.on("StaticsFeeReceiver:FeesHarvested", async ({ event, context }) => {
   });
 });
 
-ponder.on("PoolManager:Swap", async ({ event, context }) => {
-  if (!canonicalPoolId || event.args.id.toLowerCase() !== canonicalPoolId) return;
+onPoolManager("PoolManager:Swap", async ({ event, context }) => {
   await context.db.insert(marketSwap).values({
     key: eventKey(event.transaction.hash, event.log.logIndex),
     deploymentId,

--- a/ponder/src/source-config.ts
+++ b/ponder/src/source-config.ts
@@ -1,0 +1,30 @@
+import { getAddress, isHex, size, zeroAddress, type Address, type Hex } from "viem";
+
+type Environment = Record<string, string | undefined>;
+
+export function configuredAddress(
+  name: string,
+  environment: Environment = process.env
+): Address | undefined {
+  const value = environment[name]?.trim();
+  if (!value) return undefined;
+  const address = getAddress(value);
+  return address === zeroAddress ? undefined : address;
+}
+
+export function configuredCanonicalPool(
+  poolManager: Address | undefined,
+  environment: Environment = process.env
+): Hex | undefined {
+  const value = environment.PONDER_CANONICAL_POOL_ID?.trim();
+  if (!poolManager && !value) return undefined;
+  if (!poolManager || !value) {
+    throw new Error(
+      "PONDER_POOL_MANAGER_ADDRESS and PONDER_CANONICAL_POOL_ID must be configured together."
+    );
+  }
+  if (!isHex(value, { strict: true }) || size(value) !== 32) {
+    throw new Error("PONDER_CANONICAL_POOL_ID must be a 32-byte hex value.");
+  }
+  return value;
+}

--- a/ponder/test/source-config.test.ts
+++ b/ponder/test/source-config.test.ts
@@ -1,0 +1,36 @@
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { configuredAddress, configuredCanonicalPool } from "../src/source-config";
+
+const poolManager = getAddress("0x1111111111111111111111111111111111111111");
+const poolId = `0x${"12".repeat(32)}` as const;
+
+describe("Ponder source configuration", () => {
+  it("omits empty and zero-address sources", () => {
+    expect(configuredAddress("SOURCE", {})).toBeUndefined();
+    expect(
+      configuredAddress("SOURCE", { SOURCE: "0x0000000000000000000000000000000000000000" })
+    ).toBeUndefined();
+  });
+
+  it("normalizes configured source addresses", () => {
+    expect(
+      configuredAddress("SOURCE", { SOURCE: "0x1111111111111111111111111111111111111111" })
+    ).toBe(poolManager);
+  });
+
+  it("requires PoolManager and canonical PoolId together", () => {
+    expect(() => configuredCanonicalPool(poolManager, {})).toThrow("must be configured together");
+    expect(() => configuredCanonicalPool(undefined, { PONDER_CANONICAL_POOL_ID: poolId })).toThrow(
+      "must be configured together"
+    );
+  });
+
+  it("accepts only a 32-byte canonical PoolId", () => {
+    expect(configuredCanonicalPool(poolManager, { PONDER_CANONICAL_POOL_ID: poolId })).toBe(poolId);
+    expect(() =>
+      configuredCanonicalPool(poolManager, { PONDER_CANONICAL_POOL_ID: "0x1234" })
+    ).toThrow("32-byte hex value");
+  });
+});

--- a/test/api/launch-verification-route.test.ts
+++ b/test/api/launch-verification-route.test.ts
@@ -1,0 +1,97 @@
+import { getAddress, zeroAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DeploymentOption, LaunchDeployment } from "@/lib/deployments/types";
+
+const mocks = vi.hoisted(() => ({
+  registry: vi.fn(),
+  verify: vi.fn(),
+}));
+
+vi.mock("@/lib/deployments/registry", () => ({ deploymentRegistry: mocks.registry }));
+vi.mock("@/lib/server/launch-verification", () => ({
+  verifyLaunchDeploymentOnServer: mocks.verify,
+}));
+
+import { POST } from "@/app/api/deployments/launch-verification/route";
+
+const address = getAddress("0x1111111111111111111111111111111111111111");
+const deployment = {
+  kind: "launch",
+  descriptor: {
+    deploymentId: "robinhood-genesis",
+    label: "Genesis",
+    network: "Robinhood Chain",
+    chainId: 4_663,
+    stage: "launch",
+    capabilities: [],
+    available: true,
+  },
+  deploymentStartBlock: 1n,
+  protocolCommit: "commit",
+  source: "checked-in-manifest",
+  contracts: {
+    statics: address,
+    genesis: address,
+    vault: address,
+    activationRegistry: address,
+    feeReceiver: address,
+    launchDistributor: address,
+    weth: address,
+    poolManager: address,
+    stateView: address,
+    quoter: address,
+    universalRouter: address,
+    permit2: address,
+  },
+  runtimeCodeHashes: {},
+  market: {
+    poolId: `0x${"12".repeat(32)}`,
+    poolKey: { currency0: address, currency1: address, fee: 0, tickSpacing: 1, hooks: zeroAddress },
+  },
+} as const satisfies LaunchDeployment;
+const option = {
+  networkId: "robinhood",
+  descriptor: deployment.descriptor,
+  launch: deployment,
+  protocol: null,
+} satisfies DeploymentOption;
+
+function request(body: unknown, origin = "https://staticsprotocol.com") {
+  return new Request("https://staticsprotocol.com/api/deployments/launch-verification", {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "staticsprotocol.com", origin },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("launch verification route", () => {
+  beforeEach(() => {
+    mocks.registry.mockReset().mockReturnValue([option]);
+    mocks.verify.mockReset().mockReturnValue({
+      status: "miss",
+      verification: Promise.resolve(),
+    });
+  });
+
+  it("verifies only a known checked-in deployment", async () => {
+    const response = await POST(request({ chainId: 4_663, deploymentId: "robinhood-genesis" }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-statics-verification-cache")).toBe("miss");
+    await expect(response.json()).resolves.toMatchObject({ verified: true });
+  });
+
+  it("rejects unknown deployments without calling the RPC", async () => {
+    const response = await POST(request({ chainId: 4_663, deploymentId: "unknown" }));
+    expect(response.status).toBe(404);
+    expect(mocks.verify).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-origin requests", async () => {
+    const response = await POST(
+      request({ chainId: 4_663, deploymentId: "robinhood-genesis" }, "https://attacker.example")
+    );
+    expect(response.status).toBe(403);
+    expect(mocks.verify).not.toHaveBeenCalled();
+  });
+});

--- a/test/api/launch-verification-route.test.ts
+++ b/test/api/launch-verification-route.test.ts
@@ -94,4 +94,16 @@ describe("launch verification route", () => {
     expect(response.status).toBe(403);
     expect(mocks.verify).not.toHaveBeenCalled();
   });
+
+  it("rejects requests without origin validation headers", async () => {
+    const response = await POST(
+      new Request("https://staticsprotocol.com/api/deployments/launch-verification", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ chainId: 4_663, deploymentId: "robinhood-genesis" }),
+      })
+    );
+    expect(response.status).toBe(403);
+    expect(mocks.verify).not.toHaveBeenCalled();
+  });
 });

--- a/test/components/genesis-vault-swap.test.tsx
+++ b/test/components/genesis-vault-swap.test.tsx
@@ -20,6 +20,9 @@ vi.mock("@/lib/deployments/verify-launch", () => ({
   verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
   verifyLaunchDeploymentCached: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/lib/deployments/verify-launch-read", () => ({
+  verifyLaunchDeploymentForRead: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("@/lib/genesis/discovery", () => ({
   discoverNextAvailableGenesisId: (...args: unknown[]) => discoverNextAvailableGenesisId(...args),
   discoverWalletGenesisSnapshot: (...args: unknown[]) => discoverWalletGenesisSnapshot(...args),

--- a/test/components/launch-presentation.test.tsx
+++ b/test/components/launch-presentation.test.tsx
@@ -27,6 +27,9 @@ vi.mock("@/lib/deployments/verify-launch", () => ({
   verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
   verifyLaunchDeploymentCached: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/lib/deployments/verify-launch-read", () => ({
+  verifyLaunchDeploymentForRead: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("@/lib/indexer/statics", () => ({
   loadRecoverableGenesisCredits: (...args: unknown[]) => loadRecoverableGenesisCredits(...args),
 }));

--- a/test/components/standalone-genesis-claims.test.tsx
+++ b/test/components/standalone-genesis-claims.test.tsx
@@ -20,6 +20,9 @@ vi.mock("@/lib/deployments/verify-launch", () => ({
   verifyLaunchDeployment: vi.fn().mockResolvedValue(undefined),
   verifyLaunchDeploymentCached: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("@/lib/deployments/verify-launch-read", () => ({
+  verifyLaunchDeploymentForRead: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("@/lib/protocol/transactions", async () => {
   const actual = await vi.importActual<typeof import("@/lib/protocol/transactions")>(
     "@/lib/protocol/transactions"

--- a/test/foundation/launch-verification-read.test.ts
+++ b/test/foundation/launch-verification-read.test.ts
@@ -1,0 +1,73 @@
+import type { PublicClient } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+
+const mocks = vi.hoisted(() => ({ cached: vi.fn() }));
+
+vi.mock("@/lib/deployments/verify-launch", () => ({
+  verifyLaunchDeploymentCached: (...args: unknown[]) => mocks.cached(...args),
+}));
+
+import { verifyLaunchDeploymentForRead } from "@/lib/deployments/verify-launch-read";
+
+const deployment = {
+  descriptor: { deploymentId: "robinhood-genesis", chainId: 4_663 },
+  source: "checked-in-manifest",
+} as unknown as LaunchDeployment;
+const publicClient = {} as PublicClient;
+
+describe("read-only launch verification", () => {
+  beforeEach(() => {
+    mocks.cached.mockReset().mockResolvedValue(undefined);
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the shared server verifier for checked-in deployments", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ verified: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    await verifyLaunchDeploymentForRead(publicClient, deployment);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/deployments/launch-verification",
+      expect.objectContaining({
+        body: JSON.stringify({ chainId: 4_663, deploymentId: "robinhood-genesis" }),
+        method: "POST",
+      })
+    );
+    expect(mocks.cached).not.toHaveBeenCalled();
+  });
+
+  it("keeps development fixtures on the configured local client", async () => {
+    const local = { ...deployment, source: "development-fixture" } as LaunchDeployment;
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    await verifyLaunchDeploymentForRead(publicClient, local);
+
+    expect(mocks.cached).toHaveBeenCalledWith(publicClient, local);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a server verification failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Launch deployment verification failed." }), {
+          status: 502,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+
+    await expect(verifyLaunchDeploymentForRead(publicClient, deployment)).rejects.toThrow(
+      "Launch deployment verification failed"
+    );
+  });
+});

--- a/test/foundation/server-launch-verification.test.ts
+++ b/test/foundation/server-launch-verification.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LaunchDeployment } from "@/lib/deployments/types";
+
+const mocks = vi.hoisted(() => ({
+  getChainId: vi.fn(),
+  verify: vi.fn(),
+}));
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual<typeof import("viem")>("viem");
+  return {
+    ...actual,
+    createPublicClient: () => ({ getChainId: mocks.getChainId }),
+    http: vi.fn(() => ({})),
+  };
+});
+vi.mock("@/lib/deployments/verify-launch", () => ({
+  verifyLaunchDeployment: (...args: unknown[]) => mocks.verify(...args),
+}));
+vi.mock("@/lib/server/robinhood-rpc", () => ({
+  robinhoodRpcUrl: () => "https://rpc.example",
+}));
+
+import {
+  resetLaunchVerificationCacheForTests,
+  verifyLaunchDeploymentOnServer,
+} from "@/lib/server/launch-verification";
+
+const deployment = {
+  descriptor: { deploymentId: "launch", chainId: 4_663 },
+  protocolCommit: "commit",
+  runtimeCodeHashes: { statics: "0x1234" },
+} as unknown as LaunchDeployment;
+
+describe("server launch verification cache", () => {
+  beforeEach(() => {
+    resetLaunchVerificationCacheForTests();
+    mocks.getChainId.mockReset().mockResolvedValue(4_663);
+    mocks.verify.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("deduplicates verification across callers and reports cache status", async () => {
+    const first = verifyLaunchDeploymentOnServer(deployment);
+    const second = verifyLaunchDeploymentOnServer(deployment);
+
+    expect(first.status).toBe("miss");
+    expect(second.status).toBe("hit");
+    await Promise.all([first.verification, second.verification]);
+    expect(mocks.getChainId).toHaveBeenCalledTimes(1);
+    expect(mocks.verify).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts a failed verification so the next request can retry", async () => {
+    mocks.verify.mockRejectedValueOnce(new Error("binding mismatch"));
+    const failed = verifyLaunchDeploymentOnServer(deployment);
+    await expect(failed.verification).rejects.toThrow("binding mismatch");
+
+    const retry = verifyLaunchDeploymentOnServer(deployment);
+    expect(retry.status).toBe("miss");
+    await expect(retry.verification).resolves.toBeUndefined();
+    expect(mocks.verify).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the authenticated endpoint is on the wrong chain", async () => {
+    mocks.getChainId.mockResolvedValue(46_630);
+    await expect(verifyLaunchDeploymentOnServer(deployment).verification).rejects.toThrow(
+      "RPC chain does not match"
+    );
+    expect(mocks.verify).not.toHaveBeenCalled();
+  });
+});

--- a/test/foundation/server-launch-verification.test.ts
+++ b/test/foundation/server-launch-verification.test.ts
@@ -30,6 +30,7 @@ import {
 const deployment = {
   descriptor: { deploymentId: "launch", chainId: 4_663 },
   protocolCommit: "commit",
+  contracts: { statics: "0x1111111111111111111111111111111111111111" },
   runtimeCodeHashes: { statics: "0x1234" },
 } as unknown as LaunchDeployment;
 
@@ -59,6 +60,20 @@ describe("server launch verification cache", () => {
     const retry = verifyLaunchDeploymentOnServer(deployment);
     expect(retry.status).toBe("miss");
     await expect(retry.verification).resolves.toBeUndefined();
+    expect(mocks.verify).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share verification across different contract addresses", async () => {
+    const changed = {
+      ...deployment,
+      contracts: { statics: "0x2222222222222222222222222222222222222222" },
+    } as unknown as LaunchDeployment;
+
+    await verifyLaunchDeploymentOnServer(deployment).verification;
+    const second = verifyLaunchDeploymentOnServer(changed);
+
+    expect(second.status).toBe("miss");
+    await second.verification;
     expect(mocks.verify).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary

- filter Uniswap v4 `Swap` events by the canonical indexed PoolId before Ponder fetches and indexes them
- omit unconfigured full-protocol Ponder sources instead of retaining zero-address filters
- verify immutable checked-in launch deployments once per app-server process for display reads
- preserve fresh direct deployment verification on every transaction path

## Why

Robinhood Chain produces roughly nine blocks per second. The staging indexer has processed about 2.58 million PoolManager swaps even though the UI only needs the canonical STATICS/WETH pool; the prior handler discarded unrelated pools after they had already been fetched and decoded.

A fresh `/app` browser session also repeated 12 runtime-code reads and 19 immutable binding reads. The server-owned verification cache deduplicates those calls across users while failed checks are evicted and retried.

## Safety boundaries

- `PONDER_POOL_MANAGER_ADDRESS` and a valid 32-byte `PONDER_CANONICAL_POOL_ID` must be configured together
- the server resolves only checked-in deployment manifests and verifies the authenticated RPC chain
- local Anvil fixtures remain on their configured local client
- transaction preparation continues to call the uncached verifier immediately before user actions
- no generic RPC cache, public-RPC fallback, dependency upgrade, credential change, or production infrastructure change is included

## Validation

- app typecheck
- Ponder typecheck and code generation with Genesis-only source configuration
- 117 app test files / 626 tests
- 4 Ponder test files / 23 tests
- production Next.js build
