### PR TITLE
feat(api): expose CoinGecko supply foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ Coinbase ETH/USD may use its last good value for no more than 15 minutes and the
 `null`. Ponder supplies activity and history; onchain reads remain authoritative for reserves,
 supply, vesting, backing, and spot price.
 
+### Public CoinGecko API
+
+The following HTTPS JSON routes are anonymous and do not accept or require an API key:
+
+- `GET /api/coingecko/v1/supply/total` returns `{"result":"1000000000"}` in decimal token
+  units.
+- `GET /api/coingecko/v1/supply/circulating` returns the public tradable supply as
+  `{"result":"<decimal token units>"}`.
+- `GET /api/coingecko/v1/supply` discloses both supplies, all exclusions, the source block,
+  timestamp, and methodology.
+
+Circulating supply is the onchain total supply minus unreleased treasury vesting and Operator Vault
+token backing. Canonical AMM pool inventory remains circulating because it is publicly tradable.
+These fundamentals are read at one block and shared with the Overview dashboard. Supply responses
+cache for five minutes and may use the last successful onchain snapshot for at most 30 minutes
+during an RPC interruption.
+
+All routes allow read-only cross-origin requests. Configure the public reverse proxy or CDN for a
+limit of 60 requests per minute per source IP with a burst of 20. If Cloudflare protects these
+paths, prefer an explicit CoinGecko IP allowlist. Where an IP allowlist is unavailable, skip bot
+challenges only for the exact `/api/coingecko/v1/*` paths when both of these headers are present,
+while retaining the WAF and rate limit:
+
+```text
+X-Requested-With: com.coingecko
+User-Agent: CoinGecko +https://coingecko.com/
+```
+
+The market-data endpoints are documented with the stacked CoinGecko market integration.
+
 ## Connected local environment
 
 The complete local workflow requires a separate clean clone of the public Statics protocol

--- a/app/api/coingecko/v1/supply/circulating/route.ts
+++ b/app/api/coingecko/v1/supply/circulating/route.ts
@@ -1,0 +1,24 @@
+import { coinGeckoCirculatingSupply, coinGeckoSupplyResult } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(
+      coinGeckoSupplyResult(coinGeckoCirculatingSupply(snapshot).toString(), snapshot.decimals),
+      COINGECKO_CACHE.supply
+    );
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/supply/route.ts
+++ b/app/api/coingecko/v1/supply/route.ts
@@ -1,0 +1,21 @@
+import { coinGeckoSupplyDisclosure } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(coinGeckoSupplyDisclosure(snapshot), COINGECKO_CACHE.supply);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/supply/total/route.ts
+++ b/app/api/coingecko/v1/supply/total/route.ts
@@ -1,0 +1,24 @@
+import { coinGeckoSupplyResult } from "@/lib/market/coingecko";
+import { loadCoinGeckoSupply } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const snapshot = await loadCoinGeckoSupply();
+    return coinGeckoJson(
+      coinGeckoSupplyResult(snapshot.total, snapshot.decimals),
+      COINGECKO_CACHE.supply
+    );
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/lib/market/client.ts
+++ b/lib/market/client.ts
@@ -62,6 +62,7 @@ export function isStaticsMarketOverview(value: unknown): value is StaticsMarketO
     unsigned(liquidity.principalStatics) &&
     nullableUnsigned(liquidity.tvlUsdWad) &&
     activity &&
