### PR TITLE
feat(api): expose public CoinGecko feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,43 @@ Coinbase ETH/USD may use its last good value for no more than 15 minutes and the
 `null`. Ponder supplies activity and history; onchain reads remain authoritative for reserves,
 supply, vesting, backing, and spot price.
 
+### Public CoinGecko API
+
+The following HTTPS JSON routes are anonymous and do not accept or require an API key:
+
+- `GET /api/coingecko/v1/supply/total` returns `{"result":"1000000000"}` in decimal token
+  units.
+- `GET /api/coingecko/v1/supply/circulating` returns the strict liquid float as
+  `{"result":"<decimal token units>"}`.
+- `GET /api/coingecko/v1/supply` discloses both supplies, all exclusions, the source block,
+  timestamp, and methodology.
+- `GET /api/coingecko/v1/pairs` returns the canonical `STATICS_WETH` pair and contract metadata.
+- `GET /api/coingecko/v1/ticker` returns spot price, 24-hour base/target/USD volume, liquidity,
+  24-hour change, and two-percent executable costs in both directions.
+
+Circulating supply is the onchain total supply minus canonical pool inventory, unreleased treasury
+vesting, and Operator Vault token backing. These fundamentals are read at one block and shared with
+the Overview dashboard. Supply responses cache for five minutes and may use the last successful
+onchain snapshot for at most 30 minutes during an RPC interruption. Ticker responses cache for one
+minute; pair metadata caches for one day. An unavailable indexer or USD feed returns `503` instead
+of publishing synthetic zero activity. Quoter-derived depth may be `null` without suppressing an
+otherwise healthy ticker.
+
+All routes allow read-only cross-origin requests. Configure the public reverse proxy or CDN for a
+limit of 60 requests per minute per source IP with a burst of 20. If Cloudflare protects these
+paths, prefer an explicit CoinGecko IP allowlist. Where an IP allowlist is unavailable, skip bot
+challenges only for the exact `/api/coingecko/v1/*` paths when both of these headers are present,
+while retaining the WAF and rate limit:
+
+```text
+X-Requested-With: com.coingecko
+User-Agent: CoinGecko +https://coingecko.com/
+```
+
+The protocol is an AMM, so orderbook, open-interest, and funding-rate fields do not apply. The
+Overview page is the corresponding public interface for price, USD volume, liquidity, supply, and
+executable depth.
+
 ## Connected local environment
 
 The complete local workflow requires a separate clean clone of the public Statics protocol

