### PR TITLE
feat(api): complete CoinGecko market feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ The following HTTPS JSON routes are anonymous and do not accept or require an AP
 - `GET /api/coingecko/v1/tickers` returns the canonical STATICS/WETH market as a one-item array.
 - `GET /api/coingecko/v1/historical_trades?ticker_id=<id>` returns completed trades split into
   `buy` and `sell` arrays.
-- `GET /api/coingecko/v1/status` reports the public market feed's chain, deployment, source block,
-  latest indexed trade, and index lag.
+- `GET /api/coingecko/v1/status` reports the public market feed's chain, deployment, RPC source
+  block, Ponder indexed block/time, latest indexed trade, and actual index lag.
 
 Circulating supply is the onchain total supply minus unreleased treasury vesting and Operator Vault
 token backing. Canonical AMM pool inventory remains circulating because it is publicly tradable.

--- a/README.md
+++ b/README.md
@@ -155,12 +155,36 @@ The following HTTPS JSON routes are anonymous and do not accept or require an AP
   `{"result":"<decimal token units>"}`.
 - `GET /api/coingecko/v1/supply` discloses both supplies, all exclusions, the source block,
   timestamp, and methodology.
+- `GET /api/coingecko/v1/tickers` returns the canonical STATICS/WETH market as a one-item array.
+- `GET /api/coingecko/v1/historical_trades?ticker_id=<id>` returns completed trades split into
+  `buy` and `sell` arrays.
+- `GET /api/coingecko/v1/status` reports the public market feed's chain, deployment, source block,
+  latest indexed trade, and index lag.
 
 Circulating supply is the onchain total supply minus unreleased treasury vesting and Operator Vault
 token backing. Canonical AMM pool inventory remains circulating because it is publicly tradable.
 These fundamentals are read at one block and shared with the Overview dashboard. Supply responses
 cache for five minutes and may use the last successful onchain snapshot for at most 30 minutes
 during an RPC interruption.
+
+The ticker ID is the lowercase STATICS contract address, an underscore, and the lowercase WETH
+contract address. Ticker values use decimal token units. `last_price`, `high`, and `low` are
+transaction prices in WETH per STATICS; volumes are rolling single-sided 24-hour STATICS and WETH
+amounts. `bid` and `ask` are fee-inclusive executable prices for matching 0.01 WETH notionals from
+the canonical Uniswap v4 Quoter. Their server result is shared for one minute, so polling never
+starts the multi-level market-depth search.
+
+Historical trades accept optional `type=buy|sell`, `limit` from 1 through 500 (default 200), and
+inclusive `start_time`/`end_time` Unix timestamps in seconds. Results are newest first. A trade ID
+is the safe integer `blockNumber * 1,000,000 + logIndex`, which is deterministic per onchain event.
+The public CoinGecko history limit does not change the authenticated `/api/market/v1/swaps` limit.
+
+Statics is an AMM, so it does not expose a synthetic orderbook. The canonical 2% depth methodology
+uses the Uniswap v4 Quoter in each direction and finds the largest exact-input trade whose
+fee-adjusted execution price remains within 2% of the current pool price. This reflects executable
+concentrated liquidity rather than a Uniswap v2 constant-product approximation. The richer 1%, 2%,
+and 5% depth calculation remains available on the Statics Overview interface and is not performed
+for each CoinGecko ticker request.
 
 All routes allow read-only cross-origin requests. Configure the public reverse proxy or CDN for a
 limit of 60 requests per minute per source IP with a burst of 20. If Cloudflare protects these