+    typeof activity.available === "boolean" &&
     unsigned(activity.wethVolume) &&
     unsigned(activity.staticsVolume) &&
     ["swaps", "buys", "sells", "priceChangeBps"].every(

--- a/lib/market/coingecko.ts
+++ b/lib/market/coingecko.ts
@@ -1,0 +1,40 @@
+import { formatUnits } from "viem";
+
+import type { MarketSupplySnapshot } from "@/lib/market/types";
+
+export function coinGeckoCirculatingSupply(snapshot: MarketSupplySnapshot): bigint {
+  const total = BigInt(snapshot.total);
+  const excluded = BigInt(snapshot.unreleasedTreasury) + BigInt(snapshot.vaultBacking);
+  if (excluded > total) throw new Error("Circulating-supply exclusions exceed total supply.");
+  return total - excluded;
+}
+
+export function coinGeckoSupplyResult(raw: string, decimals: number): Readonly<{ result: string }> {
+  return { result: formatUnits(BigInt(raw), decimals) };
+}
+
+export function coinGeckoSupplyDisclosure(snapshot: MarketSupplySnapshot) {
+  const circulatingSupply = coinGeckoCirculatingSupply(snapshot);
+  return {
+    schema_version: 1,
+    asset: "STATICS",
+    chain_id: snapshot.chainId,
+    contract_address: snapshot.tokenAddress,
+    decimals: snapshot.decimals,
+    total_supply: formatUnits(BigInt(snapshot.total), snapshot.decimals),
+    circulating_supply: formatUnits(circulatingSupply, snapshot.decimals),
+    public_distributed_supply: formatUnits(BigInt(snapshot.publicDistributed), snapshot.decimals),
+    exclusions: {
+      unreleased_treasury_vesting: formatUnits(
+        BigInt(snapshot.unreleasedTreasury),
+        snapshot.decimals
+      ),
+      operator_vault_backing: formatUnits(BigInt(snapshot.vaultBacking), snapshot.decimals),
+    },
+    methodology:
+      "total_supply - unreleased_treasury_vesting - operator_vault_backing; canonical AMM pool inventory remains circulating because it is publicly tradable",
+    status: snapshot.status,
+    as_of_block: snapshot.asOfBlock,
+    updated_at: snapshot.snapshotAt,
+  } as const;
+}

--- a/lib/market/types.ts
+++ b/lib/market/types.ts
@@ -42,6 +42,7 @@ export type StaticsMarketOverview = Readonly<{
     tvlUsdWad: string | null;
   }>;
   activity24h: Readonly<{
+    available: boolean;
     wethVolume: string;
     staticsVolume: string;
     swaps: number;
@@ -60,4 +61,20 @@ export type StaticsMarketOverview = Readonly<{
     usdPriceAt: string | null;
     usdPriceStale: boolean;
   }>;
+}>;
+
+export type MarketSupplySnapshot = Readonly<{
+  status: "fresh" | "stale";
+  chainId: number;
+  deploymentId: string;
+  tokenAddress: string;
+  decimals: 18;
+  asOfBlock: string;
+  snapshotAt: string;
+  total: string;
+  poolInventory: string;
+  publicDistributed: string;
+  unreleasedTreasury: string;
+  vaultBacking: string;
+  strictLiquidFloat: string;
 }>;

--- a/lib/server/coingecko-market.ts
+++ b/lib/server/coingecko-market.ts
@@ -1,0 +1,5 @@
+import { loadMarketSupplySnapshot } from "@/lib/server/market-overview";
+
+export async function loadCoinGeckoSupply() {
+  return loadMarketSupplySnapshot();
+}

--- a/lib/server/coingecko-route.ts
+++ b/lib/server/coingecko-route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+export const COINGECKO_CACHE = {
+  supply: "public, max-age=60, s-maxage=300, stale-while-revalidate=1800",
+} as const;
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Accept, Content-Type, X-Requested-With",
+} as const;
+
+export function coinGeckoJson(body: unknown, cacheControl: string, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { ...CORS_HEADERS, "Cache-Control": cacheControl },
+  });
+}
+
+export function coinGeckoUnavailable(): NextResponse {
+  return coinGeckoJson({ error: "Market data are temporarily unavailable." }, "no-store", 503);
+}
+
+export function coinGeckoOptions(): NextResponse {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/lib/server/market-overview.ts
+++ b/lib/server/market-overview.ts
@@ -15,7 +15,11 @@ import {
   strictLiquidFloat,
   usdValueWad,
 } from "@/lib/market/analytics";
-import type { MarketDepthLevel, StaticsMarketOverview } from "@/lib/market/types";
+import type {
+  MarketDepthLevel,
+  MarketSupplySnapshot,
+  StaticsMarketOverview,
+} from "@/lib/market/types";
 import { poolKeyForLaunch } from "@/lib/trade/canonical-market";
 import { loadEthUsd } from "@/lib/server/eth-usd";
 import { verifyLaunchDeploymentOnServer } from "@/lib/server/launch-verification";
@@ -30,6 +34,7 @@ const vestingAbi = parseAbi([
 ]);
 
 const SNAPSHOT_TTL_MS = 60_000;
+const SUPPLY_MAX_STALE_MS = 30 * 60_000;
 const DEPTH_TTL_MS = 5 * 60_000;
 const DEPTH_MAX_STALE_MS = 15 * 60_000;
 const DEPTH_TARGETS = [100, 200, 500] as const;
@@ -62,8 +67,29 @@ type DepthCache = Readonly<{
   stale: boolean;
 }>;
 
+type MarketFundamentals = Readonly<{
+  deployment: LaunchDeployment;
+  client: PublicClient;
+  blockNumber: bigint;
+  poolStatics: bigint;
+  poolWeth: bigint;
+  prices: ReturnType<typeof canonicalPrices>;
+  totalSupply: bigint;
+  unreleasedTreasury: bigint;
+  vaultBacking: bigint;
+  publicDistributed: bigint;
+  liquidFloat: bigint;
+}>;
+
+type FundamentalsCache = Readonly<{
+  value: MarketFundamentals;
+  fetchedAt: number;
+}>;
+
 let snapshotCache: Readonly<{ value: StaticsMarketOverview; fetchedAt: number }> | null = null;
 let snapshotInFlight: Promise<StaticsMarketOverview> | null = null;
+let fundamentalsCache: FundamentalsCache | null = null;
+let fundamentalsInFlight: Promise<FundamentalsCache> | null = null;
 let depthCache: DepthCache | null = null;
 let depthInFlight: Promise<DepthCache | null> | null = null;
 
@@ -302,7 +328,7 @@ async function loadDepth(
   return depthInFlight;
 }
 
-async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
+async function refreshFundamentals(now: number): Promise<FundamentalsCache> {
   const deployment = mainnetLaunch();
   const analytics = deployment.analytics!;
   await verifyLaunchDeploymentOnServer(deployment).verification;
@@ -311,7 +337,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
   });
   const blockNumber = await client.getBlockNumber();
   const poolKey = poolKeyForLaunch(deployment);