--- a/app/api/coingecko/v1/pairs/route.ts
+++ b/app/api/coingecko/v1/pairs/route.ts
@@ -1,0 +1,19 @@
+import { loadCoinGeckoPairs } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export function GET() {
+  try {
+    return coinGeckoJson(loadCoinGeckoPairs(), COINGECKO_CACHE.pairs);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/supply/circulating/route.ts
+++ b/app/api/coingecko/v1/supply/circulating/route.ts
@@ -1,0 +1,24 @@
+import { coinGeckoSupplyResult } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(
+      coinGeckoSupplyResult(snapshot.strictLiquidFloat, snapshot.decimals),
+      COINGECKO_CACHE.supply
+    );
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/supply/route.ts
+++ b/app/api/coingecko/v1/supply/route.ts
@@ -1,0 +1,21 @@
+import { coinGeckoSupplyDisclosure } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(coinGeckoSupplyDisclosure(snapshot), COINGECKO_CACHE.supply);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/supply/total/route.ts
+++ b/app/api/coingecko/v1/supply/total/route.ts
@@ -1,0 +1,24 @@
+import { coinGeckoSupplyResult } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(
+      coinGeckoSupplyResult(snapshot.total, snapshot.decimals),
+      COINGECKO_CACHE.supply
+    );
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/ticker/route.ts
+++ b/app/api/coingecko/v1/ticker/route.ts
@@ -1,0 +1,19 @@
+import { loadCoinGeckoTicker } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return coinGeckoJson(await loadCoinGeckoTicker(), COINGECKO_CACHE.ticker);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/lib/market/client.ts
+++ b/lib/market/client.ts
@@ -62,6 +62,7 @@ export function isStaticsMarketOverview(value: unknown): value is StaticsMarketO
     unsigned(liquidity.principalStatics) &&
     nullableUnsigned(liquidity.tvlUsdWad) &&
     activity &&
+    typeof activity.available === "boolean" &&
     unsigned(activity.wethVolume) &&
     unsigned(activity.staticsVolume) &&
     ["swaps", "buys", "sells", "priceChangeBps"].every(

--- a/lib/market/coingecko.ts
+++ b/lib/market/coingecko.ts
@@ -1,0 +1,80 @@
+import { formatUnits } from "viem";
+
+import type { MarketSupplySnapshot, StaticsMarketOverview } from "@/lib/market/types";
+
+function decimalNumber(raw: string, decimals = 18): number {
+  const value = Number(formatUnits(BigInt(raw), decimals));
+  if (!Number.isFinite(value)) throw new Error("Market value cannot be represented as JSON.");
+  return value;
+}
+
+function depthCost(
+  levels: NonNullable<StaticsMarketOverview["depth"]>["buyStatics"]
+): number | null {
+  const level = levels.find((candidate) => candidate.targetImpactBps === 200);
+  return level?.inputUsdWad === null || level?.inputUsdWad === undefined
+    ? null
+    : decimalNumber(level.inputUsdWad);
+}
+
+export function coinGeckoSupplyResult(raw: string, decimals: number): Readonly<{ result: string }> {
+  return { result: formatUnits(BigInt(raw), decimals) };
+}
+
+export function coinGeckoSupplyDisclosure(snapshot: MarketSupplySnapshot) {
+  return {
+    schema_version: 1,
+    asset: "STATICS",
+    chain_id: snapshot.chainId,
+    contract_address: snapshot.tokenAddress,
+    decimals: snapshot.decimals,
+    total_supply: formatUnits(BigInt(snapshot.total), snapshot.decimals),
+    circulating_supply: formatUnits(BigInt(snapshot.strictLiquidFloat), snapshot.decimals),
+    public_distributed_supply: formatUnits(BigInt(snapshot.publicDistributed), snapshot.decimals),
+    exclusions: {
+      canonical_pool_inventory: formatUnits(BigInt(snapshot.poolInventory), snapshot.decimals),
+      unreleased_treasury_vesting: formatUnits(
+        BigInt(snapshot.unreleasedTreasury),
+        snapshot.decimals
+      ),
+      operator_vault_backing: formatUnits(BigInt(snapshot.vaultBacking), snapshot.decimals),
+    },
+    methodology:
+      "total_supply - canonical_pool_inventory - unreleased_treasury_vesting - operator_vault_backing",
+    status: snapshot.status,
+    as_of_block: snapshot.asOfBlock,
+    updated_at: snapshot.snapshotAt,
+  } as const;
+}
+
+export function coinGeckoTicker(overview: StaticsMarketOverview) {
+  if (
+    !overview.activity24h.available ||
+    overview.price.ethUsdWad === null ||
+    overview.price.staticsUsdWad === null ||
+    overview.liquidity.tvlUsdWad === null
+  ) {
+    throw new Error("Public ticker dependencies are unavailable.");
+  }
+  const depth = overview.depth;
+  const wethVolumeUsdWad =
+    (BigInt(overview.activity24h.wethVolume) * BigInt(overview.price.ethUsdWad)) / 10n ** 18n;
+  return {
+    ticker_id: "STATICS_WETH",
+    base_currency: "STATICS",
+    target_currency: "WETH",
+    last_price: decimalNumber(overview.price.wethPerStaticsWad),
+    base_volume: decimalNumber(overview.activity24h.staticsVolume),
+    target_volume: decimalNumber(overview.activity24h.wethVolume),
+    volume_usd: decimalNumber(wethVolumeUsdWad.toString()),
+    liquidity_usd: decimalNumber(overview.liquidity.tvlUsdWad),
+    price_change_percent_24h: overview.activity24h.priceChangeBps / 100,
+    cost_to_move_up_usd: depth ? depthCost(depth.buyStatics) : null,
+    cost_to_move_down_usd: depth ? depthCost(depth.sellStatics) : null,
+    converted_last: { usd: decimalNumber(overview.price.staticsUsdWad) },
+    converted_volume: { usd: decimalNumber(wethVolumeUsdWad.toString()) },
+    last_trade_at: overview.freshness.indexedAt,
+    data_updated_at: overview.freshness.snapshotAt,
+    as_of_block: overview.asOfBlock,
+  } as const;
+}

--- a/lib/market/types.ts
+++ b/lib/market/types.ts
@@ -42,6 +42,7 @@ export type StaticsMarketOverview = Readonly<{
     tvlUsdWad: string | null;
   }>;
   activity24h: Readonly<{
+    available: boolean;
     wethVolume: string;
     staticsVolume: string;
     swaps: number;
@@ -60,4 +61,20 @@ export type StaticsMarketOverview = Readonly<{
     usdPriceAt: string | null;
     usdPriceStale: boolean;
   }>;
+}>;
+
+export type MarketSupplySnapshot = Readonly<{
+  status: "fresh" | "stale";
+  chainId: number;
+  deploymentId: string;
+  tokenAddress: string;
+  decimals: 18;
+  asOfBlock: string;
+  snapshotAt: string;
+  total: string;
+  poolInventory: string;
+  publicDistributed: string;
+  unreleasedTreasury: string;
+  vaultBacking: string;
+  strictLiquidFloat: string;
 }>;

--- a/lib/server/coingecko-market.ts
+++ b/lib/server/coingecko-market.ts
@@ -1,0 +1,36 @@
+import { deploymentRegistry, ROBINHOOD_GENESIS_DEPLOYMENT_ID } from "@/lib/deployments/registry";
+import { coinGeckoTicker } from "@/lib/market/coingecko";
+import { loadMarketOverview, loadMarketSupplySnapshot } from "@/lib/server/market-overview";
+
+function mainnetLaunch() {
+  const launch = deploymentRegistry().find(
+    (option) => option.descriptor.deploymentId === ROBINHOOD_GENESIS_DEPLOYMENT_ID
+  )?.launch;
+  if (!launch) throw new Error("The reviewed Robinhood launch manifest is unavailable.");
+  return launch;
+}
+
+export async function loadCoinGeckoSupply() {
+  return loadMarketSupplySnapshot();
+}
+
+export async function loadCoinGeckoTicker() {
+  return coinGeckoTicker(await loadMarketOverview());
+}
+
+export function loadCoinGeckoPairs() {
+  const launch = mainnetLaunch();
+  return [
+    {
+      ticker_id: "STATICS_WETH",
+      base_currency: "STATICS",
+      target_currency: "WETH",
+      base_address: launch.contracts.statics,
+      target_address: launch.contracts.weth,
+      pool_id: launch.market.poolId,
+      chain_id: launch.descriptor.chainId,
+      fee_bps: launch.market.poolKey.fee / 100,
+      trade_url: "https://staticsprotocol.com/app/swap",
+    },
+  ] as const;
+}

--- a/lib/server/coingecko-route.ts
+++ b/lib/server/coingecko-route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+export const COINGECKO_CACHE = {
+  supply: "public, max-age=60, s-maxage=300, stale-while-revalidate=1800",
+  ticker: "public, max-age=30, s-maxage=60, stale-while-revalidate=120",
+  pairs: "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+} as const;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Accept, Content-Type, X-Requested-With",
+} as const;
+
+export function coinGeckoJson(body: unknown, cacheControl: string, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { ...CORS_HEADERS, "Cache-Control": cacheControl },
+  });
+}
+
+export function coinGeckoUnavailable(): NextResponse {
+  return coinGeckoJson({ error: "Market data are temporarily unavailable." }, "no-store", 503);
+}
+
+export function coinGeckoOptions(): NextResponse {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/lib/server/market-overview.ts
+++ b/lib/server/market-overview.ts
@@ -15,7 +15,11 @@ import {
   strictLiquidFloat,
   usdValueWad,
 } from "@/lib/market/analytics";
-import type { MarketDepthLevel, StaticsMarketOverview } from "@/lib/market/types";
+import type {
+  MarketDepthLevel,
+  MarketSupplySnapshot,
+  StaticsMarketOverview,
+} from "@/lib/market/types";
 import { poolKeyForLaunch } from "@/lib/trade/canonical-market";
 import { loadEthUsd } from "@/lib/server/eth-usd";
 import { verifyLaunchDeploymentOnServer } from "@/lib/server/launch-verification";
@@ -30,6 +34,7 @@ const vestingAbi = parseAbi([
 ]);
 
 const SNAPSHOT_TTL_MS = 60_000;
+const SUPPLY_MAX_STALE_MS = 30 * 60_000;
 const DEPTH_TTL_MS = 5 * 60_000;
 const DEPTH_MAX_STALE_MS = 15 * 60_000;
 const DEPTH_TARGETS = [100, 200, 500] as const;
@@ -62,8 +67,29 @@ type DepthCache = Readonly<{
   stale: boolean;
 }>;
 
+type MarketFundamentals = Readonly<{
+  deployment: LaunchDeployment;
+  client: PublicClient;
+  blockNumber: bigint;
+  poolStatics: bigint;
+  poolWeth: bigint;
+  prices: ReturnType<typeof canonicalPrices>;
+  totalSupply: bigint;
+  unreleasedTreasury: bigint;
+  vaultBacking: bigint;
+  publicDistributed: bigint;
+  liquidFloat: bigint;
+}>;
+
+type FundamentalsCache = Readonly<{
+  value: MarketFundamentals;
+  fetchedAt: number;
+}>;
+
 let snapshotCache: Readonly<{ value: StaticsMarketOverview; fetchedAt: number }> | null = null;
 let snapshotInFlight: Promise<StaticsMarketOverview> | null = null;
+let fundamentalsCache: FundamentalsCache | null = null;
+let fundamentalsInFlight: Promise<FundamentalsCache> | null = null;
 let depthCache: DepthCache | null = null;
 let depthInFlight: Promise<DepthCache | null> | null = null;
 
@@ -302,7 +328,7 @@ async function loadDepth(
   return depthInFlight;
 }
 
-async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
+async function refreshFundamentals(now: number): Promise<FundamentalsCache> {
   const deployment = mainnetLaunch();
   const analytics = deployment.analytics!;
   await verifyLaunchDeploymentOnServer(deployment).verification;
@@ -311,7 +337,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
   });
   const blockNumber = await client.getBlockNumber();
   const poolKey = poolKeyForLaunch(deployment);
-  const [pool, accounting, totalSupply, vesting, ethUsd, activity] = await Promise.all([
+  const [pool, accounting, totalSupply, vesting] = await Promise.all([
     client.readContract({
       address: analytics.reservesLens.address,
       abi: reservesLensAbi,
@@ -338,8 +364,6 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
       args: [analytics.treasuryBeneficiary, 0n],
       blockNumber,
     }),
-    loadEthUsd(now),
-    loadActivity(deployment, now),
   ]);
   const staticsIsCurrency0 =
     deployment.market.poolKey.currency0.toLowerCase() ===
@@ -351,17 +375,100 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
     deployment.market.poolKey.currency0,
     deployment.contracts.statics
   );
+  const unreleasedTreasury = vesting[0] > vesting[1] ? vesting[0] - vesting[1] : 0n;
+  return {
+    fetchedAt: now,
+    value: {
+      deployment,
+      client,
+      blockNumber,
+      poolStatics,
+      poolWeth,
+      prices,
+      totalSupply,
+      unreleasedTreasury,
+      vaultBacking: accounting.tokenBacking,
+      publicDistributed: publicDistributedSupply(poolStatics),
+      liquidFloat: strictLiquidFloat(
+        totalSupply,
+        poolStatics,
+        unreleasedTreasury,
+        accounting.tokenBacking
+      ),
+    },
+  };
+}
+
+async function loadFundamentals(now: number, allowStale: boolean): Promise<FundamentalsCache> {
+  if (fundamentalsCache && now - fundamentalsCache.fetchedAt <= SNAPSHOT_TTL_MS) {
+    return fundamentalsCache;
+  }
+  if (!fundamentalsInFlight) {
+    fundamentalsInFlight = refreshFundamentals(now)
+      .then((value) => {
+        fundamentalsCache = value;
+        return value;
+      })
+      .finally(() => {
+        fundamentalsInFlight = null;
+      });
+  }
+  try {
+    return await fundamentalsInFlight;
+  } catch (error) {
+    if (
+      allowStale &&
+      fundamentalsCache &&
+      now - fundamentalsCache.fetchedAt <= SUPPLY_MAX_STALE_MS
+    ) {
+      return fundamentalsCache;
+    }
+    throw error;
+  }
+}
+
+export async function loadMarketSupplySnapshot(now = Date.now()): Promise<MarketSupplySnapshot> {
+  const fundamentals = await loadFundamentals(now, true);
+  const { value } = fundamentals;
+  return {
+    status: now - fundamentals.fetchedAt <= SNAPSHOT_TTL_MS ? "fresh" : "stale",
+    chainId: value.deployment.descriptor.chainId,
+    deploymentId: value.deployment.descriptor.deploymentId,
+    tokenAddress: value.deployment.contracts.statics,
+    decimals: 18,
+    asOfBlock: value.blockNumber.toString(),
+    snapshotAt: new Date(fundamentals.fetchedAt).toISOString(),
+    total: value.totalSupply.toString(),
+    poolInventory: value.poolStatics.toString(),
+    publicDistributed: value.publicDistributed.toString(),
+    unreleasedTreasury: value.unreleasedTreasury.toString(),
+    vaultBacking: value.vaultBacking.toString(),
+    strictLiquidFloat: value.liquidFloat.toString(),
+  };
+}
+
+async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
+  const deployment = mainnetLaunch();
+  const [fundamentals, ethUsd, activity] = await Promise.all([
+    loadFundamentals(now, false),
+    loadEthUsd(now),
+    loadActivity(deployment, now),
+  ]);
+  const {
+    client,
+    blockNumber,
+    poolStatics,
+    poolWeth,
+    prices,
+    totalSupply,
+    unreleasedTreasury,
+    vaultBacking,
+    publicDistributed,
+    liquidFloat,
+  } = fundamentals.value;
   const ethUsdWad = ethUsd?.valueWad ?? null;
   const staticsUsdWad =
     ethUsdWad === null ? null : staticsUsdPriceWad(prices.wethPerStaticsWad, ethUsdWad);
-  const unreleasedTreasury = vesting[0] > vesting[1] ? vesting[0] - vesting[1] : 0n;
-  const publicDistributed = publicDistributedSupply(poolStatics);
-  const liquidFloat = strictLiquidFloat(
-    totalSupply,
-    poolStatics,
-    unreleasedTreasury,
-    accounting.tokenBacking
-  );
   const depth = await loadDepth(
     client,
     deployment,
@@ -393,7 +500,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
       poolInventory: poolStatics.toString(),
       publicDistributed: publicDistributed.toString(),
       unreleasedTreasury: unreleasedTreasury.toString(),
-      vaultBacking: accounting.tokenBacking.toString(),
+      vaultBacking: vaultBacking.toString(),
       strictLiquidFloat: liquidFloat.toString(),
     },
     valuation: {
@@ -413,6 +520,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
     },
     activity24h: activity
       ? {
+          available: true,
           wethVolume: activity.wethVolume.toString(),
           staticsVolume: activity.staticsVolume.toString(),
           swaps: activity.swaps,
@@ -421,6 +529,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
           priceChangeBps: activity.priceChangeBps,
         }
       : {
+          available: false,
           wethVolume: "0",
           staticsVolume: "0",
           swaps: 0,
@@ -457,6 +566,8 @@ export async function loadMarketOverview(now = Date.now()): Promise<StaticsMarke
 export function resetMarketOverviewCacheForTest(): void {
   snapshotCache = null;
   snapshotInFlight = null;
+  fundamentalsCache = null;
+  fundamentalsInFlight = null;
   depthCache = null;
   depthInFlight = null;
 }

--- a/test/api/coingecko-routes.test.ts
+++ b/test/api/coingecko-routes.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadSupply: vi.fn(),
+  loadTicker: vi.fn(),
+  loadPairs: vi.fn(),
+}));
+
+vi.mock("@/lib/server/coingecko-market", () => ({
+  loadCoinGeckoSupply: mocks.loadSupply,
+  loadCoinGeckoTicker: mocks.loadTicker,
+  loadCoinGeckoPairs: mocks.loadPairs,
+}));
+
+import { GET as getPairs, OPTIONS as optionsPairs } from "@/app/api/coingecko/v1/pairs/route";
+import { GET as getSupply } from "@/app/api/coingecko/v1/supply/route";
+import { GET as getCirculating } from "@/app/api/coingecko/v1/supply/circulating/route";
+import { GET as getTotal } from "@/app/api/coingecko/v1/supply/total/route";
+import { GET as getTicker } from "@/app/api/coingecko/v1/ticker/route";
+
+const WAD = 10n ** 18n;
+const supply = {
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  tokenAddress: "0x2d8d6F4A93AcD7a916A5a654ec8b690bA3B3EAdd",
+  decimals: 18,
+  asOfBlock: "123",
+  snapshotAt: "2026-09-01T12:00:00.000Z",
+  total: (1_000_000_000n * WAD).toString(),
+  poolInventory: (99_900_000n * WAD).toString(),
+  publicDistributed: (700_100_000n * WAD).toString(),
+  unreleasedTreasury: (100_100_000n * WAD).toString(),
+  vaultBacking: (117_900_000n * WAD).toString(),
+  strictLiquidFloat: (682_100_000n * WAD).toString(),
+};
+
+beforeEach(() => {
+  mocks.loadSupply.mockReset().mockResolvedValue(supply);
+  mocks.loadTicker.mockReset().mockResolvedValue({ ticker_id: "STATICS_WETH" });
+  mocks.loadPairs.mockReset().mockReturnValue([{ ticker_id: "STATICS_WETH" }]);
+});
+
+describe("public CoinGecko routes", () => {
+  it("serves exact anonymous supply results in decimal token units", async () => {
+    expect(await (await getTotal()).json()).toEqual({ result: "1000000000" });
+    expect(await (await getCirculating()).json()).toEqual({ result: "682100000" });
+    expect(await (await getSupply()).json()).toMatchObject({
+      decimals: 18,
+      total_supply: "1000000000",
+      circulating_supply: "682100000",
+    });
+  });
+
+  it("applies public caching and permissive read-only CORS without authentication", async () => {
+    const ticker = await getTicker();
+    expect(ticker.status).toBe(200);
+    expect(ticker.headers.get("access-control-allow-origin")).toBe("*");
+    expect(ticker.headers.get("cache-control")).toContain("s-maxage=60");
+    expect(await ticker.json()).toEqual({ ticker_id: "STATICS_WETH" });
+
+    const pairs = await getPairs();
+    expect(pairs.headers.get("cache-control")).toContain("s-maxage=86400");
+    expect(await pairs.json()).toEqual([{ ticker_id: "STATICS_WETH" }]);
+
+    const preflight = optionsPairs();
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+  });
+
+  it("returns a cache-disabled 503 when authoritative dependencies are unavailable", async () => {
+    mocks.loadTicker.mockRejectedValueOnce(new Error("Indexer unavailable"));
+    const response = await getTicker();
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ error: "Market data are temporarily unavailable." });
+  });
+});