@@ -173,7 +197,11 @@ X-Requested-With: com.coingecko
 User-Agent: CoinGecko +https://coingecko.com/
 ```
 
-The market-data endpoints are documented with the stacked CoinGecko market integration.
+Ticker responses cache for one minute with a bounded five-minute last-good fallback. Historical
+responses cache for 15 seconds and status responses for 30 seconds. Missing mandatory market data
+returns `503` rather than publishing an indexer outage as zero activity. A real 24-hour period with
+no trades returns zero volumes and omits high/low; the last all-time indexed trade remains the
+ticker's last price.
 
 ## Connected local environment
 

--- a/app/(dapp)/app/app.css
+++ b/app/(dapp)/app/app.css
@@ -1796,6 +1796,49 @@
   min-width: 0;
 }
 
+.trade-market-stats {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-md);
+  background: var(--app-border);
+}
+
+.trade-market-stats > div {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.7rem;
+  background: var(--app-surface);
+}
+
+.trade-market-stats span,
+.trade-market-stats p {
+  color: var(--app-text-muted);
+  font-size: var(--text-xs);
+}
+
+.trade-market-stats strong {
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.trade-market-stats p {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 0.65rem;
+  background: var(--app-surface);
+}
+
+@media (max-width: 560px) {
+  .trade-market-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .wallet-network-row {
   display: flex;
   gap: 0.75rem;

--- a/app/api/coingecko/v1/historical_trades/route.ts
+++ b/app/api/coingecko/v1/historical_trades/route.ts
@@ -1,0 +1,26 @@
+import { parseCoinGeckoHistoricalTradeQuery } from "@/lib/market/coingecko-query";
+import { coinGeckoSpotMarket, loadCoinGeckoHistoricalTrades } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoBadRequest,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  const parsed = parseCoinGeckoHistoricalTradeQuery(request.url, coinGeckoSpotMarket().tickerId);
+  if (!parsed.ok) return coinGeckoBadRequest(parsed.error);
+  try {
+    return coinGeckoJson(
+      await loadCoinGeckoHistoricalTrades(parsed.query),
+      COINGECKO_CACHE.history
+    );
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/status/route.ts
+++ b/app/api/coingecko/v1/status/route.ts
@@ -1,0 +1,19 @@
+import { loadCoinGeckoStatus } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return coinGeckoJson(await loadCoinGeckoStatus(), COINGECKO_CACHE.status);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/coingecko/v1/tickers/route.ts
+++ b/app/api/coingecko/v1/tickers/route.ts
@@ -1,0 +1,19 @@
+import { loadCoinGeckoTickers } from "@/lib/server/coingecko-market";
+import {
+  COINGECKO_CACHE,
+  coinGeckoJson,
+  coinGeckoOptions,
+  coinGeckoUnavailable,
+} from "@/lib/server/coingecko-route";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return coinGeckoJson(await loadCoinGeckoTickers(), COINGECKO_CACHE.ticker);
+  } catch {
+    return coinGeckoUnavailable();
+  }
+}
+
+export const OPTIONS = coinGeckoOptions;

--- a/app/api/market/spot/route.ts
+++ b/app/api/market/spot/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { loadMarketSpotOverview } from "@/lib/server/market-overview";
+
+export const runtime = "nodejs";
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    return NextResponse.json(await loadMarketSpotOverview(), {
+      headers: { "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=120" },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Market analytics are unavailable." },
+      { status: 503, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+}

--- a/components/overview/DeploymentOverview.tsx
+++ b/components/overview/DeploymentOverview.tsx
@@ -75,6 +75,10 @@ function volumeUsd(data: StaticsMarketOverview): string | null {
   ).toString();
 }
 
+function wethPerStatics(value: string | null): string {
+  return value === null ? "—" : `${formatTokenAmountGrouped(BigInt(value), 18, 10)} WETH`;
+}
+
 export function MarketAnalyticsPanel({
   analytics,
   loading,
@@ -123,6 +127,9 @@ export function MarketAnalyticsPanel({
               ? `${change > 0 ? "+" : ""}${(change / 100).toFixed(2)}% ${t("last24h")}`
               : "—"}
           </small>
+          <small>
+            {analytics ? wethPerStatics(analytics.activity24h.lastWethPerStaticsWad) : "—"}
+          </small>
         </article>
         <article>
           <span>{t("publicMarketCap")}</span>
@@ -138,6 +145,20 @@ export function MarketAnalyticsPanel({
           <span>{t("volume24h")}</span>
           <strong>{analytics ? usdWad(volumeUsd(analytics)) : "—"}</strong>
           <small>{analytics ? t("swapCount", { count: analytics.activity24h.swaps }) : "—"}</small>
+        </article>
+        <article>
+          <span>{t("high24h")}</span>
+          <strong>
+            {analytics ? wethPerStatics(analytics.activity24h.highWethPerStaticsWad) : "—"}
+          </strong>
+          <small>{t("perStatics")}</small>
+        </article>
+        <article>
+          <span>{t("low24h")}</span>
+          <strong>
+            {analytics ? wethPerStatics(analytics.activity24h.lowWethPerStaticsWad) : "—"}
+          </strong>
+          <small>{t("perStatics")}</small>
         </article>
       </div>
 

--- a/components/swap/SwapPage.tsx
+++ b/components/swap/SwapPage.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { EmptyState } from "@/components/common/EmptyState";
 import { GenesisVaultSwapPanel } from "@/components/genesis/GenesisVaultSwapPanel";
 import { EvmSwapPanel } from "@/components/portal/EvmSwapPanel";
+import { TradeMarketStats } from "@/components/swap/TradeMarketStats";
 import { useDeployment } from "@/providers/deployment-context";
 
 type SwapMode = "token" | "nft";
@@ -32,6 +33,7 @@ export function SwapPage() {
 
   return (
     <div className="swap-page">
+      <TradeMarketStats deploymentId={active.descriptor.deploymentId} />
       <div className="portal-direction-tabs" role="tablist" aria-label={t("swapType")}>
         {(["token", "nft"] as const).map((item) => (
           <button

--- a/components/swap/TradeMarketStats.tsx
+++ b/components/swap/TradeMarketStats.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { formatUnits } from "viem";
+
+import { loadMarketSpotOverview } from "@/lib/market/client";
+import type { StaticsMarketOverview } from "@/lib/market/types";
+import { formatTokenAmountGrouped } from "@/lib/protocol/ux";
+
+function wethPrice(value: string | null): string {
+  return value === null ? "—" : formatTokenAmountGrouped(BigInt(value), 18, 10);
+}
+
+function usd(value: string | null): string {
+  if (value === null) return "—";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 2,
+  }).format(Number(formatUnits(BigInt(value), 18)));
+}
+
+function volumeUsd(data: StaticsMarketOverview): string | null {
+  if (data.price.ethUsdWad === null) return null;
+  return (
+    (BigInt(data.activity24h.wethVolume) * BigInt(data.price.ethUsdWad)) /
+    10n ** 18n
+  ).toString();
+}
+
+export function TradeMarketStats({ deploymentId }: { deploymentId: string }) {
+  const t = useTranslations("trade");
+  const market = useQuery({
+    queryKey: ["market-spot-overview", deploymentId],
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    retry: 1,
+    queryFn: ({ signal }) => loadMarketSpotOverview(signal),
+  });
+  const data = market.data;
+
+  return (
+    <section
+      className="trade-market-stats"
+      aria-label={t("marketStats")}
+      aria-busy={market.isLoading}
+    >
+      <div>
+        <span>{t("lastPrice")}</span>
+        <strong>{data ? wethPrice(data.activity24h.lastWethPerStaticsWad) : "—"}</strong>
+      </div>
+      <div>
+        <span>{t("high24h")}</span>
+        <strong>{data ? wethPrice(data.activity24h.highWethPerStaticsWad) : "—"}</strong>
+      </div>
+      <div>
+        <span>{t("low24h")}</span>
+        <strong>{data ? wethPrice(data.activity24h.lowWethPerStaticsWad) : "—"}</strong>
+      </div>
+      <div>
+        <span>{t("volume24h")}</span>
+        <strong>{data ? usd(volumeUsd(data)) : "—"}</strong>
+      </div>
+      <div>
+        <span>{t("liquidity")}</span>
+        <strong>{data ? usd(data.liquidity.tvlUsdWad) : "—"}</strong>
+      </div>
+      {market.isError && <p role="status">{t("marketStatsUnavailable")}</p>}
+    </section>
+  );
+}

--- a/lib/market/analytics.ts
+++ b/lib/market/analytics.ts
@@ -29,6 +29,14 @@ export function canonicalPrices(
   };
 }
 
+export function canonicalWethPerStaticsFromPrice1Per0(
+  price1Per0Wad: bigint,
+  staticsIsCurrency0: boolean
+): bigint {
+  if (price1Per0Wad <= 0n) throw new Error("Indexed execution price must be positive.");
+  return staticsIsCurrency0 ? price1Per0Wad : (WAD * WAD) / price1Per0Wad;
+}
+
 export function usdValueWad(amount: bigint, tokenUsdWad: bigint): bigint {
   return (amount * tokenUsdWad) / WAD;
 }

--- a/lib/market/client.ts
+++ b/lib/market/client.ts
@@ -65,6 +65,10 @@ export function isStaticsMarketOverview(value: unknown): value is StaticsMarketO
     typeof activity.available === "boolean" &&
     unsigned(activity.wethVolume) &&
     unsigned(activity.staticsVolume) &&
+    nullableUnsigned(activity.highWethPerStaticsWad) &&
+    nullableUnsigned(activity.lowWethPerStaticsWad) &&
+    nullableUnsigned(activity.lastWethPerStaticsWad) &&
+    (activity.lastTradeAt === null || typeof activity.lastTradeAt === "string") &&
     ["swaps", "buys", "sells", "priceChangeBps"].every(
       (key) => typeof activity[key] === "number" && Number.isSafeInteger(activity[key])
     ) &&
@@ -83,8 +87,8 @@ export function isStaticsMarketOverview(value: unknown): value is StaticsMarketO
   );
 }
 
-export async function loadMarketOverview(signal?: AbortSignal): Promise<StaticsMarketOverview> {
-  const response = await fetch("/api/market/overview", {
+async function loadMarket(path: string, signal?: AbortSignal): Promise<StaticsMarketOverview> {
+  const response = await fetch(path, {
     headers: { accept: "application/json" },
     signal,
   });
@@ -93,4 +97,12 @@ export async function loadMarketOverview(signal?: AbortSignal): Promise<StaticsM
     throw new Error("The market analytics response is unavailable or invalid.");
   }
   return payload;
+}
+
+export function loadMarketOverview(signal?: AbortSignal): Promise<StaticsMarketOverview> {
+  return loadMarket("/api/market/overview", signal);
+}
+
+export function loadMarketSpotOverview(signal?: AbortSignal): Promise<StaticsMarketOverview> {
+  return loadMarket("/api/market/spot", signal);
 }

--- a/lib/market/coingecko-query.ts
+++ b/lib/market/coingecko-query.ts
@@ -1,0 +1,51 @@
+import type { CoinGeckoTradeSide } from "@/lib/market/coingecko";
+
+export type CoinGeckoHistoricalTradeQuery = Readonly<{
+  limit: number;
+  from?: string;
+  to?: string;
+  side?: CoinGeckoTradeSide;
+}>;
+
+export function parseCoinGeckoHistoricalTradeQuery(
+  requestUrl: string,
+  expectedTickerId: string
+):
+  | Readonly<{ ok: true; query: CoinGeckoHistoricalTradeQuery }>
+  | Readonly<{ ok: false; error: string }> {
+  const params = new URL(requestUrl).searchParams;
+  const tickerId = params.get("ticker_id");
+  if (!tickerId || tickerId.toLowerCase() !== expectedTickerId.toLowerCase()) {
+    return { ok: false, error: "ticker_id must identify the canonical STATICS/WETH market." };
+  }
+
+  const rawLimit = params.get("limit");
+  const limit = rawLimit === null ? 200 : /^\d+$/.test(rawLimit) ? Number(rawLimit) : 0;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 500) {
+    return { ok: false, error: "limit must be an integer from 1 through 500." };
+  }
+
+  const rawSide = params.get("type");
+  if (rawSide !== null && rawSide !== "buy" && rawSide !== "sell") {
+    return { ok: false, error: "type must be buy or sell." };
+  }
+
+  const from = params.get("start_time") ?? undefined;
+  const to = params.get("end_time") ?? undefined;
+  if ((from !== undefined && !/^\d+$/.test(from)) || (to !== undefined && !/^\d+$/.test(to))) {
+    return { ok: false, error: "start_time and end_time must be Unix timestamps in seconds." };
+  }
+  if (from !== undefined && to !== undefined && BigInt(to) < BigInt(from)) {
+    return { ok: false, error: "end_time must not precede start_time." };
+  }
+
+  return {
+    ok: true,
+    query: {
+      limit,
+      ...(from === undefined ? {} : { from }),
+      ...(to === undefined ? {} : { to }),
+      ...(rawSide === null ? {} : { side: rawSide }),
+    },
+  };
+}

--- a/lib/market/coingecko.ts
+++ b/lib/market/coingecko.ts
@@ -1,6 +1,118 @@
-import { formatUnits } from "viem";
+import { formatUnits, type Address, type Hex } from "viem";
 
-import type { MarketSupplySnapshot } from "@/lib/market/types";
+import { canonicalWethPerStaticsFromPrice1Per0 } from "@/lib/market/analytics";
+import type { MarketSupplySnapshot, StaticsMarketOverview } from "@/lib/market/types";
+
+export type CoinGeckoSpotMarket = Readonly<{
+  tickerId: string;
+  baseCurrency: Address;
+  targetCurrency: Address;
+  poolId: Hex;
+  staticsIsCurrency0: boolean;
+}>;
+
+export type IndexedMarketTrade = Readonly<{
+  poolId: string;
+  amount0: string;
+  amount1: string;
+  volume0: string;
+  volume1: string;
+  price1Per0Wad: string;
+  transactionHash: string;
+  blockNumber: string;
+  blockTimestamp: string;
+  logIndex: number;
+}>;
+
+export type CoinGeckoTradeSide = "buy" | "sell";
+
+export function coinGeckoTickerId(base: Address, target: Address): string {
+  return `${base.toLowerCase()}_${target.toLowerCase()}`;
+}
+
+function decimalWad(raw: bigint): string {
+  return formatUnits(raw, 18);
+}
+
+function coinGeckoTradeId(blockNumber: bigint, logIndex: number): number {
+  if (!Number.isSafeInteger(logIndex) || logIndex < 0 || logIndex >= 1_000_000) {
+    throw new Error("Trade log index is outside the supported range.");
+  }
+  const value = blockNumber * 1_000_000n + BigInt(logIndex);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("Trade identifier exceeds the JSON safe-integer range.");
+  }
+  return Number(value);
+}
+
+export function coinGeckoTrade(trade: IndexedMarketTrade, market: CoinGeckoSpotMarket) {
+  const staticsAmount = BigInt(market.staticsIsCurrency0 ? trade.amount0 : trade.amount1);
+  const staticsVolume = BigInt(market.staticsIsCurrency0 ? trade.volume0 : trade.volume1);
+  const wethVolume = BigInt(market.staticsIsCurrency0 ? trade.volume1 : trade.volume0);
+  const price = canonicalWethPerStaticsFromPrice1Per0(
+    BigInt(trade.price1Per0Wad),
+    market.staticsIsCurrency0
+  );
+  const type: CoinGeckoTradeSide = staticsAmount < 0n ? "buy" : "sell";
+  return {
+    trade_id: coinGeckoTradeId(BigInt(trade.blockNumber), trade.logIndex),
+    price: decimalWad(price),
+    base_volume: decimalWad(staticsVolume),
+    target_volume: decimalWad(wethVolume),
+    trade_timestamp: trade.blockTimestamp,
+    type,
+  } as const;
+}
+
+export function coinGeckoHistoricalTrades(
+  trades: readonly IndexedMarketTrade[],
+  market: CoinGeckoSpotMarket,
+  side?: CoinGeckoTradeSide
+) {
+  const result = {
+    buy: [] as ReturnType<typeof coinGeckoTrade>[],
+    sell: [] as ReturnType<typeof coinGeckoTrade>[],
+  };
+  for (const trade of trades) {
+    const converted = coinGeckoTrade(trade, market);
+    if (side && converted.type !== side) continue;
+    result[converted.type].push(converted);
+  }
+  return result;
+}
+
+export function coinGeckoTicker(
+  overview: StaticsMarketOverview,
+  market: CoinGeckoSpotMarket,
+  quote: Readonly<{ bidWethPerStaticsWad: bigint | null; askWethPerStaticsWad: bigint | null }>,
+  lastTradeWethPerStaticsWad: bigint | null = null
+) {
+  if (!overview.activity24h.available || overview.liquidity.tvlUsdWad === null) {
+    throw new Error("Public ticker dependencies are unavailable.");
+  }
+  const lastPrice = overview.activity24h.lastWethPerStaticsWad
+    ? BigInt(overview.activity24h.lastWethPerStaticsWad)
+    : lastTradeWethPerStaticsWad;
+  if (lastPrice === null || lastPrice <= 0n) {
+    throw new Error("The last transacted market price is unavailable.");
+  }
+  const high = overview.activity24h.highWethPerStaticsWad;
+  const low = overview.activity24h.lowWethPerStaticsWad;
+  return {
+    ticker_id: market.tickerId,
+    base_currency: market.baseCurrency.toLowerCase(),
+    target_currency: market.targetCurrency.toLowerCase(),
+    pool_id: market.poolId.toLowerCase(),
+    last_price: decimalWad(lastPrice),
+    base_volume: formatUnits(BigInt(overview.activity24h.staticsVolume), 18),
+    target_volume: formatUnits(BigInt(overview.activity24h.wethVolume), 18),
+    liquidity_in_usd: formatUnits(BigInt(overview.liquidity.tvlUsdWad), 18),
+    ...(quote.bidWethPerStaticsWad === null ? {} : { bid: decimalWad(quote.bidWethPerStaticsWad) }),
+    ...(quote.askWethPerStaticsWad === null ? {} : { ask: decimalWad(quote.askWethPerStaticsWad) }),
+    ...(high === null ? {} : { high: decimalWad(BigInt(high)) }),
+    ...(low === null ? {} : { low: decimalWad(BigInt(low)) }),
+  } as const;
+}
 
 export function coinGeckoCirculatingSupply(snapshot: MarketSupplySnapshot): bigint {
   const total = BigInt(snapshot.total);

--- a/lib/market/types.ts
+++ b/lib/market/types.ts
@@ -49,6 +49,10 @@ export type StaticsMarketOverview = Readonly<{
     buys: number;
     sells: number;
     priceChangeBps: number;
+    highWethPerStaticsWad: string | null;
+    lowWethPerStaticsWad: string | null;
+    lastWethPerStaticsWad: string | null;
+    lastTradeAt: string | null;
   }>;
   depth: Readonly<{
     buyStatics: readonly MarketDepthLevel[];

--- a/lib/server/coingecko-market.ts
+++ b/lib/server/coingecko-market.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http } from "viem";
+import { createPublicClient, http, isHex, size } from "viem";
 
 import { v4QuoterAbi } from "@statics-protocol/sdk";
 
@@ -59,9 +59,13 @@ function isUnsigned(value: unknown): value is string {
 function validIndexedTrade(value: unknown): value is IndexedMarketTrade {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const row = value as Record<string, unknown>;
-  return (
+  const primitivesValid =
     typeof row.poolId === "string" &&
+    isHex(row.poolId, { strict: true }) &&
+    size(row.poolId) === 32 &&
     typeof row.transactionHash === "string" &&
+    isHex(row.transactionHash, { strict: true }) &&
+    size(row.transactionHash) === 32 &&
     [
       "amount0",
       "amount1",
@@ -77,7 +81,18 @@ function validIndexedTrade(value: unknown): value is IndexedMarketTrade {
     ) &&
     typeof row.logIndex === "number" &&
     Number.isSafeInteger(row.logIndex) &&
-    row.logIndex >= 0
+    row.logIndex >= 0;
+  if (!primitivesValid) return false;
+  const amount0 = BigInt(row.amount0 as string);
+  const amount1 = BigInt(row.amount1 as string);
+  const volume0 = BigInt(row.volume0 as string);
+  const volume1 = BigInt(row.volume1 as string);
+  return (
+    amount0 !== 0n &&
+    amount1 !== 0n &&
+    (amount0 < 0n ? -amount0 : amount0) === volume0 &&
+    (amount1 < 0n ? -amount1 : amount1) === volume1 &&
+    BigInt(row.price1Per0Wad as string) > 0n
   );
 }
 
@@ -244,8 +259,10 @@ export async function loadCoinGeckoStatus(now = Date.now()) {
     Array.isArray(block) ||
     typeof (block as { number?: unknown }).number !== "number" ||
     !Number.isSafeInteger((block as { number: number }).number) ||
+    (block as { number: number }).number < 0 ||
     typeof (block as { timestamp?: unknown }).timestamp !== "number" ||
-    !Number.isSafeInteger((block as { timestamp: number }).timestamp)
+    !Number.isSafeInteger((block as { timestamp: number }).timestamp) ||
+    (block as { timestamp: number }).timestamp < 0
   ) {
     throw new Error("The indexer status response is unavailable or invalid.");
   }

--- a/lib/server/coingecko-market.ts
+++ b/lib/server/coingecko-market.ts
@@ -91,6 +91,7 @@ async function loadIndexedTrades(
 ) {
   const url = staticsMainnetIndexerUrl("market/trades");
   url.searchParams.set("limit", String(query.limit));
+  url.searchParams.set("pool", coinGeckoSpotMarket().poolId);
   if (query.from !== undefined) url.searchParams.set("from", query.from);
   if (query.to !== undefined) url.searchParams.set("to", query.to);
   if (query.amount0Sign !== undefined) url.searchParams.set("amount0Sign", query.amount0Sign);
@@ -215,18 +216,52 @@ export async function loadCoinGeckoHistoricalTrades(
 }
 
 export async function loadCoinGeckoStatus(now = Date.now()) {
-  const overview = await loadMarketSpotOverview(now);
+  const [overview, indexerResponse] = await Promise.all([
+    loadMarketSpotOverview(now),
+    fetch(staticsMainnetIndexerUrl("status"), {
+      headers: { accept: "application/json" },
+      cache: "no-store",
+      signal: AbortSignal.timeout(4_000),
+    }),
+  ]);
   if (!overview.activity24h.available) throw new Error("Indexed market activity is unavailable.");
+  const indexer: unknown = indexerResponse.ok ? await indexerResponse.json() : null;
+  const active =
+    indexer && typeof indexer === "object" && !Array.isArray(indexer)
+      ? (indexer as { active?: unknown }).active
+      : null;
+  const block =
+    active && typeof active === "object" && !Array.isArray(active)
+      ? (active as { block?: unknown }).block
+      : null;
+  if (
+    !active ||
+    typeof active !== "object" ||
+    Array.isArray(active) ||
+    (active as { id?: unknown }).id !== overview.chainId ||
+    !block ||
+    typeof block !== "object" ||
+    Array.isArray(block) ||
+    typeof (block as { number?: unknown }).number !== "number" ||
+    !Number.isSafeInteger((block as { number: number }).number) ||
+    typeof (block as { timestamp?: unknown }).timestamp !== "number" ||
+    !Number.isSafeInteger((block as { timestamp: number }).timestamp)
+  ) {
+    throw new Error("The indexer status response is unavailable or invalid.");
+  }
+  const indexedBlock = (block as { number: number; timestamp: number }).number;
+  const indexedTimestamp = (block as { number: number; timestamp: number }).timestamp;
   const indexedAt = overview.activity24h.lastTradeAt;
   return {
     ok: true,
     chain_id: overview.chainId,
     deployment_id: overview.deploymentId,
-    as_of_block: overview.asOfBlock,
+    rpc_as_of_block: overview.asOfBlock,
+    indexed_block: String(indexedBlock),
+    indexed_at: new Date(indexedTimestamp * 1_000).toISOString(),
     last_trade_at: indexedAt,
-    observed_at: overview.freshness.snapshotAt,
-    lag_seconds:
-      indexedAt === null ? null : Math.max(0, Math.floor((now - Date.parse(indexedAt)) / 1_000)),
+    observed_at: new Date(now).toISOString(),
+    lag_seconds: Math.max(0, Math.floor(now / 1_000) - indexedTimestamp),
   } as const;
 }
 

--- a/lib/server/coingecko-market.ts
+++ b/lib/server/coingecko-market.ts
@@ -1,5 +1,236 @@
-import { loadMarketSupplySnapshot } from "@/lib/server/market-overview";
+import { createPublicClient, http } from "viem";
+
+import { v4QuoterAbi } from "@statics-protocol/sdk";
+
+import { deploymentRegistry, ROBINHOOD_GENESIS_DEPLOYMENT_ID } from "@/lib/deployments/registry";
+import type { LaunchDeployment } from "@/lib/deployments/types";
+import { canonicalWethPerStaticsFromPrice1Per0, WAD } from "@/lib/market/analytics";
+import {
+  coinGeckoHistoricalTrades,
+  coinGeckoTicker,
+  coinGeckoTickerId,
+  type CoinGeckoSpotMarket,
+  type CoinGeckoTradeSide,
+  type IndexedMarketTrade,
+} from "@/lib/market/coingecko";
+import { poolKeyForLaunch, zeroForTrade } from "@/lib/trade/canonical-market";
+import { loadMarketSpotOverview, loadMarketSupplySnapshot } from "@/lib/server/market-overview";
+import { robinhoodRpcUrl } from "@/lib/server/robinhood-rpc";
+import { staticsMainnetIndexerUrl } from "@/lib/server/statics-indexer-url";
+
+const TICKER_TTL_MS = 60_000;
+const TICKER_MAX_STALE_MS = 5 * 60_000;
+const BID_ASK_WETH_NOTIONAL = 10n ** 16n;
+
+type TickerPayload = readonly [ReturnType<typeof coinGeckoTicker>];
+
+let tickerCache: Readonly<{ value: TickerPayload; fetchedAt: number }> | null = null;
+let tickerInFlight: Promise<Readonly<{ value: TickerPayload; fetchedAt: number }>> | null = null;
+
+function mainnetLaunch(): LaunchDeployment {
+  const launch = deploymentRegistry().find(
+    (option) => option.descriptor.deploymentId === ROBINHOOD_GENESIS_DEPLOYMENT_ID
+  )?.launch;
+  if (!launch?.analytics) throw new Error("The reviewed Robinhood launch manifest is unavailable.");
+  return launch;
+}
+
+export function coinGeckoSpotMarket(): CoinGeckoSpotMarket {
+  const deployment = mainnetLaunch();
+  return {
+    tickerId: coinGeckoTickerId(deployment.contracts.statics, deployment.contracts.weth),
+    baseCurrency: deployment.contracts.statics,
+    targetCurrency: deployment.contracts.weth,
+    poolId: deployment.market.poolId,
+    staticsIsCurrency0:
+      deployment.market.poolKey.currency0.toLowerCase() ===
+      deployment.contracts.statics.toLowerCase(),
+  };
+}
 
 export async function loadCoinGeckoSupply() {
   return loadMarketSupplySnapshot();
+}
+
+function isUnsigned(value: unknown): value is string {
+  return typeof value === "string" && /^\d+$/.test(value);
+}
+
+function validIndexedTrade(value: unknown): value is IndexedMarketTrade {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.poolId === "string" &&
+    typeof row.transactionHash === "string" &&
+    [
+      "amount0",
+      "amount1",
+      "volume0",
+      "volume1",
+      "price1Per0Wad",
+      "blockNumber",
+      "blockTimestamp",
+    ].every((key) =>
+      key === "amount0" || key === "amount1"
+        ? typeof row[key] === "string" && /^-?\d+$/.test(row[key])
+        : isUnsigned(row[key])
+    ) &&
+    typeof row.logIndex === "number" &&
+    Number.isSafeInteger(row.logIndex) &&
+    row.logIndex >= 0
+  );
+}
+
+async function loadIndexedTrades(
+  query: Readonly<{
+    limit: number;
+    from?: string;
+    to?: string;
+    amount0Sign?: "positive" | "negative";
+  }>
+) {
+  const url = staticsMainnetIndexerUrl("market/trades");
+  url.searchParams.set("limit", String(query.limit));
+  if (query.from !== undefined) url.searchParams.set("from", query.from);
+  if (query.to !== undefined) url.searchParams.set("to", query.to);
+  if (query.amount0Sign !== undefined) url.searchParams.set("amount0Sign", query.amount0Sign);
+  const response = await fetch(url, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+    signal: AbortSignal.timeout(4_000),
+  });
+  const payload: unknown = response.ok ? await response.json() : null;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("The indexed market trade response is unavailable.");
+  }
+  const items = (payload as { items?: unknown }).items;
+  if (!Array.isArray(items) || !items.every(validIndexedTrade)) {
+    throw new Error("The indexed market trade response is invalid.");
+  }
+  const market = coinGeckoSpotMarket();
+  if (items.some((item) => item.poolId.toLowerCase() !== market.poolId.toLowerCase())) {
+    throw new Error("The indexer returned a trade outside the canonical market.");
+  }
+  return items;
+}
+
+async function quoteBidAsk(overview: Awaited<ReturnType<typeof loadMarketSpotOverview>>) {
+  const deployment = mainnetLaunch();
+  const client = createPublicClient({
+    transport: http(robinhoodRpcUrl(deployment.descriptor.chainId)),
+  });
+  const staticsInput = (BID_ASK_WETH_NOTIONAL * BigInt(overview.price.staticsPerWethWad)) / WAD;
+  const quote = async (zeroForOne: boolean, amountIn: bigint): Promise<bigint | null> => {
+    if (amountIn <= 0n || amountIn > (1n << 128n) - 1n) return null;
+    try {
+      const result = await client.simulateContract({
+        address: deployment.contracts.quoter,
+        abi: v4QuoterAbi,
+        functionName: "quoteExactInputSingle",
+        args: [
+          {
+            poolKey: poolKeyForLaunch(deployment),
+            zeroForOne,
+            exactAmount: amountIn,
+            hookData: "0x",
+          },
+        ],
+        blockNumber: BigInt(overview.asOfBlock),
+      });
+      return result.result[0] > 0n ? result.result[0] : null;
+    } catch {
+      return null;
+    }
+  };
+  const [askStaticsOutput, bidWethOutput] = await Promise.all([
+    quote(zeroForTrade(deployment, "weth"), BID_ASK_WETH_NOTIONAL),
+    quote(zeroForTrade(deployment, "statics"), staticsInput),
+  ]);
+  return {
+    askWethPerStaticsWad:
+      askStaticsOutput === null ? null : (BID_ASK_WETH_NOTIONAL * WAD) / askStaticsOutput,
+    bidWethPerStaticsWad:
+      bidWethOutput === null || staticsInput === 0n ? null : (bidWethOutput * WAD) / staticsInput,
+  } as const;
+}
+
+async function refreshTicker(now: number) {
+  const overview = await loadMarketSpotOverview(now);
+  const [quote, fallbackTrades] = await Promise.all([
+    quoteBidAsk(overview),
+    overview.activity24h.lastWethPerStaticsWad === null
+      ? loadIndexedTrades({ limit: 1 })
+      : Promise.resolve([]),
+  ]);
+  const market = coinGeckoSpotMarket();
+  const fallbackPrice = fallbackTrades[0]
+    ? canonicalWethPerStaticsFromPrice1Per0(
+        BigInt(fallbackTrades[0].price1Per0Wad),
+        market.staticsIsCurrency0
+      )
+    : null;
+  const value = [coinGeckoTicker(overview, market, quote, fallbackPrice)] as const;
+  return { value, fetchedAt: now } as const;
+}
+
+export async function loadCoinGeckoTickers(now = Date.now()): Promise<TickerPayload> {
+  if (tickerCache && now - tickerCache.fetchedAt <= TICKER_TTL_MS) return tickerCache.value;
+  if (!tickerInFlight) {
+    tickerInFlight = refreshTicker(now)
+      .then((result) => {
+        tickerCache = result;
+        return result;
+      })
+      .finally(() => {
+        tickerInFlight = null;
+      });
+  }
+  try {
+    return (await tickerInFlight).value;
+  } catch (error) {
+    if (tickerCache && now - tickerCache.fetchedAt <= TICKER_MAX_STALE_MS) {
+      return tickerCache.value;
+    }
+    throw error;
+  }
+}
+
+export async function loadCoinGeckoHistoricalTrades(
+  query: Readonly<{
+    limit: number;
+    from?: string;
+    to?: string;
+    side?: CoinGeckoTradeSide;
+  }>
+) {
+  const market = coinGeckoSpotMarket();
+  const amount0Sign =
+    query.side === undefined
+      ? undefined
+      : (query.side === "buy") === market.staticsIsCurrency0
+        ? "negative"
+        : "positive";
+  const trades = await loadIndexedTrades({ ...query, amount0Sign });
+  return coinGeckoHistoricalTrades(trades, market, query.side);
+}
+
+export async function loadCoinGeckoStatus(now = Date.now()) {
+  const overview = await loadMarketSpotOverview(now);
+  if (!overview.activity24h.available) throw new Error("Indexed market activity is unavailable.");
+  const indexedAt = overview.activity24h.lastTradeAt;
+  return {
+    ok: true,
+    chain_id: overview.chainId,
+    deployment_id: overview.deploymentId,
+    as_of_block: overview.asOfBlock,
+    last_trade_at: indexedAt,
+    observed_at: overview.freshness.snapshotAt,
+    lag_seconds:
+      indexedAt === null ? null : Math.max(0, Math.floor((now - Date.parse(indexedAt)) / 1_000)),
+  } as const;
+}
+
+export function resetCoinGeckoMarketCacheForTest(): void {
+  tickerCache = null;
+  tickerInFlight = null;
 }

--- a/lib/server/coingecko-route.ts
+++ b/lib/server/coingecko-route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 
 export const COINGECKO_CACHE = {
   supply: "public, max-age=60, s-maxage=300, stale-while-revalidate=1800",
+  ticker: "public, max-age=30, s-maxage=60, stale-while-revalidate=120",
+  history: "public, max-age=5, s-maxage=15, stale-while-revalidate=30",
+  status: "public, max-age=10, s-maxage=30, stale-while-revalidate=60",
 } as const;
 
 const CORS_HEADERS = {
@@ -19,6 +22,10 @@ export function coinGeckoJson(body: unknown, cacheControl: string, status = 200)
 
 export function coinGeckoUnavailable(): NextResponse {
   return coinGeckoJson({ error: "Market data are temporarily unavailable." }, "no-store", 503);
+}
+
+export function coinGeckoBadRequest(message: string): NextResponse {
+  return coinGeckoJson({ error: message }, "no-store", 400);
 }
 
 export function coinGeckoOptions(): NextResponse {

--- a/lib/server/market-overview.ts
+++ b/lib/server/market-overview.ts
@@ -150,13 +150,19 @@ async function loadActivity(deployment: LaunchDeployment, now: number): Promise<
     const url = staticsMainnetIndexerUrl("market/activity");
     url.searchParams.set("from", String(Math.floor(now / 1_000) - 24 * 60 * 60));
     url.searchParams.set("to", String(Math.floor(now / 1_000)));
+    url.searchParams.set("pool", deployment.market.poolId);
     const response = await fetch(url, {
       headers: { accept: "application/json" },
       cache: "no-store",
       signal: AbortSignal.timeout(4_000),
     });
     const activity: unknown = response.ok ? await response.json() : null;
-    if (!validIndexedActivity(activity)) return null;
+    if (
+      !validIndexedActivity(activity) ||
+      activity.deploymentId !== deployment.descriptor.deploymentId
+    ) {
+      return null;
+    }
     const staticsIsCurrency0 =
       deployment.market.poolKey.currency0.toLowerCase() ===
       deployment.contracts.statics.toLowerCase();

--- a/lib/server/market-overview.ts
+++ b/lib/server/market-overview.ts
@@ -147,9 +147,11 @@ function validIndexedActivity(value: unknown): value is IndexedActivity {
 
 async function loadActivity(deployment: LaunchDeployment, now: number): Promise<Activity | null> {
   try {
+    const from = Math.floor(now / 1_000) - 24 * 60 * 60;
+    const to = Math.floor(now / 1_000);
     const url = staticsMainnetIndexerUrl("market/activity");
-    url.searchParams.set("from", String(Math.floor(now / 1_000) - 24 * 60 * 60));
-    url.searchParams.set("to", String(Math.floor(now / 1_000)));
+    url.searchParams.set("from", String(from));
+    url.searchParams.set("to", String(to));
     url.searchParams.set("pool", deployment.market.poolId);
     const response = await fetch(url, {
       headers: { accept: "application/json" },
@@ -159,7 +161,35 @@ async function loadActivity(deployment: LaunchDeployment, now: number): Promise<
     const activity: unknown = response.ok ? await response.json() : null;
     if (
       !validIndexedActivity(activity) ||
-      activity.deploymentId !== deployment.descriptor.deploymentId
+      activity.deploymentId !== deployment.descriptor.deploymentId ||
+      activity.from !== String(from) ||
+      activity.to !== String(to)
+    ) {
+      return null;
+    }
+    const prices = [
+      activity.openPrice1Per0Wad,
+      activity.highPrice1Per0Wad,
+      activity.lowPrice1Per0Wad,
+      activity.closePrice1Per0Wad,
+    ];
+    const empty = activity.swapCount === 0;
+    if (
+      (empty &&
+        (activity.volume0 !== "0" ||
+          activity.volume1 !== "0" ||
+          activity.zeroForOneCount !== 0 ||
+          activity.oneForZeroCount !== 0 ||
+          prices.some((price) => price !== null) ||
+          activity.lastBlock !== null ||
+          activity.lastTimestamp !== null ||
+          activity.lastLogIndex !== null)) ||
+      (!empty &&
+        (activity.zeroForOneCount + activity.oneForZeroCount !== activity.swapCount ||
+          prices.some((price) => price === null) ||
+          activity.lastBlock === null ||
+          activity.lastTimestamp === null ||
+          activity.lastLogIndex === null))
     ) {
       return null;
     }

--- a/lib/server/market-overview.ts
+++ b/lib/server/market-overview.ts
@@ -7,6 +7,7 @@ import type { LaunchDeployment } from "@/lib/deployments/types";
 import { currentGenesisVaultAbi } from "@/lib/genesis/current-vault";
 import {
   canonicalPrices,
+  canonicalWethPerStaticsFromPrice1Per0,
   feeAdjustedImpactBps,
   findMaximumDepthInput,
   priceChangeBps,
@@ -39,16 +40,22 @@ const DEPTH_TTL_MS = 5 * 60_000;
 const DEPTH_MAX_STALE_MS = 15 * 60_000;
 const DEPTH_TARGETS = [100, 200, 500] as const;
 
-type Candle = Readonly<{
-  timestamp: string;
-  openSqrtPriceX96: string;
-  closeSqrtPriceX96: string;
+type IndexedActivity = Readonly<{
+  deploymentId: string;
+  from: string;
+  to: string;
   volume0: string;
   volume1: string;
   zeroForOneCount: number;
   oneForZeroCount: number;
   swapCount: number;
-  lastBlock: string;
+  openPrice1Per0Wad: string | null;
+  highPrice1Per0Wad: string | null;
+  lowPrice1Per0Wad: string | null;
+  closePrice1Per0Wad: string | null;
+  lastBlock: string | null;
+  lastTimestamp: string | null;
+  lastLogIndex: number | null;
 }>;
 
 type Activity = Readonly<{
@@ -58,6 +65,9 @@ type Activity = Readonly<{
   buys: number;
   sells: number;
   priceChangeBps: number;
+  highWethPerStaticsWad: bigint | null;
+  lowWethPerStaticsWad: bigint | null;
+  lastWethPerStaticsWad: bigint | null;
   indexedAt: string | null;
 }>;
 
@@ -88,6 +98,8 @@ type FundamentalsCache = Readonly<{
 
 let snapshotCache: Readonly<{ value: StaticsMarketOverview; fetchedAt: number }> | null = null;
 let snapshotInFlight: Promise<StaticsMarketOverview> | null = null;
+let spotSnapshotCache: Readonly<{ value: StaticsMarketOverview; fetchedAt: number }> | null = null;
+let spotSnapshotInFlight: Promise<StaticsMarketOverview> | null = null;
 let fundamentalsCache: FundamentalsCache | null = null;
 let fundamentalsInFlight: Promise<FundamentalsCache> | null = null;
 let depthCache: DepthCache | null = null;
@@ -103,13 +115,30 @@ function mainnetLaunch(): LaunchDeployment {
   return deployment;
 }
 
-function validCandle(value: unknown): value is Candle {
+function nullableUnsigned(value: unknown): value is string | null {
+  return value === null || (typeof value === "string" && /^\d+$/.test(value));
+}
+
+function validIndexedActivity(value: unknown): value is IndexedActivity {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const row = value as Record<string, unknown>;
   return (
-    ["timestamp", "openSqrtPriceX96", "closeSqrtPriceX96", "volume0", "volume1", "lastBlock"].every(
+    typeof row.deploymentId === "string" &&
+    ["from", "to", "volume0", "volume1"].every(
       (key) => typeof row[key] === "string" && /^\d+$/.test(row[key])
     ) &&
+    [
+      "openPrice1Per0Wad",
+      "highPrice1Per0Wad",
+      "lowPrice1Per0Wad",
+      "closePrice1Per0Wad",
+      "lastBlock",
+      "lastTimestamp",
+    ].every((key) => nullableUnsigned(row[key])) &&
+    (row.lastLogIndex === null ||
+      (typeof row.lastLogIndex === "number" &&
+        Number.isSafeInteger(row.lastLogIndex) &&
+        row.lastLogIndex >= 0)) &&
     ["zeroForOneCount", "oneForZeroCount", "swapCount"].every(
       (key) => typeof row[key] === "number" && Number.isSafeInteger(row[key]) && row[key] >= 0
     )
@@ -118,55 +147,43 @@ function validCandle(value: unknown): value is Candle {
 
 async function loadActivity(deployment: LaunchDeployment, now: number): Promise<Activity | null> {
   try {
-    const url = staticsMainnetIndexerUrl("market/candles");
+    const url = staticsMainnetIndexerUrl("market/activity");
     url.searchParams.set("from", String(Math.floor(now / 1_000) - 24 * 60 * 60));
     url.searchParams.set("to", String(Math.floor(now / 1_000)));
-    url.searchParams.set("resolution", "60");
     const response = await fetch(url, {
       headers: { accept: "application/json" },
       cache: "no-store",
       signal: AbortSignal.timeout(4_000),
     });
-    const payload: unknown = response.ok ? await response.json() : null;
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
-    const rawItems = (payload as { items?: unknown }).items;
-    if (!Array.isArray(rawItems) || !rawItems.every(validCandle)) return null;
-    const items = rawItems;
+    const activity: unknown = response.ok ? await response.json() : null;
+    if (!validIndexedActivity(activity)) return null;
     const staticsIsCurrency0 =
       deployment.market.poolKey.currency0.toLowerCase() ===
       deployment.contracts.statics.toLowerCase();
-    const volume0 = items.reduce((sum, item) => sum + BigInt(item.volume0), 0n);
-    const volume1 = items.reduce((sum, item) => sum + BigInt(item.volume1), 0n);
-    const first = items[0];
-    const last = items.at(-1);
-    let change = 0;
-    if (first && last) {
-      const open = canonicalPrices(
-        BigInt(first.openSqrtPriceX96),
-        deployment.market.poolKey.currency0,
-        deployment.contracts.statics
-      ).wethPerStaticsWad;
-      const close = canonicalPrices(
-        BigInt(last.closeSqrtPriceX96),
-        deployment.market.poolKey.currency0,
-        deployment.contracts.statics
-      ).wethPerStaticsWad;
-      change = priceChangeBps(open, close);
-    }
+    const canonical = (value: string | null) =>
+      value === null
+        ? null
+        : canonicalWethPerStaticsFromPrice1Per0(BigInt(value), staticsIsCurrency0);
+    const open = canonical(activity.openPrice1Per0Wad);
+    const close = canonical(activity.closePrice1Per0Wad);
+    const rawHigh = canonical(activity.highPrice1Per0Wad);
+    const rawLow = canonical(activity.lowPrice1Per0Wad);
+    const high = staticsIsCurrency0 ? rawHigh : rawLow;
+    const low = staticsIsCurrency0 ? rawLow : rawHigh;
     return {
-      wethVolume: staticsIsCurrency0 ? volume1 : volume0,
-      staticsVolume: staticsIsCurrency0 ? volume0 : volume1,
-      swaps: items.reduce((sum, item) => sum + item.swapCount, 0),
-      buys: items.reduce(
-        (sum, item) => sum + (staticsIsCurrency0 ? item.oneForZeroCount : item.zeroForOneCount),
-        0
-      ),
-      sells: items.reduce(
-        (sum, item) => sum + (staticsIsCurrency0 ? item.zeroForOneCount : item.oneForZeroCount),
-        0
-      ),
-      priceChangeBps: change,
-      indexedAt: last ? new Date(Number(BigInt(last.timestamp)) * 1_000).toISOString() : null,
+      wethVolume: BigInt(staticsIsCurrency0 ? activity.volume1 : activity.volume0),
+      staticsVolume: BigInt(staticsIsCurrency0 ? activity.volume0 : activity.volume1),
+      swaps: activity.swapCount,
+      buys: staticsIsCurrency0 ? activity.oneForZeroCount : activity.zeroForOneCount,
+      sells: staticsIsCurrency0 ? activity.zeroForOneCount : activity.oneForZeroCount,
+      priceChangeBps: open === null || close === null ? 0 : priceChangeBps(open, close),
+      highWethPerStaticsWad: high,
+      lowWethPerStaticsWad: low,
+      lastWethPerStaticsWad: close,
+      indexedAt:
+        activity.lastTimestamp === null
+          ? null
+          : new Date(Number(BigInt(activity.lastTimestamp)) * 1_000).toISOString(),
     };
   } catch {
     return null;
@@ -447,7 +464,7 @@ export async function loadMarketSupplySnapshot(now = Date.now()): Promise<Market
   };
 }
 
-async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
+async function refreshOverview(now: number, includeDepth: boolean): Promise<StaticsMarketOverview> {
   const deployment = mainnetLaunch();
   const [fundamentals, ethUsd, activity] = await Promise.all([
     loadFundamentals(now, false),
@@ -469,19 +486,21 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
   const ethUsdWad = ethUsd?.valueWad ?? null;
   const staticsUsdWad =
     ethUsdWad === null ? null : staticsUsdPriceWad(prices.wethPerStaticsWad, ethUsdWad);
-  const depth = await loadDepth(
-    client,
-    deployment,
-    prices,
-    poolStatics,
-    poolWeth,
-    ethUsdWad,
-    staticsUsdWad,
-    blockNumber,
-    now
-  );
-  const partial = !activity || !depth || ethUsdWad === null;
-  const stale = Boolean(ethUsd?.stale || depth?.stale);
+  const depth = includeDepth
+    ? await loadDepth(
+        client,
+        deployment,
+        prices,
+        poolStatics,
+        poolWeth,
+        ethUsdWad,
+        staticsUsdWad,
+        blockNumber,
+        now
+      )
+    : null;
+  const partial = !activity || ethUsdWad === null || (includeDepth && !depth);
+  const stale = Boolean(ethUsd?.stale || (includeDepth && depth?.stale));
   return {
     schemaVersion: 1,
     status: partial ? "partial" : stale ? "stale" : "fresh",
@@ -527,6 +546,10 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
           buys: activity.buys,
           sells: activity.sells,
           priceChangeBps: activity.priceChangeBps,
+          highWethPerStaticsWad: activity.highWethPerStaticsWad?.toString() ?? null,
+          lowWethPerStaticsWad: activity.lowWethPerStaticsWad?.toString() ?? null,
+          lastWethPerStaticsWad: activity.lastWethPerStaticsWad?.toString() ?? null,
+          lastTradeAt: activity.indexedAt,
         }
       : {
           available: false,
@@ -536,6 +559,10 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
           buys: 0,
           sells: 0,
           priceChangeBps: 0,
+          highWethPerStaticsWad: null,
+          lowWethPerStaticsWad: null,
+          lastWethPerStaticsWad: null,
+          lastTradeAt: null,
         },
     depth: depth?.value ?? null,
     freshness: {
@@ -551,7 +578,7 @@ async function refreshOverview(now: number): Promise<StaticsMarketOverview> {
 export async function loadMarketOverview(now = Date.now()): Promise<StaticsMarketOverview> {
   if (snapshotCache && now - snapshotCache.fetchedAt <= SNAPSHOT_TTL_MS) return snapshotCache.value;
   if (!snapshotInFlight) {
-    snapshotInFlight = refreshOverview(now)
+    snapshotInFlight = refreshOverview(now, true)
       .then((value) => {
         snapshotCache = { value, fetchedAt: now };
         return value;
@@ -563,9 +590,28 @@ export async function loadMarketOverview(now = Date.now()): Promise<StaticsMarke
   return snapshotInFlight;
 }
 
+export async function loadMarketSpotOverview(now = Date.now()): Promise<StaticsMarketOverview> {
+  if (spotSnapshotCache && now - spotSnapshotCache.fetchedAt <= SNAPSHOT_TTL_MS) {
+    return spotSnapshotCache.value;
+  }
+  if (!spotSnapshotInFlight) {
+    spotSnapshotInFlight = refreshOverview(now, false)
+      .then((value) => {
+        spotSnapshotCache = { value, fetchedAt: now };
+        return value;
+      })
+      .finally(() => {
+        spotSnapshotInFlight = null;
+      });
+  }
+  return spotSnapshotInFlight;
+}
+
 export function resetMarketOverviewCacheForTest(): void {
   snapshotCache = null;
   snapshotInFlight = null;
+  spotSnapshotCache = null;
+  spotSnapshotInFlight = null;
   fundamentalsCache = null;
   fundamentalsInFlight = null;
   depthCache = null;

--- a/messages/en.json
+++ b/messages/en.json
@@ -166,6 +166,9 @@
     "poolLiquidity": "Pool liquidity",
     "poolPrincipalOnly": "Canonical pool principal",
     "volume24h": "24h volume",
+    "high24h": "24h high",
+    "low24h": "24h low",
+    "perStatics": "per STATICS",
     "swapCount": "{count, plural, one {# swap} other {# swaps}}",
     "supplyDefinitions": "Supply definitions",
     "totalSupply": "Total supply",
@@ -229,7 +232,14 @@
     "launchUnavailable": "The Statics launch is not available on {network} yet.",
     "swapType": "Swap type",
     "token": "Token",
-    "operatorNft": "Operator NFT"
+    "operatorNft": "Operator NFT",
+    "marketStats": "STATICS/WETH market",
+    "lastPrice": "Last price",
+    "high24h": "24h high",
+    "low24h": "24h low",
+    "volume24h": "24h volume",
+    "liquidity": "Liquidity",
+    "marketStatsUnavailable": "Market statistics are temporarily unavailable."
   },
   "operatorVault": {
     "walletRejected": "The wallet request was rejected.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -166,6 +166,9 @@
     "poolLiquidity": "Liquidez del pool",
     "poolPrincipalOnly": "Principal del pool canónico",
     "volume24h": "Volumen de 24 h",
+    "high24h": "Máximo de 24 h",
+    "low24h": "Mínimo de 24 h",
+    "perStatics": "por STATICS",
     "swapCount": "{count, plural, one {# intercambio} other {# intercambios}}",
     "supplyDefinitions": "Definiciones de suministro",
     "totalSupply": "Suministro total",
@@ -229,7 +232,14 @@
     "launchUnavailable": "El lanzamiento de Statics aún no está disponible en {network}.",
     "swapType": "Tipo de intercambio",
     "token": "Token",
-    "operatorNft": "NFT de Operator"
+    "operatorNft": "NFT de Operator",
+    "marketStats": "Mercado STATICS/WETH",
+    "lastPrice": "Último precio",
+    "high24h": "Máximo de 24 h",
+    "low24h": "Mínimo de 24 h",
+    "volume24h": "Volumen de 24 h",
+    "liquidity": "Liquidez",
+    "marketStatsUnavailable": "Las estadísticas del mercado no están disponibles temporalmente."
   },
   "operatorVault": {
     "walletRejected": "Se rechazó la solicitud de la billetera.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -166,6 +166,9 @@
     "poolLiquidity": "池流动性",
     "poolPrincipalOnly": "规范池本金",
     "volume24h": "24 小时交易量",
+    "high24h": "24 小时最高价",
+    "low24h": "24 小时最低价",
+    "perStatics": "每 STATICS",
     "swapCount": "{count} 笔兑换",
     "supplyDefinitions": "供应量定义",
     "totalSupply": "总供应量",
@@ -229,7 +232,14 @@
     "launchUnavailable": "Statics 启动尚未在 {network} 上开放。",
     "swapType": "兑换类型",
     "token": "代币",
-    "operatorNft": "Operator NFT"
+    "operatorNft": "Operator NFT",
+    "marketStats": "STATICS/WETH 市场",
+    "lastPrice": "最新成交价",
+    "high24h": "24 小时最高价",
+    "low24h": "24 小时最低价",
+    "volume24h": "24 小时交易量",
+    "liquidity": "流动性",
+    "marketStatsUnavailable": "市场统计数据暂时不可用。"
   },
   "operatorVault": {
     "walletRejected": "钱包请求已被拒绝。",

--- a/ponder/ponder.schema.ts
+++ b/ponder/ponder.schema.ts
@@ -102,6 +102,9 @@ export const marketSwap = onchainTable(
     sender: table.hex().notNull(),
     amount0: table.bigint().notNull(),
     amount1: table.bigint().notNull(),
+    volume0: table.bigint().notNull(),
+    volume1: table.bigint().notNull(),
+    price1Per0Wad: table.bigint().notNull(),
     sqrtPriceX96: table.bigint().notNull(),
     liquidity: table.bigint().notNull(),
     tick: table.integer().notNull(),
@@ -109,8 +112,17 @@ export const marketSwap = onchainTable(
     transactionHash: table.hex().notNull(),
     blockNumber: table.bigint().notNull(),
     blockTimestamp: table.bigint().notNull(),
+    logIndex: table.integer().notNull(),
   }),
-  (table) => ({ market: index().on(table.deploymentId, table.poolId, table.blockNumber) })
+  (table) => ({
+    market: index().on(
+      table.deploymentId,
+      table.poolId,
+      table.blockTimestamp,
+      table.blockNumber,
+      table.logIndex
+    ),
+  })
 );
 
 export const marketCandle = onchainTable(

--- a/ponder/src/api/index.ts
+++ b/ponder/src/api/index.ts
@@ -2,7 +2,7 @@ import { and, asc, count, desc, eq, gt, gte, lt, lte, max, min, sum } from "pond
 import { db } from "ponder:api";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { getAddress, isAddress } from "viem";
+import { getAddress, isAddress, isHex, size, type Hex } from "viem";
 
 import {
   activeGenesisCredit,
@@ -47,9 +47,14 @@ function marketRange(fromValue: string | undefined, toValue: string | undefined)
   return { from, to } as const;
 }
 
-function marketRangeWhere(from: bigint | undefined, to: bigint | undefined) {
+function readMarketPool(value: string | undefined): Hex | null {
+  return value && isHex(value, { strict: true }) && size(value) === 32 ? value : null;
+}
+
+function marketRangeWhere(poolId: Hex, from: bigint | undefined, to: bigint | undefined) {
   return and(
     eq(marketSwap.deploymentId, deploymentId),
+    eq(marketSwap.poolId, poolId),
     from === undefined ? undefined : gte(marketSwap.blockTimestamp, from),
     to === undefined ? undefined : lte(marketSwap.blockTimestamp, to)
   );
@@ -325,10 +330,12 @@ app.get("/market/swaps", async (context) => {
 app.get("/market/trades", async (context) => {
   const limit = readMarketTradeLimit(context.req.query("limit"));
   const range = marketRange(context.req.query("from"), context.req.query("to"));
+  const poolId = readMarketPool(context.req.query("pool"));
   const amount0Sign = context.req.query("amount0Sign");
   if (
     limit === 0 ||
     range === null ||
+    poolId === null ||
     (amount0Sign !== undefined && amount0Sign !== "positive" && amount0Sign !== "negative")
   ) {
     return context.json({ error: "Invalid trade query." }, 400);
@@ -349,7 +356,7 @@ app.get("/market/trades", async (context) => {
     .from(marketSwap)
     .where(
       and(
-        marketRangeWhere(range.from, range.to),
+        marketRangeWhere(poolId, range.from, range.to),
         amount0Sign === "positive"
           ? gt(marketSwap.amount0, 0n)
           : amount0Sign === "negative"
@@ -383,15 +390,17 @@ app.get("/market/trades", async (context) => {
 
 app.get("/market/activity", async (context) => {
   const range = marketRange(context.req.query("from"), context.req.query("to"));
+  const poolId = readMarketPool(context.req.query("pool"));
   if (
     range === null ||
+    poolId === null ||
     range.from === undefined ||
     range.to === undefined ||
     range.to - range.from > MAX_MARKET_RANGE_SECONDS
   ) {
     return context.json({ error: "Invalid market activity range." }, 400);
   }
-  const where = marketRangeWhere(range.from, range.to);
+  const where = marketRangeWhere(poolId, range.from, range.to);
   const [aggregateRows, firstRows, lastRows, zeroForOneRows, oneForZeroRows] = await Promise.all([
     db
       .select({

--- a/ponder/src/api/index.ts
+++ b/ponder/src/api/index.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, lt, lte } from "ponder";
+import { and, asc, count, desc, eq, gt, gte, lt, lte, max, min, sum } from "ponder";
 import { db } from "ponder:api";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -22,6 +22,38 @@ import { aggregateMarketCandles, readMarketResolution } from "../market";
 const app = new Hono();
 app.use("*", cors({ origin: process.env.PONDER_ALLOWED_ORIGIN || "*" }));
 const deploymentId = process.env.PONDER_DEPLOYMENT_ID?.trim() || "unconfigured";
+
+const MAX_MARKET_RANGE_SECONDS = 31n * 24n * 60n * 60n;
+
+function readUnsignedTimestamp(value: string | undefined): bigint | null | undefined {
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(value)) return null;
+  return BigInt(value);
+}
+
+function readMarketTradeLimit(value: string | undefined): number {
+  if (value === undefined) return 200;
+  if (!/^\d+$/.test(value)) return 0;
+  const limit = Number(value);
+  return Number.isSafeInteger(limit) && limit >= 1 && limit <= 500 ? limit : 0;
+}
+
+function marketRange(fromValue: string | undefined, toValue: string | undefined) {
+  const from = readUnsignedTimestamp(fromValue);
+  const to = readUnsignedTimestamp(toValue);
+  if (from === null || to === null || (from !== undefined && to !== undefined && to < from)) {
+    return null;
+  }
+  return { from, to } as const;
+}
+
+function marketRangeWhere(from: bigint | undefined, to: bigint | undefined) {
+  return and(
+    eq(marketSwap.deploymentId, deploymentId),
+    from === undefined ? undefined : gte(marketSwap.blockTimestamp, from),
+    to === undefined ? undefined : lte(marketSwap.blockTimestamp, to)
+  );
+}
 
 app.get("/loans/recoverable", async (context) => {
   const asOfValue = context.req.query("asOf");
@@ -287,6 +319,128 @@ app.get("/market/swaps", async (context) => {
       blockNumber: row.blockNumber.toString(),
       blockTimestamp: row.blockTimestamp.toString(),
     })),
+  });
+});
+
+app.get("/market/trades", async (context) => {
+  const limit = readMarketTradeLimit(context.req.query("limit"));
+  const range = marketRange(context.req.query("from"), context.req.query("to"));
+  if (limit === 0 || range === null) return context.json({ error: "Invalid trade query." }, 400);
+  const rows = await db
+    .select({
+      poolId: marketSwap.poolId,
+      amount0: marketSwap.amount0,
+      amount1: marketSwap.amount1,
+      volume0: marketSwap.volume0,
+      volume1: marketSwap.volume1,
+      price1Per0Wad: marketSwap.price1Per0Wad,
+      transactionHash: marketSwap.transactionHash,
+      blockNumber: marketSwap.blockNumber,
+      blockTimestamp: marketSwap.blockTimestamp,
+      logIndex: marketSwap.logIndex,
+    })
+    .from(marketSwap)
+    .where(marketRangeWhere(range.from, range.to))
+    .orderBy(
+      desc(marketSwap.blockTimestamp),
+      desc(marketSwap.blockNumber),
+      desc(marketSwap.logIndex)
+    )
+    .limit(limit);
+  context.header("Cache-Control", "public, max-age=5, stale-while-revalidate=15");
+  return context.json({
+    deploymentId,
+    items: rows.map((row) => ({
+      poolId: row.poolId,
+      amount0: row.amount0.toString(),
+      amount1: row.amount1.toString(),
+      volume0: row.volume0.toString(),
+      volume1: row.volume1.toString(),
+      price1Per0Wad: row.price1Per0Wad.toString(),
+      transactionHash: row.transactionHash,
+      blockNumber: row.blockNumber.toString(),
+      blockTimestamp: row.blockTimestamp.toString(),
+      logIndex: row.logIndex,
+    })),
+  });
+});
+
+app.get("/market/activity", async (context) => {
+  const range = marketRange(context.req.query("from"), context.req.query("to"));
+  if (
+    range === null ||
+    range.from === undefined ||
+    range.to === undefined ||
+    range.to - range.from > MAX_MARKET_RANGE_SECONDS
+  ) {
+    return context.json({ error: "Invalid market activity range." }, 400);
+  }
+  const where = marketRangeWhere(range.from, range.to);
+  const [aggregateRows, firstRows, lastRows, zeroForOneRows, oneForZeroRows] = await Promise.all([
+    db
+      .select({
+        volume0: sum(marketSwap.volume0),
+        volume1: sum(marketSwap.volume1),
+        lowPrice1Per0Wad: min(marketSwap.price1Per0Wad),
+        highPrice1Per0Wad: max(marketSwap.price1Per0Wad),
+        swapCount: count(),
+      })
+      .from(marketSwap)
+      .where(where),
+    db
+      .select({ price1Per0Wad: marketSwap.price1Per0Wad })
+      .from(marketSwap)
+      .where(where)
+      .orderBy(
+        asc(marketSwap.blockTimestamp),
+        asc(marketSwap.blockNumber),
+        asc(marketSwap.logIndex)
+      )
+      .limit(1),
+    db
+      .select({
+        price1Per0Wad: marketSwap.price1Per0Wad,
+        blockNumber: marketSwap.blockNumber,
+        blockTimestamp: marketSwap.blockTimestamp,
+        logIndex: marketSwap.logIndex,
+      })
+      .from(marketSwap)
+      .where(where)
+      .orderBy(
+        desc(marketSwap.blockTimestamp),
+        desc(marketSwap.blockNumber),
+        desc(marketSwap.logIndex)
+      )
+      .limit(1),
+    db
+      .select({ swapCount: count() })
+      .from(marketSwap)
+      .where(and(where, gt(marketSwap.amount0, 0n))),
+    db
+      .select({ swapCount: count() })
+      .from(marketSwap)
+      .where(and(where, lt(marketSwap.amount0, 0n))),
+  ]);
+  const aggregate = aggregateRows[0];
+  const first = firstRows[0];
+  const last = lastRows[0];
+  context.header("Cache-Control", "public, max-age=5, stale-while-revalidate=15");
+  return context.json({
+    deploymentId,
+    from: range.from.toString(),
+    to: range.to.toString(),
+    volume0: String(aggregate?.volume0 ?? 0),
+    volume1: String(aggregate?.volume1 ?? 0),
+    swapCount: Number(aggregate?.swapCount ?? 0),
+    zeroForOneCount: Number(zeroForOneRows[0]?.swapCount ?? 0),
+    oneForZeroCount: Number(oneForZeroRows[0]?.swapCount ?? 0),
+    openPrice1Per0Wad: first?.price1Per0Wad.toString() ?? null,
+    highPrice1Per0Wad: aggregate?.highPrice1Per0Wad?.toString() ?? null,
+    lowPrice1Per0Wad: aggregate?.lowPrice1Per0Wad?.toString() ?? null,
+    closePrice1Per0Wad: last?.price1Per0Wad.toString() ?? null,
+    lastBlock: last?.blockNumber.toString() ?? null,
+    lastTimestamp: last?.blockTimestamp.toString() ?? null,
+    lastLogIndex: last?.logIndex ?? null,
   });
 });
 

--- a/ponder/src/api/index.ts
+++ b/ponder/src/api/index.ts
@@ -325,7 +325,14 @@ app.get("/market/swaps", async (context) => {
 app.get("/market/trades", async (context) => {
   const limit = readMarketTradeLimit(context.req.query("limit"));
   const range = marketRange(context.req.query("from"), context.req.query("to"));
-  if (limit === 0 || range === null) return context.json({ error: "Invalid trade query." }, 400);
+  const amount0Sign = context.req.query("amount0Sign");
+  if (
+    limit === 0 ||
+    range === null ||
+    (amount0Sign !== undefined && amount0Sign !== "positive" && amount0Sign !== "negative")
+  ) {
+    return context.json({ error: "Invalid trade query." }, 400);
+  }
   const rows = await db
     .select({
       poolId: marketSwap.poolId,
@@ -340,7 +347,16 @@ app.get("/market/trades", async (context) => {
       logIndex: marketSwap.logIndex,
     })
     .from(marketSwap)
-    .where(marketRangeWhere(range.from, range.to))
+    .where(
+      and(
+        marketRangeWhere(range.from, range.to),
+        amount0Sign === "positive"
+          ? gt(marketSwap.amount0, 0n)
+          : amount0Sign === "negative"
+            ? lt(marketSwap.amount0, 0n)
+            : undefined
+      )
+    )
     .orderBy(
       desc(marketSwap.blockTimestamp),
       desc(marketSwap.blockNumber),

--- a/ponder/src/index.ts
+++ b/ponder/src/index.ts
@@ -16,7 +16,7 @@ import {
   marketSwap,
   v4Position,
 } from "ponder:schema";
-import { absoluteAmount, candleBucket, marketCandleKey } from "./market";
+import { absoluteAmount, candleBucket, marketCandleKey, marketSwapMetrics } from "./market";
 
 const deploymentId = process.env.PONDER_DEPLOYMENT_ID?.trim();
 if (!deploymentId) throw new Error("PONDER_DEPLOYMENT_ID is required.");
@@ -291,6 +291,7 @@ ponder.on("StaticsFeeReceiver:FeesHarvested", async ({ event, context }) => {
 });
 
 onPoolManager("PoolManager:Swap", async ({ event, context }) => {
+  const metrics = marketSwapMetrics(event.args.amount0, event.args.amount1);
   await context.db.insert(marketSwap).values({
     key: eventKey(event.transaction.hash, event.log.logIndex),
     deploymentId,
@@ -298,6 +299,9 @@ onPoolManager("PoolManager:Swap", async ({ event, context }) => {
     sender: getAddress(event.args.sender),
     amount0: event.args.amount0,
     amount1: event.args.amount1,
+    volume0: metrics.volume0,
+    volume1: metrics.volume1,
+    price1Per0Wad: metrics.price1Per0Wad,
     sqrtPriceX96: event.args.sqrtPriceX96,
     liquidity: event.args.liquidity,
     tick: event.args.tick,
@@ -305,6 +309,7 @@ onPoolManager("PoolManager:Swap", async ({ event, context }) => {
     transactionHash: event.transaction.hash,
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
+    logIndex: event.log.logIndex,
   });
 
   const bucketTimestamp = candleBucket(event.block.timestamp);

--- a/ponder/src/market.ts
+++ b/ponder/src/market.ts
@@ -1,4 +1,5 @@
 export const MARKET_CANDLE_SECONDS = 60n;
+export const MARKET_PRICE_SCALE = 10n ** 18n;
 export const MARKET_RESOLUTIONS = [1, 5, 15, 60, 240, 1_440] as const;
 
 export type MarketResolution = (typeof MARKET_RESOLUTIONS)[number];
@@ -20,6 +21,19 @@ export type MarketCandleRow = Readonly<{
 
 export function absoluteAmount(value: bigint): bigint {
   return value < 0n ? -value : value;
+}
+
+export function marketSwapMetrics(amount0: bigint, amount1: bigint) {
+  const volume0 = absoluteAmount(amount0);
+  const volume1 = absoluteAmount(amount1);
+  if (volume0 === 0n || volume1 === 0n) {
+    throw new Error("Canonical market swaps must exchange non-zero token amounts.");
+  }
+  return {
+    volume0,
+    volume1,
+    price1Per0Wad: (volume1 * MARKET_PRICE_SCALE) / volume0,
+  } as const;
 }
 
 export function candleBucket(timestamp: bigint, resolutionMinutes = 1): bigint {

--- a/ponder/test/api-routes.test.ts
+++ b/ponder/test/api-routes.test.ts
@@ -48,6 +48,28 @@ describe("indexer API routes", () => {
     const response = await app.request(path);
     expect(response.status).toBe(400);
   });
+
+  it.each([
+    "/market/trades?limit=0",
+    "/market/trades?limit=501",
+    "/market/trades?limit=1.5",
+    "/market/trades?from=nope",
+    "/market/trades?from=2&to=1",
+  ])("rejects invalid market trade query %s", async (path) => {
+    const response = await app.request(path);
+    expect(response.status).toBe(400);
+  });
+
+  it.each([
+    "/market/activity",
+    "/market/activity?from=1",
+    "/market/activity?from=nope&to=2",
+    "/market/activity?from=2&to=1",
+    "/market/activity?from=0&to=2678401",
+  ])("rejects invalid market activity query %s", async (path) => {
+    const response = await app.request(path);
+    expect(response.status).toBe(400);
+  });
 });
 
 describe("recoverable Genesis credit query", () => {

--- a/ponder/test/api-routes.test.ts
+++ b/ponder/test/api-routes.test.ts
@@ -55,6 +55,7 @@ describe("indexer API routes", () => {
     "/market/trades?limit=1.5",
     "/market/trades?from=nope",
     "/market/trades?from=2&to=1",
+    "/market/trades?amount0Sign=zero",
   ])("rejects invalid market trade query %s", async (path) => {
     const response = await app.request(path);
     expect(response.status).toBe(400);

--- a/ponder/test/api-routes.test.ts
+++ b/ponder/test/api-routes.test.ts
@@ -56,6 +56,7 @@ describe("indexer API routes", () => {
     "/market/trades?from=nope",
     "/market/trades?from=2&to=1",
     "/market/trades?amount0Sign=zero",
+    "/market/trades?pool=0x12",
   ])("rejects invalid market trade query %s", async (path) => {
     const response = await app.request(path);
     expect(response.status).toBe(400);
@@ -67,6 +68,7 @@ describe("indexer API routes", () => {
     "/market/activity?from=nope&to=2",
     "/market/activity?from=2&to=1",
     "/market/activity?from=0&to=2678401",
+    `/market/activity?from=1&to=2&pool=0x${"12".repeat(31)}`,
   ])("rejects invalid market activity query %s", async (path) => {
     const response = await app.request(path);
     expect(response.status).toBe(400);

--- a/ponder/test/market.test.ts
+++ b/ponder/test/market.test.ts
@@ -4,6 +4,7 @@ import {
   absoluteAmount,
   aggregateMarketCandles,
   candleBucket,
+  marketSwapMetrics,
   marketCandleKey,
   readMarketResolution,
   type MarketCandleRow,
@@ -32,6 +33,15 @@ describe("canonical market candles", () => {
     expect(absoluteAmount(-42n)).toBe(42n);
     expect(candleBucket(179n)).toBe(120n);
     expect(marketCandleKey("launch", `0x${"12".repeat(32)}`, 179n)).toContain(":120");
+  });
+
+  it("derives absolute volumes and token1-per-token0 execution price", () => {
+    expect(marketSwapMetrics(2n * 10n ** 18n, -5n * 10n ** 15n)).toEqual({
+      volume0: 2n * 10n ** 18n,
+      volume1: 5n * 10n ** 15n,
+      price1Per0Wad: 25n * 10n ** 14n,
+    });
+    expect(() => marketSwapMetrics(0n, 1n)).toThrow("non-zero token amounts");
   });
 
   it("aggregates exact OHLC, volume, direction counts, and block bounds", () => {

--- a/test/api/coingecko-routes.test.ts
+++ b/test/api/coingecko-routes.test.ts
@@ -2,18 +2,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   loadSupply: vi.fn(),
+  loadTickers: vi.fn(),
+  loadTrades: vi.fn(),
+  loadStatus: vi.fn(),
 }));
 
 vi.mock("@/lib/server/coingecko-market", () => ({
   loadCoinGeckoSupply: mocks.loadSupply,
+  loadCoinGeckoTickers: mocks.loadTickers,
+  loadCoinGeckoHistoricalTrades: mocks.loadTrades,
+  loadCoinGeckoStatus: mocks.loadStatus,
+  coinGeckoSpotMarket: () => ({ tickerId: "0xbase_0xtarget" }),
 }));
 
+import { GET as getHistory } from "@/app/api/coingecko/v1/historical_trades/route";
+import { GET as getStatus } from "@/app/api/coingecko/v1/status/route";
 import { GET as getSupply } from "@/app/api/coingecko/v1/supply/route";
-import {
-  GET as getCirculating,
-  OPTIONS as optionsCirculating,
-} from "@/app/api/coingecko/v1/supply/circulating/route";
+import { GET as getCirculating } from "@/app/api/coingecko/v1/supply/circulating/route";
 import { GET as getTotal } from "@/app/api/coingecko/v1/supply/total/route";
+import { GET as getTickers, OPTIONS as optionsTickers } from "@/app/api/coingecko/v1/tickers/route";
 
 const WAD = 10n ** 18n;
 const supply = {
@@ -34,6 +41,9 @@ const supply = {
 
 beforeEach(() => {
   mocks.loadSupply.mockReset().mockResolvedValue(supply);
+  mocks.loadTickers.mockReset().mockResolvedValue([{ ticker_id: "0xbase_0xtarget" }]);
+  mocks.loadTrades.mockReset().mockResolvedValue({ buy: [], sell: [] });
+  mocks.loadStatus.mockReset().mockResolvedValue({ ok: true });
 });
 
 describe("public CoinGecko routes", () => {
@@ -53,9 +63,39 @@ describe("public CoinGecko routes", () => {
     expect(circulating.headers.get("access-control-allow-origin")).toBe("*");
     expect(circulating.headers.get("cache-control")).toContain("s-maxage=300");
 
-    const preflight = optionsCirculating();
+    const ticker = await getTickers();
+    expect(ticker.headers.get("cache-control")).toContain("s-maxage=60");
+    expect(await ticker.json()).toEqual([{ ticker_id: "0xbase_0xtarget" }]);
+
+    const status = await getStatus();
+    expect(status.headers.get("cache-control")).toContain("s-maxage=30");
+
+    const preflight = optionsTickers();
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+  });
+
+  it("validates and forwards historical trade filters", async () => {
+    const response = await getHistory(
+      new Request(
+        "https://staticsprotocol.com/api/coingecko/v1/historical_trades?" +
+          "ticker_id=0xbase_0xtarget&type=buy&limit=500&start_time=10&end_time=20"
+      )
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toContain("s-maxage=15");
+    expect(mocks.loadTrades).toHaveBeenCalledWith({
+      limit: 500,
+      from: "10",
+      to: "20",
+      side: "buy",
+    });
+
+    const invalid = await getHistory(
+      new Request("https://staticsprotocol.com/api/coingecko/v1/historical_trades?ticker_id=wrong")
+    );
+    expect(invalid.status).toBe(400);
+    expect(mocks.loadTrades).toHaveBeenCalledTimes(1);
   });
 
   it("returns a cache-disabled 503 when authoritative dependencies are unavailable", async () => {
@@ -64,5 +104,8 @@ describe("public CoinGecko routes", () => {
     expect(response.status).toBe(503);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(await response.json()).toEqual({ error: "Market data are temporarily unavailable." });
+
+    mocks.loadTickers.mockRejectedValueOnce(new Error("Indexer unavailable"));
+    expect((await getTickers()).status).toBe(503);
   });
 });

--- a/test/api/market-routes.test.ts
+++ b/test/api/market-routes.test.ts
@@ -2,11 +2,15 @@ import { createHash } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ loadOverview: vi.fn() }));
+const mocks = vi.hoisted(() => ({ loadOverview: vi.fn(), loadSpotOverview: vi.fn() }));
 
-vi.mock("@/lib/server/market-overview", () => ({ loadMarketOverview: mocks.loadOverview }));
+vi.mock("@/lib/server/market-overview", () => ({
+  loadMarketOverview: mocks.loadOverview,
+  loadMarketSpotOverview: mocks.loadSpotOverview,
+}));
 
 import { GET as getInternalOverview } from "@/app/api/market/overview/route";
+import { GET as getSpotOverview } from "@/app/api/market/spot/route";
 import { GET as getCandles } from "@/app/api/market/v1/candles/route";
 import { GET as getExternalOverview } from "@/app/api/market/v1/overview/route";
 import { GET as getStatus } from "@/app/api/market/v1/status/route";
@@ -32,6 +36,7 @@ function authorized(url: string): Request {
 beforeEach(() => {
   resetMarketRateLimitsForTest();
   mocks.loadOverview.mockResolvedValue(overview);
+  mocks.loadSpotOverview.mockResolvedValue({ ...overview, depth: null });
   process.env.STATICS_MARKET_API_KEYS = `partner:${createHash("sha256").update(secret).digest("hex")}`;
   process.env.NEXT_PUBLIC_STATICS_MAINNET_INDEXER_URL = "https://indexer.example/api";
 });
@@ -45,6 +50,9 @@ afterEach(() => {
 describe("market API routes", () => {
   it("keeps the dashboard overview public while authenticating external routes", async () => {
     expect((await getInternalOverview()).status).toBe(200);
+    const spot = await getSpotOverview();
+    expect(spot.status).toBe(200);
+    expect(spot.headers.get("cache-control")).toContain("s-maxage=60");
     expect(
       (await getExternalOverview(new Request("https://app.example/api/market/v1/overview"))).status
     ).toBe(401);
@@ -52,6 +60,7 @@ describe("market API routes", () => {
       (await getExternalOverview(authorized("https://app.example/api/market/v1/overview"))).status
     ).toBe(200);
     expect(mocks.loadOverview).toHaveBeenCalledTimes(2);
+    expect(mocks.loadSpotOverview).toHaveBeenCalledOnce();
   });
 
   it("returns bounded status data", async () => {

--- a/test/components/market-analytics.test.tsx
+++ b/test/components/market-analytics.test.tsx
@@ -44,6 +44,10 @@ const analytics = {
     buys: 7,
     sells: 5,
     priceChangeBps: 125,
+    highWethPerStaticsWad: 4_400_000_000_000n.toString(),
+    lowWethPerStaticsWad: 3_800_000_000_000n.toString(),
+    lastWethPerStaticsWad: 4_000_000_000_000n.toString(),
+    lastTradeAt: "2026-08-31T00:00:00.000Z",
   },
   depth: {
     buyStatics: [100, 200, 500].map((impact) => ({

--- a/test/components/market-analytics.test.tsx
+++ b/test/components/market-analytics.test.tsx
@@ -84,6 +84,8 @@ describe("market analytics panel", () => {
     expect(screen.getByText("Public market cap")).toBeInTheDocument();
     expect(screen.getByText("STATICS price")).toBeInTheDocument();
     expect(screen.getByText("24h volume")).toBeInTheDocument();
+    expect(screen.getByText("24h high")).toBeInTheDocument();
+    expect(screen.getByText("24h low")).toBeInTheDocument();
     expect(screen.getByText("Public distributed supply")).toBeInTheDocument();
     expect(screen.getByText("Strict liquid float")).toBeInTheDocument();
     expect(screen.getByText("Canonical pool principal")).toBeInTheDocument();

--- a/test/components/swap-page.test.tsx
+++ b/test/components/swap-page.test.tsx
@@ -19,6 +19,9 @@ vi.mock("@/components/portal/EvmSwapPanel", () => ({
 vi.mock("@/components/genesis/GenesisVaultSwapPanel", () => ({
   GenesisVaultSwapPanel: () => <div>Next available Operator NFT</div>,
 }));
+vi.mock("@/components/swap/TradeMarketStats", () => ({
+  TradeMarketStats: () => <div>Market statistics</div>,
+}));
 
 const statics = getAddress("0x1111111111111111111111111111111111111111");
 const weth = getAddress("0x7777777777777777777777777777777777777777");

--- a/test/components/trade-market-stats.test.tsx
+++ b/test/components/trade-market-stats.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@/test/render";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ loadSpot: vi.fn() }));
+
+vi.mock("@/lib/market/client", () => ({ loadMarketSpotOverview: mocks.loadSpot }));
+
+import { TradeMarketStats } from "@/components/swap/TradeMarketStats";
+
+const WAD = 10n ** 18n;
+
+beforeEach(() => {
+  mocks.loadSpot.mockReset().mockResolvedValue({
+    price: { ethUsdWad: (2_500n * WAD).toString() },
+    activity24h: {
+      wethVolume: (40n * WAD).toString(),
+      lastWethPerStaticsWad: "4000000000000",
+      highWethPerStaticsWad: "5000000000000",
+      lowWethPerStaticsWad: "3000000000000",
+    },
+    liquidity: { tvlUsdWad: (2_000_000n * WAD).toString() },
+  });
+});
+
+describe("trade market statistics", () => {
+  it("shows the same transaction and liquidity metrics exposed by the public feed", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TradeMarketStats deploymentId="robinhood-genesis" />
+      </QueryClientProvider>
+    );
+    expect(await screen.findByText("0.000004")).toBeInTheDocument();
+    expect(screen.getByText("0.000005")).toBeInTheDocument();
+    expect(screen.getByText("0.000003")).toBeInTheDocument();
+    expect(screen.getByText("24h volume")).toBeInTheDocument();
+    expect(screen.getByText("Liquidity")).toBeInTheDocument();
+    expect(mocks.loadSpot).toHaveBeenCalledOnce();
+  });
+});

--- a/test/market/client.test.ts
+++ b/test/market/client.test.ts
@@ -37,6 +37,10 @@ const fixture = {
     buys: 5,
     sells: 4,
     priceChangeBps: -25,
+    highWethPerStaticsWad: "9",
+    lowWethPerStaticsWad: "6",
+    lastWethPerStaticsWad: "7",
+    lastTradeAt: "2026-08-31T00:00:00.000Z",
   },
   depth: {
     buyStatics: [

--- a/test/market/coingecko-query.test.ts
+++ b/test/market/coingecko-query.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCoinGeckoHistoricalTradeQuery } from "@/lib/market/coingecko-query";
+
+const ticker = "0xbase_0xtarget";
+
+describe("CoinGecko historical trade query", () => {
+  it("applies the bounded default and accepts filters", () => {
+    expect(
+      parseCoinGeckoHistoricalTradeQuery(
+        `https://staticsprotocol.com/api?` +
+          new URLSearchParams({
+            ticker_id: ticker.toUpperCase(),
+            type: "sell",
+            limit: "500",
+            start_time: "10",
+            end_time: "20",
+          }),
+        ticker
+      )
+    ).toEqual({ ok: true, query: { limit: 500, from: "10", to: "20", side: "sell" } });
+    expect(
+      parseCoinGeckoHistoricalTradeQuery(
+        `https://staticsprotocol.com/api?ticker_id=${ticker}`,
+        ticker
+      )
+    ).toEqual({ ok: true, query: { limit: 200 } });
+  });
+
+  it.each([
+    "",
+    `ticker_id=wrong`,
+    `ticker_id=${ticker}&limit=0`,
+    `ticker_id=${ticker}&limit=501`,
+    `ticker_id=${ticker}&limit=1.5`,
+    `ticker_id=${ticker}&type=both`,
+    `ticker_id=${ticker}&start_time=nope`,
+    `ticker_id=${ticker}&start_time=20&end_time=10`,
+  ])("rejects invalid query %s", (query) => {
+    expect(
+      parseCoinGeckoHistoricalTradeQuery(`https://staticsprotocol.com/api?${query}`, ticker).ok
+    ).toBe(false);
+  });
+});