-  const [pool, accounting, totalSupply, vesting, ethUsd, activity] = await Promise.all([
+  const [pool, accounting, totalSupply, vesting] = await Promise.all([
     client.readContract({
       address: analytics.reservesLens.address,
       abi: reservesLensAbi,
@@ -338,8 +364,6 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
       args: [analytics.treasuryBeneficiary, 0n],
       blockNumber,
     }),
-    loadEthUsd(now),
-    loadActivity(deployment, now),
   ]);
   const staticsIsCurrency0 =
     deployment.market.poolKey.currency0.toLowerCase() ===
@@ -351,17 +375,100 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
     deployment.market.poolKey.currency0,
     deployment.contracts.statics
   );
+  const unreleasedTreasury = vesting[0] > vesting[1] ? vesting[0] - vesting[1] : 0n;
+  return {
+    fetchedAt: now,
+    value: {
+      deployment,
+      client,
+      blockNumber,
+      poolStatics,
+      poolWeth,
+      prices,
+      totalSupply,
+      unreleasedTreasury,
+      vaultBacking: accounting.tokenBacking,
+      publicDistributed: publicDistributedSupply(poolStatics),
+      liquidFloat: strictLiquidFloat(
+        totalSupply,
+        poolStatics,
+        unreleasedTreasury,
+        accounting.tokenBacking
+      ),
+    },
+  };
+}
+
+async function loadFundamentals(now: number, allowStale: boolean): Promise<FundamentalsCache> {
+  if (fundamentalsCache && now - fundamentalsCache.fetchedAt <= SNAPSHOT_TTL_MS) {
+    return fundamentalsCache;
+  }
+  if (!fundamentalsInFlight) {
+    fundamentalsInFlight = refreshFundamentals(now)
+      .then((value) => {
+        fundamentalsCache = value;
+        return value;
+      })
+      .finally(() => {
+        fundamentalsInFlight = null;
+      });
+  }
+  try {
+    return await fundamentalsInFlight;
+  } catch (error) {
+    if (
+      allowStale &&
+      fundamentalsCache &&
+      now - fundamentalsCache.fetchedAt <= SUPPLY_MAX_STALE_MS
+    ) {
+      return fundamentalsCache;
+    }
+    throw error;
+  }
+}
+
+export async function loadMarketSupplySnapshot(now = Date.now()): Promise<MarketSupplySnapshot> {
+  const fundamentals = await loadFundamentals(now, true);
+  const { value } = fundamentals;
+  return {
+    status: now - fundamentals.fetchedAt <= SNAPSHOT_TTL_MS ? "fresh" : "stale",
+    chainId: value.deployment.descriptor.chainId,
+    deploymentId: value.deployment.descriptor.deploymentId,
+    tokenAddress: value.deployment.contracts.statics,
+    decimals: 18,
+    asOfBlock: value.blockNumber.toString(),
+    snapshotAt: new Date(fundamentals.fetchedAt).toISOString(),
+    total: value.totalSupply.toString(),
+    poolInventory: value.poolStatics.toString(),
+    publicDistributed: value.publicDistributed.toString(),
+    unreleasedTreasury: value.unreleasedTreasury.toString(),
+    vaultBacking: value.vaultBacking.toString(),
+    strictLiquidFloat: value.liquidFloat.toString(),
+  };
+}
+
+async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
+  const deployment = mainnetLaunch();
+  const [fundamentals, ethUsd, activity] = await Promise.all([
+    loadFundamentals(now, false),
+    loadEthUsd(now),
+    loadActivity(deployment, now),
+  ]);
+  const {
+    client,
+    blockNumber,
+    poolStatics,
+    poolWeth,
+    prices,
+    totalSupply,
+    unreleasedTreasury,
+    vaultBacking,
+    publicDistributed,
+    liquidFloat,
+  } = fundamentals.value;
   const ethUsdWad = ethUsd?.valueWad ?? null;
   const staticsUsdWad =
     ethUsdWad === null ? null : staticsUsdPriceWad(prices.wethPerStaticsWad, ethUsdWad);