--- a/test/components/market-analytics.test.tsx
+++ b/test/components/market-analytics.test.tsx
@@ -37,6 +37,7 @@ const analytics = {
     tvlUsdWad: (2_000_000n * WAD).toString(),
   },
   activity24h: {
+    available: true,
     wethVolume: (40n * WAD).toString(),
     staticsVolume: (10_000_000n * WAD).toString(),
     swaps: 12,
@@ -77,6 +78,8 @@ describe("market analytics panel", () => {
   it("separates valuation, supply, pool principal, and executable depth", () => {
     render(<MarketAnalyticsPanel analytics={analytics} loading={false} error={false} />);
     expect(screen.getByText("Public market cap")).toBeInTheDocument();
+    expect(screen.getByText("STATICS price")).toBeInTheDocument();
+    expect(screen.getByText("24h volume")).toBeInTheDocument();
     expect(screen.getByText("Public distributed supply")).toBeInTheDocument();
     expect(screen.getByText("Strict liquid float")).toBeInTheDocument();
     expect(screen.getByText("Canonical pool principal")).toBeInTheDocument();

--- a/test/market/client.test.ts
+++ b/test/market/client.test.ts
@@ -30,6 +30,7 @@ const fixture = {
   },
   liquidity: { principalWeth: "4", principalStatics: "5", tvlUsdWad: "6" },
   activity24h: {
+    available: true,
     wethVolume: "7",
     staticsVolume: "8",
     swaps: 9,

--- a/test/market/coingecko.test.ts
+++ b/test/market/coingecko.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coinGeckoSupplyDisclosure,
+  coinGeckoSupplyResult,
+  coinGeckoTicker,
+} from "@/lib/market/coingecko";
+import type { MarketSupplySnapshot, StaticsMarketOverview } from "@/lib/market/types";
+
+const WAD = 10n ** 18n;
+const supply = {
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  tokenAddress: "0x2d8d6F4A93AcD7a916A5a654ec8b690bA3B3EAdd",
+  decimals: 18,
+  asOfBlock: "123",
+  snapshotAt: "2026-09-01T12:00:00.000Z",
+  total: (1_000_000_000n * WAD).toString(),
+  poolInventory: (99_900_000n * WAD).toString(),
+  publicDistributed: (700_100_000n * WAD).toString(),
+  unreleasedTreasury: (100_100_000n * WAD).toString(),
+  vaultBacking: (117_900_000n * WAD).toString(),
+  strictLiquidFloat: (682_100_000n * WAD).toString(),
+} satisfies MarketSupplySnapshot;
+
+const overview = {
+  schemaVersion: 1,
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  poolId: `0x${"1".repeat(64)}`,
+  asOfBlock: "123",
+  price: {
+    staticsPerWethWad: (250_000n * WAD).toString(),
+    wethPerStaticsWad: (WAD / 250_000n).toString(),
+    ethUsdWad: (2_500n * WAD).toString(),
+    staticsUsdWad: (WAD / 100n).toString(),
+  },
+  supply: {
+    total: supply.total,
+    poolInventory: supply.poolInventory,
+    publicDistributed: supply.publicDistributed,
+    unreleasedTreasury: supply.unreleasedTreasury,
+    vaultBacking: supply.vaultBacking,
+    strictLiquidFloat: supply.strictLiquidFloat,
+  },
+  valuation: {
+    fdvUsdWad: (10_000_000n * WAD).toString(),
+    publicMarketCapUsdWad: (7_001_000n * WAD).toString(),
+    liquidFloatMarketCapUsdWad: (6_821_000n * WAD).toString(),
+  },
+  liquidity: {
+    principalWeth: (400n * WAD).toString(),
+    principalStatics: supply.poolInventory,
+    tvlUsdWad: (2_000_000n * WAD).toString(),
+  },
+  activity24h: {
+    available: true,
+    wethVolume: (40n * WAD).toString(),
+    staticsVolume: (10_000_000n * WAD).toString(),
+    swaps: 12,
+    buys: 7,
+    sells: 5,
+    priceChangeBps: 125,
+  },
+  depth: {
+    buyStatics: [
+      {
+        targetImpactBps: 200,
+        actualImpactBps: 199,
+        inputToken: "WETH",
+        outputToken: "STATICS",
+        amountIn: WAD.toString(),
+        amountOut: (250_000n * WAD).toString(),
+        inputUsdWad: (2_500n * WAD).toString(),
+      },
+    ],
+    sellStatics: [
+      {
+        targetImpactBps: 200,
+        actualImpactBps: 199,
+        inputToken: "STATICS",
+        outputToken: "WETH",
+        amountIn: (250_000n * WAD).toString(),
+        amountOut: WAD.toString(),
+        inputUsdWad: (2_500n * WAD).toString(),
+      },
+    ],
+  },
+  freshness: {
+    indexedAt: "2026-09-01T11:59:00.000Z",
+    snapshotAt: supply.snapshotAt,
+    depthAt: supply.snapshotAt,
+    usdPriceAt: supply.snapshotAt,
+    usdPriceStale: false,
+  },
+} satisfies StaticsMarketOverview;
+
+describe("CoinGecko market payloads", () => {
+  it("returns decimal token units and discloses every circulating-supply exclusion", () => {
+    expect(coinGeckoSupplyResult(supply.total, supply.decimals)).toEqual({
+      result: "1000000000",
+    });
+    expect(coinGeckoSupplyResult(supply.strictLiquidFloat, supply.decimals)).toEqual({
+      result: "682100000",
+    });
+    expect(coinGeckoSupplyDisclosure(supply)).toMatchObject({
+      total_supply: "1000000000",
+      circulating_supply: "682100000",
+      exclusions: {
+        canonical_pool_inventory: "99900000",
+        unreleased_treasury_vesting: "100100000",
+        operator_vault_backing: "117900000",
+      },
+      as_of_block: "123",
+    });
+  });
+
+  it("maps canonical activity and two-percent executable depth into the ticker", () => {
+    expect(coinGeckoTicker(overview)).toMatchObject({
+      ticker_id: "STATICS_WETH",
+      last_price: 0.000004,
+      base_volume: 10_000_000,
+      target_volume: 40,
+      volume_usd: 100_000,
+      liquidity_usd: 2_000_000,
+      price_change_percent_24h: 1.25,
+      cost_to_move_up_usd: 2_500,
+      cost_to_move_down_usd: 2_500,
+      converted_last: { usd: 0.01 },
+    });
+  });
+
+  it("fails closed instead of reporting an indexer outage as zero volume", () => {
+    expect(() =>
+      coinGeckoTicker({
+        ...overview,
+        activity24h: { ...overview.activity24h, available: false },
+      })
+    ).toThrow("Public ticker dependencies are unavailable.");
+  });
+});

--- a/test/server/market-overview.test.ts
+++ b/test/server/market-overview.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getBlockNumber: vi.fn(),
+  readContract: vi.fn(),
+  simulateContract: vi.fn(),
+  loadEthUsd: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const original = await importOriginal<typeof import("viem")>();
+  return {
+    ...original,
+    createPublicClient: () => ({
+      getBlockNumber: mocks.getBlockNumber,
+      readContract: mocks.readContract,
+      simulateContract: mocks.simulateContract,
+    }),
+    http: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/eth-usd", () => ({ loadEthUsd: mocks.loadEthUsd }));
+vi.mock("@/lib/server/launch-verification", () => ({
+  verifyLaunchDeploymentOnServer: () => ({ status: "hit", verification: Promise.resolve() }),
+}));
+vi.mock("@/lib/server/robinhood-rpc", () => ({
+  robinhoodRpcUrl: () => "https://rpc.example",
+}));
+vi.mock("@/lib/server/statics-indexer-url", () => ({
+  staticsMainnetIndexerUrl: () => new URL("https://indexer.example/market/candles"),
+}));
+
+import {
+  loadMarketOverview,
+  loadMarketSupplySnapshot,
+  resetMarketOverviewCacheForTest,
+} from "@/lib/server/market-overview";
+
+const WAD = 10n ** 18n;
+const NOW = Date.parse("2026-09-01T12:00:00.000Z");
+
+beforeEach(() => {
+  resetMarketOverviewCacheForTest();
+  mocks.getBlockNumber.mockReset().mockResolvedValue(123n);
+  mocks.readContract.mockReset().mockImplementation(({ functionName }) => {
+    if (functionName === "getPoolTVL") {
+      return Promise.resolve({
+        coreAmount0: 400n * WAD,
+        coreAmount1: 99_900_000n * WAD,
+        sqrtPriceX96: 1n << 96n,
+      });
+    }
+    if (functionName === "vaultAccounting") {
+      return Promise.resolve({ tokenBacking: 117_900_000n * WAD });
+    }
+    if (functionName === "totalSupply") return Promise.resolve(1_000_000_000n * WAD);
+    if (functionName === "vestingOf") return Promise.resolve([100_100_000n * WAD, 0n]);
+    throw new Error(`Unexpected read: ${String(functionName)}`);
+  });
+  mocks.simulateContract.mockReset().mockRejectedValue(new Error("Quoter unavailable"));
+  mocks.loadEthUsd.mockReset().mockResolvedValue(null);
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ items: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  );
+});
+
+describe("shared market fundamentals", () => {
+  it("serves supply without indexer, USD, or Quoter calls and reuses reads for the overview", async () => {
+    const supply = await loadMarketSupplySnapshot(NOW);
+    expect(supply).toMatchObject({
+      status: "fresh",
+      asOfBlock: "123",
+      strictLiquidFloat: (682_100_000n * WAD).toString(),
+    });
+    expect(mocks.readContract).toHaveBeenCalledTimes(4);
+    expect(mocks.loadEthUsd).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.simulateContract).not.toHaveBeenCalled();
+
+    await loadMarketOverview(NOW);
+    expect(mocks.readContract).toHaveBeenCalledTimes(4);
+    expect(mocks.loadEthUsd).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses a last-good supply snapshot only within the bounded stale window", async () => {
+    await loadMarketSupplySnapshot(NOW);
+    mocks.readContract.mockRejectedValue(new Error("RPC unavailable"));
+    expect(await loadMarketSupplySnapshot(NOW + 61_000)).toMatchObject({ status: "stale" });
+    await expect(loadMarketSupplySnapshot(NOW + 30 * 60_000 + 1)).rejects.toThrow(
+      "RPC unavailable"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- expose anonymous CoinGecko-facing total supply, circulating supply, disclosure, pair, and ticker JSON routes
- share one block-pinned onchain fundamentals cache between the Overview dashboard and supply feeds
- publish strict liquid float as total supply minus pool inventory, unreleased treasury vesting, and Operator Vault backing
- fail ticker requests closed when indexed activity or USD conversion is unavailable while allowing Quoter depth to be null
- document public caching, CORS, edge rate limits, and Cloudflare handling for CoinGecko requests

## Public routes

- `GET /api/coingecko/v1/supply/total`
- `GET /api/coingecko/v1/supply/circulating`
- `GET /api/coingecko/v1/supply`
- `GET /api/coingecko/v1/pairs`
- `GET /api/coingecko/v1/ticker`

## Validation

- `npx vitest run test/server/market-overview.test.ts test/market/coingecko.test.ts test/api/coingecko-routes.test.ts test/market/client.test.ts test/components/market-analytics.test.tsx`
- `npm run verify:assets`
- `npm run lint` (passes with one pre-existing warning in `.local-tools/genesis-launch-dashboard/simulator.mjs`)
- `npm run lint:css`
- `npm run format:check`
- `npm run typecheck`
- `npm test` (127 files, 657 tests)
- `npm run build`
- read-only Robinhood mainnet rehearsal against the configured RPC and production indexer: all five public routes returned `200`, the exact CORS/cache policy, onchain supply at block `51747467`, and live ticker/depth data

`npm run test:e2e` builds successfully and passes 43 browser cases, with 9 failures in existing wallet-gating and localized-heading assertions. The same failing assertions reproduce on unmodified `origin/master` across desktop, tablet, and mobile, so they are not introduced by this branch.

`npm audit --omit=dev` reports existing transitive dependency advisories; this PR changes no dependencies or lockfiles.