--- a/test/market/coingecko.test.ts
+++ b/test/market/coingecko.test.ts
@@ -1,11 +1,17 @@
+import { getAddress } from "viem";
 import { describe, expect, it } from "vitest";
 
 import {
   coinGeckoCirculatingSupply,
+  coinGeckoHistoricalTrades,
   coinGeckoSupplyDisclosure,
   coinGeckoSupplyResult,
+  coinGeckoTicker,
+  coinGeckoTickerId,
+  type CoinGeckoSpotMarket,
+  type IndexedMarketTrade,
 } from "@/lib/market/coingecko";
-import type { MarketSupplySnapshot } from "@/lib/market/types";
+import type { MarketSupplySnapshot, StaticsMarketOverview } from "@/lib/market/types";
 
 const WAD = 10n ** 18n;
 const supply = {
@@ -23,6 +29,86 @@ const supply = {
   vaultBacking: (117_900_000n * WAD).toString(),
   strictLiquidFloat: (682_100_000n * WAD).toString(),
 } satisfies MarketSupplySnapshot;
+
+const baseCurrency = getAddress("0x2222222222222222222222222222222222222222");
+const targetCurrency = getAddress("0x1111111111111111111111111111111111111111");
+const market = {
+  tickerId: coinGeckoTickerId(baseCurrency, targetCurrency),
+  baseCurrency,
+  targetCurrency,
+  poolId: `0x${"12".repeat(32)}`,
+  staticsIsCurrency0: true,
+} satisfies CoinGeckoSpotMarket;
+
+const overview = {
+  schemaVersion: 1,
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  poolId: market.poolId,
+  asOfBlock: "123",
+  price: {
+    staticsPerWethWad: (250_000n * WAD).toString(),
+    wethPerStaticsWad: (WAD / 250_000n).toString(),
+    ethUsdWad: (2_500n * WAD).toString(),
+    staticsUsdWad: (WAD / 100n).toString(),
+  },
+  supply: {
+    total: supply.total,
+    poolInventory: supply.poolInventory,
+    publicDistributed: supply.publicDistributed,
+    unreleasedTreasury: supply.unreleasedTreasury,
+    vaultBacking: supply.vaultBacking,
+    strictLiquidFloat: supply.strictLiquidFloat,
+  },
+  valuation: {
+    fdvUsdWad: (10_000_000n * WAD).toString(),
+    publicMarketCapUsdWad: (7_001_000n * WAD).toString(),
+    liquidFloatMarketCapUsdWad: (6_821_000n * WAD).toString(),
+  },
+  liquidity: {
+    principalWeth: (400n * WAD).toString(),
+    principalStatics: supply.poolInventory,
+    tvlUsdWad: (2_000_000n * WAD).toString(),
+  },
+  activity24h: {
+    available: true,
+    wethVolume: (40n * WAD).toString(),
+    staticsVolume: (10_000_000n * WAD).toString(),
+    swaps: 12,
+    buys: 7,
+    sells: 5,
+    priceChangeBps: 125,
+    highWethPerStaticsWad: 5_000_000_000_000n.toString(),
+    lowWethPerStaticsWad: 3_000_000_000_000n.toString(),
+    lastWethPerStaticsWad: 4_000_000_000_000n.toString(),
+    lastTradeAt: "2026-09-01T11:59:00.000Z",
+  },
+  depth: null,
+  freshness: {
+    indexedAt: "2026-09-01T11:59:00.000Z",
+    snapshotAt: supply.snapshotAt,
+    depthAt: null,
+    usdPriceAt: supply.snapshotAt,
+    usdPriceStale: false,
+  },
+} satisfies StaticsMarketOverview;
+
+function indexedTrade(overrides: Partial<IndexedMarketTrade> = {}): IndexedMarketTrade {
+  return {
+    poolId: market.poolId,
+    amount0: (-2n * WAD).toString(),
+    amount1: (8n * 10n ** 12n).toString(),
+    volume0: (2n * WAD).toString(),
+    volume1: (8n * 10n ** 12n).toString(),
+    price1Per0Wad: 4_000_000_000_000n.toString(),
+    transactionHash: `0x${"34".repeat(32)}`,
+    blockNumber: "123",
+    blockTimestamp: "1788278400",
+    logIndex: 7,
+    ...overrides,
+  };
+}
 
 describe("CoinGecko market payloads", () => {
   it("keeps publicly tradable AMM inventory in circulating supply", () => {
@@ -50,5 +136,72 @@ describe("CoinGecko market payloads", () => {
     expect(() =>
       coinGeckoCirculatingSupply({ ...supply, vaultBacking: (1_000_000_000n * WAD).toString() })
     ).toThrow("Circulating-supply exclusions exceed total supply.");
+  });
+
+  it("returns CoinGecko DEX ticker decimals and executable quotes", () => {
+    expect(
+      coinGeckoTicker(overview, market, {
+        bidWethPerStaticsWad: 3_900_000_000_000n,
+        askWethPerStaticsWad: 4_100_000_000_000n,
+      })
+    ).toEqual({
+      ticker_id: market.tickerId,
+      base_currency: baseCurrency.toLowerCase(),
+      target_currency: targetCurrency.toLowerCase(),
+      pool_id: market.poolId,
+      last_price: "0.000004",
+      base_volume: "10000000",
+      target_volume: "40",
+      liquidity_in_usd: "2000000",
+      bid: "0.0000039",
+      ask: "0.0000041",
+      high: "0.000005",
+      low: "0.000003",
+    });
+  });
+
+  it("maps indexed direction, amounts, and stable integer trade IDs", () => {
+    expect(coinGeckoHistoricalTrades([indexedTrade()], market)).toEqual({
+      buy: [
+        {
+          trade_id: 123000007,
+          price: "0.000004",
+          base_volume: "2",
+          target_volume: "0.000008",
+          trade_timestamp: "1788278400",
+          type: "buy",
+        },
+      ],
+      sell: [],
+    });
+    expect(
+      coinGeckoHistoricalTrades(
+        [indexedTrade({ amount0: (2n * WAD).toString(), logIndex: 8 })],
+        market,
+        "buy"
+      )
+    ).toEqual({ buy: [], sell: [] });
+  });
+
+  it("inverts execution prices when STATICS is currency1", () => {
+    const invertedMarket = { ...market, staticsIsCurrency0: false };
+    const result = coinGeckoHistoricalTrades(
+      [
+        indexedTrade({
+          amount0: (-8n * 10n ** 12n).toString(),
+          amount1: (2n * WAD).toString(),
+          volume0: (8n * 10n ** 12n).toString(),
+          volume1: (2n * WAD).toString(),
+          price1Per0Wad: (250_000n * WAD).toString(),
+        }),
+      ],
+      invertedMarket
+    );
+    expect(result.sell[0]).toMatchObject({
+      price: "0.000004",
+      base_volume: "2",
+      target_volume: "0.000008",
+      type: "sell",
+    });
   });
 });

--- a/test/server/coingecko-market.test.ts
+++ b/test/server/coingecko-market.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/server/statics-indexer-url", () => ({
 import {
   coinGeckoSpotMarket,
   loadCoinGeckoHistoricalTrades,
+  loadCoinGeckoStatus,
   loadCoinGeckoTickers,
   resetCoinGeckoMarketCacheForTest,
 } from "@/lib/server/coingecko-market";
@@ -152,9 +153,25 @@ describe("CoinGecko market server adapter", () => {
     expect(requested.pathname).toBe("/market/trades");
     expect(Object.fromEntries(requested.searchParams)).toEqual({
       limit: "500",
+      pool: market.poolId,
       from: "10",
       to: "20",
       amount0Sign: "positive",
+    });
+  });
+
+  it("reports indexer block lag independently from the age of the last trade", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ active: { id: 4_663, block: { number: 456, timestamp: 1_788_278_390 } } }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    await expect(loadCoinGeckoStatus(1_788_278_400_000)).resolves.toMatchObject({
+      indexed_block: "456",
+      indexed_at: "2026-09-01T15:59:50.000Z",
+      last_trade_at: overview.activity24h.lastTradeAt,
+      lag_seconds: 10,
     });
   });
 });