-  const unreleasedTreasury = vesting[0] > vesting[1] ? vesting[0] - vesting[1] : 0n;
-  const publicDistributed = publicDistributedSupply(poolStatics);
-  const liquidFloat = strictLiquidFloat(
-    totalSupply,
-    poolStatics,
-    unreleasedTreasury,
-    accounting.tokenBacking
-  );
   const depth = await loadDepth(
     client,
     deployment,
@@ -393,7 +500,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
       poolInventory: poolStatics.toString(),
       publicDistributed: publicDistributed.toString(),
       unreleasedTreasury: unreleasedTreasury.toString(),
-      vaultBacking: accounting.tokenBacking.toString(),
+      vaultBacking: vaultBacking.toString(),
       strictLiquidFloat: liquidFloat.toString(),
     },
     valuation: {
@@ -413,6 +520,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
     },
     activity24h: activity
       ? {
+          available: true,
           wethVolume: activity.wethVolume.toString(),
           staticsVolume: activity.staticsVolume.toString(),
           swaps: activity.swaps,
@@ -421,6 +529,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
           priceChangeBps: activity.priceChangeBps,
         }
       : {
+          available: false,
           wethVolume: "0",
           staticsVolume: "0",
           swaps: 0,
@@ -457,6 +566,8 @@ export async function loadMarketOverview(now = Date.now()): Promise<StaticsMarke
 export function resetMarketOverviewCacheForTest(): void {
   snapshotCache = null;
   snapshotInFlight = null;
+  fundamentalsCache = null;
+  fundamentalsInFlight = null;
   depthCache = null;
   depthInFlight = null;
 }

--- a/test/api/coingecko-routes.test.ts
+++ b/test/api/coingecko-routes.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadSupply: vi.fn(),
+}));
+
+vi.mock("@/lib/server/coingecko-market", () => ({
+  loadCoinGeckoSupply: mocks.loadSupply,
+}));
+
+import { GET as getSupply } from "@/app/api/coingecko/v1/supply/route";
+import {
+  GET as getCirculating,
+  OPTIONS as optionsCirculating,
+} from "@/app/api/coingecko/v1/supply/circulating/route";
+import { GET as getTotal } from "@/app/api/coingecko/v1/supply/total/route";
+
+const WAD = 10n ** 18n;
+const supply = {
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  tokenAddress: "0x2d8d6F4A93AcD7a916A5a654ec8b690bA3B3EAdd",
+  decimals: 18,
+  asOfBlock: "123",
+  snapshotAt: "2026-09-01T12:00:00.000Z",
+  total: (1_000_000_000n * WAD).toString(),
+  poolInventory: (99_900_000n * WAD).toString(),
+  publicDistributed: (700_100_000n * WAD).toString(),
+  unreleasedTreasury: (100_100_000n * WAD).toString(),
+  vaultBacking: (117_900_000n * WAD).toString(),
+  strictLiquidFloat: (682_100_000n * WAD).toString(),
+};
+
+beforeEach(() => {
+  mocks.loadSupply.mockReset().mockResolvedValue(supply);
+});
+
+describe("public CoinGecko routes", () => {
+  it("serves exact anonymous supply results in decimal token units", async () => {
+    expect(await (await getTotal()).json()).toEqual({ result: "1000000000" });
+    expect(await (await getCirculating()).json()).toEqual({ result: "782000000" });
+    expect(await (await getSupply()).json()).toMatchObject({
+      decimals: 18,
+      total_supply: "1000000000",
+      circulating_supply: "782000000",
+    });
+  });
+
+  it("applies public caching and permissive read-only CORS without authentication", async () => {
+    const circulating = await getCirculating();
+    expect(circulating.status).toBe(200);
+    expect(circulating.headers.get("access-control-allow-origin")).toBe("*");
+    expect(circulating.headers.get("cache-control")).toContain("s-maxage=300");
+
+    const preflight = optionsCirculating();
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+  });
+
+  it("returns a cache-disabled 503 when authoritative dependencies are unavailable", async () => {
+    mocks.loadSupply.mockRejectedValueOnce(new Error("RPC unavailable"));
+    const response = await getCirculating();
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ error: "Market data are temporarily unavailable." });
+  });
+});

