### PR TITLE
fix(wallet): separate Privy write RPC routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ NEXT_PUBLIC_APP_NETWORK=robinhood-testnet
 # these credentials or their provider quota with PONDER_RPC_URL_*.
 STATICS_ROBINHOOD_TESTNET_RPC_URL=
 STATICS_ROBINHOOD_MAINNET_RPC_URL=
+# Server-only upstreams used only by Privy embedded wallets to prepare and broadcast signed
+# transactions. Configure these explicitly; wallet traffic never falls back to the read upstreams.
+STATICS_ROBINHOOD_TESTNET_WALLET_RPC_URL=
+STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL=
 # Mainnet Ponder API used for market history and the dashboard's 24-hour activity snapshot.
 NEXT_PUBLIC_STATICS_MAINNET_INDEXER_URL=
 # Server-only approved market API keys as comma-separated id:sha256(secret) entries.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Server-only configuration:
 - `EVE_ROBINHOOD_RPC_URL`
 - `STATICS_ROBINHOOD_TESTNET_RPC_URL`
 - `STATICS_ROBINHOOD_MAINNET_RPC_URL`
+- `STATICS_ROBINHOOD_TESTNET_WALLET_RPC_URL`
+- `STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL`
 - `STATICS_MARKET_API_KEYS`
 
 The server integrations read these values only from their process environment. They are never
@@ -100,6 +102,13 @@ copied into browser configuration.
 The `STATICS_ROBINHOOD_*` values back the same-origin, read-only browser RPC proxy. Use a dedicated
 authenticated provider application/key for them. Ponder must use a different provider key so
 browser request bursts cannot consume the indexer's quota.
+
+The `STATICS_ROBINHOOD_*_WALLET_RPC_URL` values back a separate same-origin path used only by Privy
+embedded wallets. That path permits bounded transaction-preparation reads and one signed raw
+transaction broadcast; it does not accept unsigned sends or arbitrary JSON-RPC methods. Configure
+the wallet upstreams explicitly with write-capable provider URLs. They do not fall back to the read
+upstreams, and their credentials remain server-only. External wallets continue to submit through
+their own providers.
 
 The EVE RPCs verify the destination `OFTReceived` receipt before a LayerZero bridge is displayed as
 filled. They must point to authenticated, production-capable Base and Robinhood Chain RPC services;

--- a/app/api/rpc/[chainId]/route.ts
+++ b/app/api/rpc/[chainId]/route.ts
@@ -1,46 +1,9 @@
 import { NextResponse } from "next/server";
 
+import { isRobinhoodReadRequest } from "@/lib/server/robinhood-rpc-methods";
 import { robinhoodRpcUrl } from "@/lib/server/robinhood-rpc";
 
 export const runtime = "nodejs";