--- a/test/server/coingecko-market.test.ts
+++ b/test/server/coingecko-market.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { StaticsMarketOverview } from "@/lib/market/types";
+
+const mocks = vi.hoisted(() => ({
+  loadSpot: vi.fn(),
+  loadSupply: vi.fn(),
+  simulateContract: vi.fn(),
+}));
+
+vi.mock("viem", async (importOriginal) => {
+  const original = await importOriginal<typeof import("viem")>();
+  return {
+    ...original,
+    createPublicClient: () => ({ simulateContract: mocks.simulateContract }),
+    http: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/market-overview", () => ({
+  loadMarketSpotOverview: mocks.loadSpot,
+  loadMarketSupplySnapshot: mocks.loadSupply,
+}));
+
+vi.mock("@/lib/server/robinhood-rpc", () => ({ robinhoodRpcUrl: () => "https://rpc.example" }));
+vi.mock("@/lib/server/statics-indexer-url", () => ({
+  staticsMainnetIndexerUrl: (path: string) => new URL(`https://indexer.example/${path}`),
+}));
+
+import {
+  coinGeckoSpotMarket,
+  loadCoinGeckoHistoricalTrades,
+  loadCoinGeckoTickers,
+  resetCoinGeckoMarketCacheForTest,
+} from "@/lib/server/coingecko-market";
+
+const WAD = 10n ** 18n;
+const overview = {
+  schemaVersion: 1,
+  status: "fresh",
+  chainId: 4_663,
+  deploymentId: "robinhood-genesis",
+  poolId: coinGeckoSpotMarket().poolId,
+  asOfBlock: "123",
+  price: {
+    staticsPerWethWad: (250_000n * WAD).toString(),
+    wethPerStaticsWad: 4_000_000_000_000n.toString(),
+    ethUsdWad: (2_500n * WAD).toString(),
+    staticsUsdWad: (WAD / 100n).toString(),
+  },
+  supply: {
+    total: (1_000_000_000n * WAD).toString(),
+    poolInventory: (100_000_000n * WAD).toString(),
+    publicDistributed: (700_000_000n * WAD).toString(),
+    unreleasedTreasury: (100_100_000n * WAD).toString(),
+    vaultBacking: (117_900_000n * WAD).toString(),
+    strictLiquidFloat: (682_000_000n * WAD).toString(),
+  },
+  valuation: {
+    fdvUsdWad: (10_000_000n * WAD).toString(),
+    publicMarketCapUsdWad: (7_000_000n * WAD).toString(),
+    liquidFloatMarketCapUsdWad: (6_820_000n * WAD).toString(),
+  },
+  liquidity: {
+    principalWeth: (400n * WAD).toString(),
+    principalStatics: (100_000_000n * WAD).toString(),
+    tvlUsdWad: (2_000_000n * WAD).toString(),
+  },
+  activity24h: {
+    available: true,
+    wethVolume: (40n * WAD).toString(),
+    staticsVolume: (10_000_000n * WAD).toString(),
+    swaps: 12,
+    buys: 7,
+    sells: 5,
+    priceChangeBps: 125,
+    highWethPerStaticsWad: 5_000_000_000_000n.toString(),
+    lowWethPerStaticsWad: 3_000_000_000_000n.toString(),
+    lastWethPerStaticsWad: 4_000_000_000_000n.toString(),
+    lastTradeAt: "2026-09-01T11:59:50.000Z",
+  },
+  depth: null,
+  freshness: {
+    indexedAt: "2026-09-01T11:59:50.000Z",
+    snapshotAt: "2026-09-01T12:00:00.000Z",
+    depthAt: null,
+    usdPriceAt: "2026-09-01T12:00:00.000Z",
+    usdPriceStale: false,
+  },
+} satisfies StaticsMarketOverview;
+
+beforeEach(() => {
+  resetCoinGeckoMarketCacheForTest();
+  mocks.loadSpot.mockReset().mockResolvedValue(overview);
+  mocks.loadSupply.mockReset();
+  mocks.simulateContract.mockReset().mockImplementation(({ args }) =>
+    Promise.resolve({
+      result: [args[0].zeroForOne ? 2_500n * WAD : (98n * WAD) / 10_000n],
+    })
+  );
+  vi.restoreAllMocks();
+});
+
+describe("CoinGecko market server adapter", () => {
+  it("coalesces ticker reads and performs only two executable quote calls per cache fill", async () => {
+    const first = await loadCoinGeckoTickers(1_000);
+    const second = await loadCoinGeckoTickers(2_000);
+    expect(first).toEqual(second);
+    expect(first[0]).toMatchObject({ bid: "0.00000392", ask: "0.000004" });
+    expect(mocks.loadSpot).toHaveBeenCalledTimes(1);
+    expect(mocks.simulateContract).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a bounded last-good ticker when a refresh dependency fails", async () => {
+    const first = await loadCoinGeckoTickers(1_000);
+    mocks.loadSpot.mockRejectedValue(new Error("Indexer unavailable"));
+    await expect(loadCoinGeckoTickers(62_000)).resolves.toEqual(first);
+    await expect(loadCoinGeckoTickers(302_000)).rejects.toThrow("Indexer unavailable");
+  });
+
+  it("loads filtered canonical trades without exposing the authenticated market API", async () => {
+    const market = coinGeckoSpotMarket();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              poolId: market.poolId,
+              amount0: (8n * 10n ** 12n).toString(),
+              amount1: (-2n * WAD).toString(),
+              volume0: (8n * 10n ** 12n).toString(),
+              volume1: (2n * WAD).toString(),
+              price1Per0Wad: (250_000n * WAD).toString(),
+              transactionHash: `0x${"34".repeat(32)}`,
+              blockNumber: "123",
+              blockTimestamp: "1788278400",
+              logIndex: 7,
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    const result = await loadCoinGeckoHistoricalTrades({
+      limit: 500,
+      from: "10",
+      to: "20",
+      side: "buy",
+    });
+    expect(result.buy[0]).toMatchObject({ type: "buy", price: "0.000004" });
+    const requested = new URL(String(vi.mocked(fetch).mock.calls[0]?.[0]));
+    expect(requested.pathname).toBe("/market/trades");
+    expect(Object.fromEntries(requested.searchParams)).toEqual({
+      limit: "500",
+      from: "10",
+      to: "20",
+      amount0Sign: "positive",
+    });
+  });
+});