--- a/test/components/market-analytics.test.tsx
+++ b/test/components/market-analytics.test.tsx
@@ -37,6 +37,7 @@ const analytics = {
     tvlUsdWad: (2_000_000n * WAD).toString(),
   },
   activity24h: {
+    available: true,
     wethVolume: (40n * WAD).toString(),
     staticsVolume: (10_000_000n * WAD).toString(),
     swaps: 12,
@@ -77,6 +78,8 @@ describe("market analytics panel", () => {
   it("separates valuation, supply, pool principal, and executable depth", () => {
     render(<MarketAnalyticsPanel analytics={analytics} loading={false} error={false} />);
     expect(screen.getByText("Public market cap")).toBeInTheDocument();
+    expect(screen.getByText("STATICS price")).toBeInTheDocument();
+    expect(screen.getByText("24h volume")).toBeInTheDocument();
     expect(screen.getByText("Public distributed supply")).toBeInTheDocument();
     expect(screen.getByText("Strict liquid float")).toBeInTheDocument();
     expect(screen.getByText("Canonical pool principal")).toBeInTheDocument();

--- a/test/market/client.test.ts
+++ b/test/market/client.test.ts
@@ -30,6 +30,7 @@ const fixture = {
   },
   liquidity: { principalWeth: "4", principalStatics: "5", tvlUsdWad: "6" },
   activity24h: {
+    available: true,
     wethVolume: "7",
     staticsVolume: "8",
     swaps: 9,

--- a/test/market/coingecko.test.ts
+++ b/test/market/coingecko.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coinGeckoCirculatingSupply,
+  coinGeckoSupplyDisclosure,
+  coinGeckoSupplyResult,
+} from "@/lib/market/coingecko";
+import type { MarketSupplySnapshot } from "@/lib/market/types";
+
+const WAD = 10n ** 18n;
+const supply = {
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  tokenAddress: "0x2d8d6F4A93AcD7a916A5a654ec8b690bA3B3EAdd",
+  decimals: 18,
+  asOfBlock: "123",
+  snapshotAt: "2026-09-01T12:00:00.000Z",
+  total: (1_000_000_000n * WAD).toString(),
+  poolInventory: (99_900_000n * WAD).toString(),
+  publicDistributed: (700_100_000n * WAD).toString(),
+  unreleasedTreasury: (100_100_000n * WAD).toString(),
+  vaultBacking: (117_900_000n * WAD).toString(),
+  strictLiquidFloat: (682_100_000n * WAD).toString(),
+} satisfies MarketSupplySnapshot;
+
+describe("CoinGecko market payloads", () => {
+  it("keeps publicly tradable AMM inventory in circulating supply", () => {
+    expect(coinGeckoCirculatingSupply(supply)).toBe(782_000_000n * WAD);
+    expect(coinGeckoSupplyResult(supply.total, supply.decimals)).toEqual({
+      result: "1000000000",
+    });
+    expect(
+      coinGeckoSupplyResult(coinGeckoCirculatingSupply(supply).toString(), supply.decimals)
+    ).toEqual({
+      result: "782000000",
+    });
+    expect(coinGeckoSupplyDisclosure(supply)).toMatchObject({
+      total_supply: "1000000000",
+      circulating_supply: "782000000",
+      exclusions: {
+        unreleased_treasury_vesting: "100100000",
+        operator_vault_backing: "117900000",
+      },
+      as_of_block: "123",
+    });
+  });
+
+  it("rejects impossible exclusion totals", () => {
+    expect(() =>
+      coinGeckoCirculatingSupply({ ...supply, vaultBacking: (1_000_000_000n * WAD).toString() })
+    ).toThrow("Circulating-supply exclusions exceed total supply.");
+  });
+});

--- a/test/server/market-overview.test.ts
+++ b/test/server/market-overview.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getBlockNumber: vi.fn(),
+  readContract: vi.fn(),
+  simulateContract: vi.fn(),
+  loadEthUsd: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const original = await importOriginal<typeof import("viem")>();
+  return {
+    ...original,
+    createPublicClient: () => ({
+      getBlockNumber: mocks.getBlockNumber,
+      readContract: mocks.readContract,
+      simulateContract: mocks.simulateContract,
+    }),
+    http: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/eth-usd", () => ({ loadEthUsd: mocks.loadEthUsd }));
+vi.mock("@/lib/server/launch-verification", () => ({
+  verifyLaunchDeploymentOnServer: () => ({ status: "hit", verification: Promise.resolve() }),
+}));
+vi.mock("@/lib/server/robinhood-rpc", () => ({
+  robinhoodRpcUrl: () => "https://rpc.example",
+}));
+vi.mock("@/lib/server/statics-indexer-url", () => ({
+  staticsMainnetIndexerUrl: () => new URL("https://indexer.example/market/candles"),
+}));
+
+import {
+  loadMarketOverview,
+  loadMarketSupplySnapshot,
+  resetMarketOverviewCacheForTest,
+} from "@/lib/server/market-overview";
+
+const WAD = 10n ** 18n;
+const NOW = Date.parse("2026-09-01T12:00:00.000Z");
+
+beforeEach(() => {
+  resetMarketOverviewCacheForTest();
+  mocks.getBlockNumber.mockReset().mockResolvedValue(123n);
+  mocks.readContract.mockReset().mockImplementation(({ functionName }) => {
+    if (functionName === "getPoolTVL") {
+      return Promise.resolve({
+        coreAmount0: 400n * WAD,
+        coreAmount1: 99_900_000n * WAD,
+        sqrtPriceX96: 1n << 96n,
+      });
+    }
+    if (functionName === "vaultAccounting") {
+      return Promise.resolve({ tokenBacking: 117_900_000n * WAD });
+    }
+    if (functionName === "totalSupply") return Promise.resolve(1_000_000_000n * WAD);
+    if (functionName === "vestingOf") return Promise.resolve([100_100_000n * WAD, 0n]);
+    throw new Error(`Unexpected read: ${String(functionName)}`);
+  });
+  mocks.simulateContract.mockReset().mockRejectedValue(new Error("Quoter unavailable"));
+  mocks.loadEthUsd.mockReset().mockResolvedValue(null);
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ items: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  );
+});
+
+describe("shared market fundamentals", () => {
+  it("serves supply without indexer, USD, or Quoter calls and reuses reads for the overview", async () => {
+    const supply = await loadMarketSupplySnapshot(NOW);
+    expect(supply).toMatchObject({
+      status: "fresh",
+      asOfBlock: "123",
+      strictLiquidFloat: (682_100_000n * WAD).toString(),
+    });
+    expect(mocks.readContract).toHaveBeenCalledTimes(4);
+    expect(mocks.loadEthUsd).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.simulateContract).not.toHaveBeenCalled();
+
+    await loadMarketOverview(NOW);
+    expect(mocks.readContract).toHaveBeenCalledTimes(4);
+    expect(mocks.loadEthUsd).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses a last-good supply snapshot only within the bounded stale window", async () => {
+    await loadMarketSupplySnapshot(NOW);
+    mocks.readContract.mockRejectedValue(new Error("RPC unavailable"));
+    expect(await loadMarketSupplySnapshot(NOW + 61_000)).toMatchObject({ status: "stale" });
+    await expect(loadMarketSupplySnapshot(NOW + 30 * 60_000 + 1)).rejects.toThrow(
+      "RPC unavailable"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- share one block-pinned market fundamentals snapshot between Overview and public adapters
- expose anonymous total, circulating, and disclosed supply endpoints with read-only CORS and bounded caching
- define CoinGecko circulating supply as total supply less unreleased treasury vesting and locked Operator Vault backing while retaining tradable AMM inventory

## Validation

- `npm run lint` (passes with one pre-existing warning in `.local-tools/genesis-launch-dashboard/simulator.mjs`)
- tracked-file Prettier check
- `npm run typecheck`
- `npm test` (128 files, 662 tests)
- project PR-readiness check from a clean validation worktree

## Stack

This replaces PR #64 on top of post-#67 `master`. The CoinGecko market/indexer implementation will be opened as a dependent PR against this branch.