-
-const READ_METHODS = new Set([
-  "eth_blobBaseFee",
-  "eth_blockNumber",
-  "eth_call",
-  "eth_chainId",
-  "eth_estimateGas",
-  "eth_feeHistory",
-  "eth_gasPrice",
-  "eth_getBalance",
-  "eth_getBlockByHash",
-  "eth_getBlockByNumber",
-  "eth_getBlockReceipts",
-  "eth_getBlockTransactionCountByHash",
-  "eth_getBlockTransactionCountByNumber",
-  "eth_getCode",
-  "eth_getLogs",
-  "eth_getProof",
-  "eth_getStorageAt",
-  "eth_getTransactionByBlockHashAndIndex",
-  "eth_getTransactionByBlockNumberAndIndex",
-  "eth_getTransactionByHash",
-  "eth_getTransactionCount",
-  "eth_getTransactionReceipt",
-  "eth_maxPriorityFeePerGas",
-  "eth_syncing",
-  "net_version",
-  "web3_clientVersion",
-]);
-
-function isReadRequest(value: unknown): boolean {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    READ_METHODS.has((value as { method?: unknown }).method as string)
-  );
-}
 
 export async function POST(request: Request, context: { params: Promise<{ chainId: string }> }) {
   const origin = request.headers.get("origin");
@@ -84,7 +47,7 @@ export async function POST(request: Request, context: { params: Promise<{ chainI
     return NextResponse.json({ error: "Invalid JSON-RPC request." }, { status: 400 });
   }
   const requests = Array.isArray(payload) ? payload : [payload];
-  if (requests.length === 0 || requests.length > 50 || !requests.every(isReadRequest)) {
+  if (requests.length === 0 || requests.length > 50 || !requests.every(isRobinhoodReadRequest)) {
     return NextResponse.json(
       { error: "Only bounded, read-only JSON-RPC requests are allowed." },
       { status: 403 }

--- a/app/api/wallet-rpc/[chainId]/route.ts
+++ b/app/api/wallet-rpc/[chainId]/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from "next/server";
+import { parseTransaction, recoverTransactionAddress, type TransactionSerialized } from "viem";
+
+import { isRobinhoodReadRequest } from "@/lib/server/robinhood-rpc-methods";
+import { robinhoodWalletRpcUrl } from "@/lib/server/robinhood-rpc";
+
+export const runtime = "nodejs";
+
+type RpcRequest = Readonly<{
+  method?: unknown;
+  params?: unknown;
+}>;
+
+function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  const host = request.headers.get("host");
+  if (!origin || !host) return false;
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+function rawTransactionFrom(value: unknown): TransactionSerialized | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const request = value as RpcRequest;
+  if (request.method !== "eth_sendRawTransaction" || !Array.isArray(request.params)) return null;
+  if (request.params.length !== 1) return null;
+  const raw = request.params[0];
+  return typeof raw === "string" && /^0x[0-9a-fA-F]+$/.test(raw)
+    ? (raw as TransactionSerialized)
+    : null;
+}
+
+async function validSignedTransaction(
+  raw: TransactionSerialized,
+  chainId: number
+): Promise<boolean> {
+  try {
+    const transaction = parseTransaction(raw);
+    if (transaction.chainId !== chainId) return false;
+    await recoverTransactionAddress({ serializedTransaction: raw });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request, context: { params: Promise<{ chainId: string }> }) {
+  if (!sameOrigin(request)) {
+    return NextResponse.json(
+      { error: "Wallet RPC access requires the same application origin." },
+      { status: 403 }
+    );
+  }
+
+  const { chainId: rawChainId } = await context.params;
+  const chainId = Number(rawChainId);
+  if (!Number.isSafeInteger(chainId)) {
+    return NextResponse.json({ error: "Invalid chain id." }, { status: 400 });
+  }
+
+  let upstream: string;
+  try {
+    upstream = robinhoodWalletRpcUrl(chainId);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Wallet RPC proxy is not configured." },
+      { status: 503 }
+    );
+  }
+
+  const body = await request.text();
+  if (!body || body.length > 2_000_000) {
+    return NextResponse.json({ error: "Invalid or oversized JSON-RPC request." }, { status: 400 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON-RPC request." }, { status: 400 });
+  }
+
+  const requests = Array.isArray(payload) ? payload : [payload];
+  if (requests.length === 0 || requests.length > 50) {
+    return NextResponse.json({ error: "Invalid JSON-RPC request batch." }, { status: 400 });
+  }
+
+  const rawTransaction = requests.length === 1 ? rawTransactionFrom(requests[0]) : null;
+  const readOnlyBatch = requests.every(isRobinhoodReadRequest);
+  if (!readOnlyBatch && !rawTransaction) {
+    return NextResponse.json(
+      { error: "Only bounded wallet preparation reads and one signed transaction are allowed." },
+      { status: 403 }
+    );
+  }
+  if (rawTransaction && !(await validSignedTransaction(rawTransaction, chainId))) {
+    return NextResponse.json(
+      { error: "The signed transaction is invalid or targets a different chain." },
+      { status: 400 }
+    );
+  }
+
+  const methods = [
+    ...new Set(requests.map((entry) => (entry as { method: string }).method)),
+  ].sort();
+  const startedAt = Date.now();
+  try {
+    const response = await fetch(upstream, {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body,
+      cache: "no-store",
+    });
+    const retryAfter = response.headers.get("retry-after");
+    if (!response.ok) {
+      console.warn("Robinhood wallet RPC upstream request failed", {
+        batchSize: requests.length,
+        chainId,
+        durationMs: Date.now() - startedAt,
+        methods,
+        retryAfter: Boolean(retryAfter),
+        status: response.status,
+      });
+    }
+    const headers = new Headers({
+      "cache-control": "no-store",
+      "content-type": response.headers.get("content-type") ?? "application/json",
+    });
+    if (retryAfter) headers.set("retry-after", retryAfter);
+    return new Response(await response.text(), {
+      status: response.status,
+      headers,
+    });
+  } catch {
+    console.warn("Robinhood wallet RPC upstream request failed", {
+      batchSize: requests.length,
+      chainId,
+      durationMs: Date.now() - startedAt,
+      methods,
+      retryAfter: false,
+      status: 502,
+    });
+    return NextResponse.json(
+      { error: "The Robinhood wallet RPC upstream is unavailable." },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/server/robinhood-rpc-methods.ts
+++ b/lib/server/robinhood-rpc-methods.ts
@@ -1,0 +1,37 @@
+export const ROBINHOOD_READ_METHODS = new Set([
+  "eth_blobBaseFee",
+  "eth_blockNumber",
+  "eth_call",
+  "eth_chainId",
+  "eth_estimateGas",
+  "eth_feeHistory",
+  "eth_gasPrice",
+  "eth_getBalance",
+  "eth_getBlockByHash",
+  "eth_getBlockByNumber",
+  "eth_getBlockReceipts",
+  "eth_getBlockTransactionCountByHash",
+  "eth_getBlockTransactionCountByNumber",
+  "eth_getCode",
+  "eth_getLogs",
+  "eth_getProof",
+  "eth_getStorageAt",
+  "eth_getTransactionByBlockHashAndIndex",
+  "eth_getTransactionByBlockNumberAndIndex",
+  "eth_getTransactionByHash",
+  "eth_getTransactionCount",
+  "eth_getTransactionReceipt",
+  "eth_maxPriorityFeePerGas",
+  "eth_syncing",
+  "net_version",
+  "web3_clientVersion",
+]);
+
+export function isRobinhoodReadRequest(value: unknown): value is { method: string } {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    ROBINHOOD_READ_METHODS.has((value as { method?: unknown }).method as string)
+  );
+}

--- a/lib/server/robinhood-rpc.ts
+++ b/lib/server/robinhood-rpc.ts
@@ -3,11 +3,17 @@ const RPC_ENV_BY_CHAIN: Record<number, string> = {
   46_630: "STATICS_ROBINHOOD_TESTNET_RPC_URL",
 };
 
-export function robinhoodRpcUrl(
+const WALLET_RPC_ENV_BY_CHAIN: Record<number, string> = {
+  4_663: "STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL",
+  46_630: "STATICS_ROBINHOOD_TESTNET_WALLET_RPC_URL",
+};
+
+function configuredRpcUrl(
   chainId: number,
-  environment: Record<string, string | undefined> = process.env
+  variablesByChain: Record<number, string>,
+  environment: Record<string, string | undefined>
 ): string {
-  const variableName = RPC_ENV_BY_CHAIN[chainId];
+  const variableName = variablesByChain[chainId];
   if (!variableName) throw new Error("Unsupported Robinhood chain.");
   const value = environment[variableName]?.trim();
   if (!value) throw new Error(`${variableName} is not configured on the server.`);
@@ -21,4 +27,18 @@ export function robinhoodRpcUrl(
     throw new Error(`${variableName} must be an HTTP(S) URL.`);
   }
   return url.toString();
+}
+
+export function robinhoodRpcUrl(
+  chainId: number,
+  environment: Record<string, string | undefined> = process.env
+): string {
+  return configuredRpcUrl(chainId, RPC_ENV_BY_CHAIN, environment);
+}
+
+export function robinhoodWalletRpcUrl(
+  chainId: number,
+  environment: Record<string, string | undefined> = process.env
+): string {
+  return configuredRpcUrl(chainId, WALLET_RPC_ENV_BY_CHAIN, environment);
 }

--- a/lib/wallet-config.ts
+++ b/lib/wallet-config.ts
@@ -7,6 +7,8 @@ export type WalletNetwork = "robinhood" | "robinhood-testnet" | "anvil";
 // URL and credentials remain server-only; these paths are safe to expose.
 const ROBINHOOD_MAINNET_RPC_PROXY = "/api/rpc/4663";
 const ROBINHOOD_TESTNET_RPC_PROXY = "/api/rpc/46630";
+const ROBINHOOD_MAINNET_WALLET_RPC_PROXY = "/api/wallet-rpc/4663";
+const ROBINHOOD_TESTNET_WALLET_RPC_PROXY = "/api/wallet-rpc/46630";
 
 export const robinhoodMainnet = defineChain({
   id: 4_663,
@@ -100,6 +102,8 @@ export type WalletEnvironment = Readonly<{
   anvilRpcUrl: string;
   defaultChain: Chain;
   supportedChains: readonly [Chain, ...Chain[]];
+  privyDefaultChain: Chain;
+  privySupportedChains: readonly [Chain, ...Chain[]];
   configured: boolean;
 }>;
 
@@ -109,6 +113,16 @@ function chainWithRpc(chain: Chain, rpcUrl: string): Chain {
     rpcUrls: {
       ...chain.rpcUrls,
       default: { http: [rpcUrl] },
+    },
+  };
+}
+
+function chainWithPrivyWalletRpc(chain: Chain, rpcUrl: string): Chain {
+  return {
+    ...chain,
+    rpcUrls: {
+      ...chain.rpcUrls,
+      privyWalletOverride: { http: [rpcUrl] },
     },
   };
 }
@@ -141,6 +155,14 @@ export function readWalletEnvironment(
         ? robinhoodMainnet
         : robinhoodTestnet;
   const publicRobinhoodChains = [robinhoodMainnet, robinhoodTestnet];
+  const privyRobinhoodChains = [
+    chainWithPrivyWalletRpc(robinhoodMainnet, ROBINHOOD_MAINNET_WALLET_RPC_PROXY),
+    chainWithPrivyWalletRpc(robinhoodTestnet, ROBINHOOD_TESTNET_WALLET_RPC_PROXY),
+  ];
+  const privyDefaultChain =
+    network === "anvil"
+      ? configuredAnvil
+      : privyRobinhoodChains.find((chain) => chain.id === defaultChain.id)!;
   return {
     appEnvironment,
     network,
@@ -154,6 +176,14 @@ export function readWalletEnvironment(
       defaultChain,
       ...publicRobinhoodChains.filter((chain) => chain.id !== defaultChain.id),
       ...(appEnvironment === "development" && defaultChain.id !== anvil.id
+        ? [configuredAnvil]
+        : []),
+    ] as [Chain, ...Chain[]],
+    privyDefaultChain,
+    privySupportedChains: [
+      privyDefaultChain,
+      ...privyRobinhoodChains.filter((chain) => chain.id !== privyDefaultChain.id),
+      ...(appEnvironment === "development" && privyDefaultChain.id !== anvil.id
         ? [configuredAnvil]
         : []),
     ] as [Chain, ...Chain[]],

--- a/providers/DAppProviders.tsx
+++ b/providers/DAppProviders.tsx
@@ -58,7 +58,7 @@ const wagmiConfig = createConfig({
   transports,
 });
 const privySupportedChains = [
-  ...walletEnvironment.supportedChains,
+  ...walletEnvironment.privySupportedChains,
   ...fundingNetworks.map((network) => network.chain),
 ].filter(
   (chain, index, chains) => chains.findIndex((candidate) => candidate.id === chain.id) === index
@@ -430,7 +430,7 @@ function ConfiguredWalletProviders({ children }: { children: React.ReactNode }) 
       config={{
         loginMethods: ["wallet", "email"],
         supportedChains: privySupportedChains,
-        defaultChain: walletEnvironment.defaultChain,
+        defaultChain: walletEnvironment.privyDefaultChain,
         embeddedWallets: {
           ethereum: { createOnLogin: "users-without-wallets" },
           solana: { createOnLogin: "off" },

--- a/test/api/rpc-route.test.ts
+++ b/test/api/rpc-route.test.ts
@@ -23,6 +23,20 @@ afterEach(() => {
 });
 
 describe("Robinhood RPC read proxy", () => {
+  it("continues to reject signed transaction broadcasts", async () => {
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_RPC_URL", upstream);
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+
+    const response = await POST(
+      request({ id: 1, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: ["0x01"] }),
+      { params: Promise.resolve({ chainId: "4663" }) }
+    );
+
+    expect(response.status).toBe(403);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("forwards Retry-After and logs only sanitized request metadata", async () => {
     vi.stubEnv("STATICS_ROBINHOOD_MAINNET_RPC_URL", upstream);
     const fetch = vi.fn().mockResolvedValue(

--- a/test/api/wallet-rpc-route.test.ts
+++ b/test/api/wallet-rpc-route.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { privateKeyToAccount } from "viem/accounts";
+
+import { POST } from "@/app/api/wallet-rpc/[chainId]/route";
+
+const upstream = "https://rpc.example/v2/private-wallet-key";
+const account = privateKeyToAccount(`0x${"01".repeat(32)}`);
+
+function request(payload: unknown, origin = "http://localhost") {
+  return new Request("http://localhost/api/wallet-rpc/4663", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      host: "localhost",
+      ...(origin ? { origin } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function signedTransaction(chainId: number) {
+  return account.signTransaction({
+    chainId,
+    gas: 21_000n,
+    maxFeePerGas: 2n,
+    maxPriorityFeePerGas: 1n,
+    nonce: 0,
+    to: "0x1111111111111111111111111111111111111111",
+    type: "eip1559",
+    value: 1n,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("Robinhood embedded-wallet RPC proxy", () => {
+  it("forwards bounded transaction-preparation reads", async () => {
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL", upstream);
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, jsonrpc: "2.0", result: "0x1" }), {
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const response = await POST(
+      request({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "eth_getTransactionCount",
+        params: [account.address, "pending"],
+      }),
+      { params: Promise.resolve({ chainId: "4663" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      upstream,
+      expect.objectContaining({ method: "POST", cache: "no-store" })
+    );
+  });
+
+  it("forwards one valid signed transaction for the requested chain", async () => {
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL", upstream);
+    const raw = await signedTransaction(4_663);
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 2, jsonrpc: "2.0", result: `0x${"22".repeat(32)}` }), {
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const response = await POST(
+      request({ id: 2, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: [raw] }),
+      { params: Promise.resolve({ chainId: "4663" }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects unsigned sends, write batches, malformed signatures, and wrong-chain transactions", async () => {
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL", upstream);
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const raw = await signedTransaction(4_663);
+    const wrongChain = await signedTransaction(46_630);
+
+    const cases = [
+      { id: 1, jsonrpc: "2.0", method: "eth_sendTransaction", params: [{}] },
+      [
+        { id: 2, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: [raw] },
+        { id: 3, jsonrpc: "2.0", method: "eth_chainId", params: [] },
+      ],
+      { id: 4, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: ["0x01"] },
+      { id: 5, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: [wrongChain] },
+    ];
+
+    for (const payload of cases) {
+      const response = await POST(request(payload), {
+        params: Promise.resolve({ chainId: "4663" }),
+      });
+      expect([400, 403]).toContain(response.status);
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("requires the application origin and explicit wallet RPC configuration", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    const noOrigin = await POST(request({ method: "eth_chainId", params: [] }, ""), {
+      params: Promise.resolve({ chainId: "4663" }),
+    });
+    expect(noOrigin.status).toBe(403);
+
+    const crossOrigin = await POST(
+      request({ method: "eth_chainId", params: [] }, "https://attacker.example"),
+      { params: Promise.resolve({ chainId: "4663" }) }
+    );
+    expect(crossOrigin.status).toBe(403);
+
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_RPC_URL", "https://rpc.example/read-only-key");
+    const missingConfiguration = await POST(request({ method: "eth_chainId", params: [] }), {
+      params: Promise.resolve({ chainId: "4663" }),
+    });
+    expect(missingConfiguration.status).toBe(503);
+    expect(await missingConfiguration.json()).toEqual({
+      error: "STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL is not configured on the server.",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards Retry-After and never logs signed data or provider credentials", async () => {
+    vi.stubEnv("STATICS_ROBINHOOD_MAINNET_WALLET_RPC_URL", upstream);
+    const raw = await signedTransaction(4_663);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: { code: 429, message: "rate limited" } }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "2" },
+        })
+      )
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await POST(
+      request({ id: 6, jsonrpc: "2.0", method: "eth_sendRawTransaction", params: [raw] }),
+      { params: Promise.resolve({ chainId: "4663" }) }
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("2");
+    expect(warn).toHaveBeenCalledWith("Robinhood wallet RPC upstream request failed", {
+      batchSize: 1,
+      chainId: 4_663,
+      durationMs: expect.any(Number),
+      methods: ["eth_sendRawTransaction"],
+      retryAfter: true,
+      status: 429,
+    });
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(raw);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("private-wallet-key");
+  });
+});

--- a/test/foundation/wallet-config.test.ts
+++ b/test/foundation/wallet-config.test.ts
@@ -17,6 +17,17 @@ describe("wallet environment", () => {
     expect(environment.configured).toBe(false);
     expect(environment.defaultChain.rpcUrls.default.http).toEqual(["/api/rpc/46630"]);
     expect(environment.supportedChains.map((chain) => chain.id)).toEqual([46_630, 4_663, 31_337]);
+    expect(environment.privyDefaultChain.rpcUrls.default.http).toEqual(["/api/rpc/46630"]);
+    expect(environment.privyDefaultChain.rpcUrls.privyWalletOverride?.http).toEqual([
+      "/api/wallet-rpc/46630",
+    ]);
+    expect(environment.privySupportedChains.map((chain) => chain.id)).toEqual([
+      46_630, 4_663, 31_337,
+    ]);
+    expect(
+      environment.privySupportedChains.find((chain) => chain.id === 4_663)?.rpcUrls
+        .privyWalletOverride?.http
+    ).toEqual(["/api/wallet-rpc/4663"]);
   });
 
   it("accepts Anvil only for local development", () => {
@@ -42,6 +53,8 @@ describe("wallet environment", () => {
     expect(environment.defaultChain.name).toBe("Local Anvil");
     expect(environment.defaultChain.blockExplorers).toBeUndefined();
     expect(environment.defaultChain.rpcUrls.default.http).toEqual(["http://127.0.0.1:8546/"]);
+    expect(environment.privyDefaultChain.rpcUrls.default.http).toEqual(["http://127.0.0.1:8546/"]);
+    expect(environment.privyDefaultChain.rpcUrls.privyWalletOverride).toBeUndefined();
     expect(environment.supportedChains.map((chain) => chain.id)).toEqual([31_337, 4_663, 46_630]);
   });
 


### PR DESCRIPTION
## Summary

- keep the existing Robinhood application RPC proxy read-only
- give Privy embedded wallets a separate server-side RPC path for bounded preparation reads and a single signed raw transaction
- require explicit server-only wallet RPC configuration with no fallback to read RPC credentials
- keep external wallets on their own providers

## Security boundary

- rejects unsigned sends, arbitrary write methods, and batches containing a broadcast
- validates the signed transaction and route chain ID before forwarding
- enforces same-origin browser access and preserves upstream rate-limit metadata
- never exposes provider credentials or signed payloads in logs

## Validation

- npm run lint (passes with one pre-existing warning in an untracked local tool)
- npm run lint:css
- scoped Prettier check (repository-wide check is blocked locally by a protected untracked planning document)
- npm run typecheck
- npm test (125 files, 655 tests)
- npm run build

Closes #65