--- a/test/server/market-overview.test.ts
+++ b/test/server/market-overview.test.ts
@@ -28,11 +28,12 @@ vi.mock("@/lib/server/robinhood-rpc", () => ({
   robinhoodRpcUrl: () => "https://rpc.example",
 }));
 vi.mock("@/lib/server/statics-indexer-url", () => ({
-  staticsMainnetIndexerUrl: () => new URL("https://indexer.example/market/candles"),
+  staticsMainnetIndexerUrl: (path: string) => new URL(`https://indexer.example/${path}`),
 }));
 
 import {
   loadMarketOverview,
+  loadMarketSpotOverview,
   loadMarketSupplySnapshot,
   resetMarketOverviewCacheForTest,
 } from "@/lib/server/market-overview";
@@ -61,10 +62,29 @@ beforeEach(() => {
   mocks.simulateContract.mockReset().mockRejectedValue(new Error("Quoter unavailable"));
   mocks.loadEthUsd.mockReset().mockResolvedValue(null);
   vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(JSON.stringify({ items: [] }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    })
+    new Response(
+      JSON.stringify({
+        deploymentId: "robinhood-genesis",
+        from: "1",
+        to: "2",
+        volume0: (10_000_000n * WAD).toString(),
+        volume1: (40n * WAD).toString(),
+        swapCount: 12,
+        zeroForOneCount: 5,
+        oneForZeroCount: 7,
+        openPrice1Per0Wad: (250_000n * WAD).toString(),
+        highPrice1Per0Wad: (333_333n * WAD).toString(),
+        lowPrice1Per0Wad: (200_000n * WAD).toString(),
+        closePrice1Per0Wad: (222_222n * WAD).toString(),
+        lastBlock: "122",
+        lastTimestamp: "1788263990",
+        lastLogIndex: 3,
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    )
   );
 });
 
@@ -94,5 +114,21 @@ describe("shared market fundamentals", () => {
     await expect(loadMarketSupplySnapshot(NOW + 30 * 60_000 + 1)).rejects.toThrow(
       "RPC unavailable"
     );
+  });
+
+  it("loads exact indexed activity without running executable depth quotes", async () => {
+    const overview = await loadMarketSpotOverview(NOW);
+    expect(overview.activity24h).toMatchObject({
+      available: true,
+      swaps: 12,
+      buys: 5,
+      sells: 7,
+      highWethPerStaticsWad: ((WAD * WAD) / (200_000n * WAD)).toString(),
+      lowWethPerStaticsWad: ((WAD * WAD) / (333_333n * WAD)).toString(),
+      lastWethPerStaticsWad: ((WAD * WAD) / (222_222n * WAD)).toString(),
+      lastTradeAt: "2026-09-01T11:59:50.000Z",
+    });
+    expect(mocks.simulateContract).not.toHaveBeenCalled();
+    expect(String(vi.mocked(fetch).mock.calls[0]?.[0])).toContain("/market/activity?");
   });
 });

--- a/test/server/market-overview.test.ts
+++ b/test/server/market-overview.test.ts
@@ -65,8 +65,8 @@ beforeEach(() => {
     new Response(
       JSON.stringify({
         deploymentId: "robinhood-genesis",
-        from: "1",
-        to: "2",
+        from: String(NOW / 1_000 - 24 * 60 * 60),
+        to: String(NOW / 1_000),
         volume0: (10_000_000n * WAD).toString(),
         volume1: (40n * WAD).toString(),
         swapCount: 12,
@@ -130,5 +130,39 @@ describe("shared market fundamentals", () => {
     });
     expect(mocks.simulateContract).not.toHaveBeenCalled();
     expect(String(vi.mocked(fetch).mock.calls[0]?.[0])).toContain("/market/activity?");
+  });
+
+  it("distinguishes a valid quiet market from an unavailable indexer", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          deploymentId: "robinhood-genesis",
+          from: String(NOW / 1_000 - 24 * 60 * 60),
+          to: String(NOW / 1_000),
+          volume0: "0",
+          volume1: "0",
+          swapCount: 0,
+          zeroForOneCount: 0,
+          oneForZeroCount: 0,
+          openPrice1Per0Wad: null,
+          highPrice1Per0Wad: null,
+          lowPrice1Per0Wad: null,
+          closePrice1Per0Wad: null,
+          lastBlock: null,
+          lastTimestamp: null,
+          lastLogIndex: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    await expect(loadMarketSpotOverview(NOW)).resolves.toMatchObject({
+      activity24h: {
+        available: true,
+        swaps: 0,
+        highWethPerStaticsWad: null,
+        lowWethPerStaticsWad: null,
+        lastWethPerStaticsWad: null,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- index canonical swaps with deterministic log identity, execution prices, exact rolling activity, and pool-scoped time indexes
- expose anonymous CoinGecko-compatible `/tickers`, `/historical_trades`, and `/status` routes without weakening the authenticated market API
- derive cached executable bid/ask with two block-pinned Quoter calls while keeping ticker polling out of the multi-level depth path
- show the same last price, 24-hour high/low, volume, and liquidity on Overview and Trade in English, Spanish, and Chinese

## Data behavior

- historical queries accept the canonical address-derived ticker ID, optional buy/sell and Unix-time filters, and 1-500 results
- trade IDs are safe deterministic `blockNumber * 1,000,000 + logIndex` integers
- actual inactivity returns zero volume without being treated as an indexer outage
- status lag comes from Ponder's indexed block timestamp, independently of the latest trade time

## Validation

- `npm run verify:assets`
- `npm run lint` (passes with one pre-existing warning in `.local-tools/genesis-launch-dashboard/simulator.mjs`)
- `npm run lint:css`
- tracked-file Prettier check
- `npm run typecheck`
- `npm test` (131 files, 681 tests)
- `npm --prefix ponder run typecheck`
- `npm --prefix ponder test` (5 files, 45 tests)
- `npm run build`
- project PR-readiness check from a clean validation worktree

## Stack and rollout

- depends on #68
- the Ponder schema changes require a fresh-schema staging candidate and reindex before the staging app is cut over
- production is intentionally out of scope until staging validation is complete

Closes #66 after the stack is merged.
