### PR TITLE
fix(genesis): preserve Operator discovery liveness

### DIFF
--- a/docs/adr/network-aware-genesis-launch-application.md
+++ b/docs/adr/network-aware-genesis-launch-application.md
@@ -87,18 +87,18 @@ ownership as the implicit initial state and does not expand the ERC-2309 `Consec
 
 Ponder stores circulating ownership changes plus activation, registration, fee, and reward events.
 A transfer back to the Vault removes the circulating ownership row. The next available token ID is
-derived from the bounded collection and circulating exceptions. It is authoritative only while the
-Ponder checkpoint is within 100 blocks of the RPC head, and the returned candidate is rechecked
-against `isVaultInventory(tokenId)` before acquisition. A fresh `null` response means the Vault is
-exhausted. An unavailable or stale response means inventory is syncing and must never be presented
-as exhaustion. The application does not scan all 5,555 IDs as a fallback.
+derived from the bounded collection and circulating exceptions, then rechecked against
+`isVaultInventory(tokenId)` before acquisition regardless of checkpoint lag. A `null` response means
+the Vault is exhausted only when the checkpoint is at the RPC head; otherwise inventory is syncing.
+The application does not scan all 5,555 IDs as a fallback.
 
-Wallet discovery starts from Ponder's ownership snapshot. When its checkpoint is healthy enough to
-reconcile, the application requests `Transfer` logs once for at most the next 50,000 blocks and then
-rechecks every resulting candidate with `ownerOf`. If the checkpoint is unavailable, is ahead of the
-RPC, or trails by more than 50,000 blocks, the indexed snapshot remains visible but is marked stale;
-the application does not replay the collection's full history. A stale empty snapshot is presented
-as syncing rather than as proof that the wallet owns no Operators.
+Wallet discovery starts from Ponder's ownership snapshot. When the checkpoint trails by no more than
+50,000 blocks, the application reconciles `Transfer` logs in sequential 5,000-block requests and then
+rechecks every resulting candidate with `ownerOf`. Any lag marks the snapshot stale. If the checkpoint
+is unavailable, is ahead of the RPC, or trails by more than the reconciliation bound, the indexed
+snapshot remains visible but is marked stale; the application never replays the collection's full
+history. A stale empty snapshot is presented as syncing rather than as proof that the wallet owns no
+Operators.
 
 ### Local fork
 

--- a/lib/genesis/discovery.ts
+++ b/lib/genesis/discovery.ts
@@ -11,10 +11,8 @@ import {
 } from "@/lib/indexer/statics";
 import type { IndexedLaunchGenesis } from "@/lib/indexer/statics";
 
-const GENESIS_SUPPLY = 5_555n;
-const DISCOVERY_BATCH = 64n;
-const DISCOVERY_LOG_CHUNK = 50_000n;
-const MAX_INDEXER_BLOCK_LAG = 100n;
+const DISCOVERY_LOG_CHUNK = 5_000n;
+export const MAX_GENESIS_RECONCILIATION_BLOCKS = 50_000n;
 
 const genesisTransferEvent = staticsGenesisAbi.find(
   (entry) => entry.type === "event" && entry.name === "Transfer"
@@ -28,6 +26,9 @@ async function loadIncomingGenesisIds(
   latestBlock: bigint
 ): Promise<bigint[]> {
   if (fromBlock > latestBlock) return [];
+  if (latestBlock - fromBlock + 1n > MAX_GENESIS_RECONCILIATION_BLOCKS) {
+    throw new Error("The Operator reconciliation range exceeds its browser RPC bound.");
+  }
   const ids = new Set<string>();
   for (let start = fromBlock; start <= latestBlock; start += DISCOVERY_LOG_CHUNK) {
     const end = start + DISCOVERY_LOG_CHUNK - 1n;
@@ -50,51 +51,33 @@ export async function discoverNextAvailableGenesisId(
   deployment: LaunchDeployment
 ): Promise<bigint | null> {
   const indexerUrl = configuredIndexerUrlForDeployment(deployment.descriptor.deploymentId);
-  if (indexerUrl) {
-    try {
-      const indexed = await loadNextAvailableGenesisId(
-        deployment.descriptor.deploymentId,
-        indexerUrl
-      );
-      // A null or stale indexer response must never make the UI claim that the
-      // vault is exhausted. Verify the candidate and fall through to the
-      // authoritative scan when the snapshot cannot prove availability.
-      if (
-        indexed !== null &&
-        (await publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "isVaultInventory",
-          args: [indexed],
-        }))
-      ) {
-        return indexed;
-      }
-    } catch {
-      // A degraded indexer is a discovery optimization only. The onchain scan
-      // below remains the correctness fallback.
+  if (!indexerUrl) throw new Error("Operator inventory indexing is unavailable.");
+  const [indexed, checkpoint, chainHead] = await Promise.all([
+    loadNextAvailableGenesisId(deployment.descriptor.deploymentId, indexerUrl),
+    loadIndexerCheckpoint(
+      deployment.descriptor.chainId,
+      deployment.descriptor.deploymentId,
+      indexerUrl
+    ),
+    publicClient.getBlockNumber(),
+  ]);
+  if (checkpoint.blockNumber > chainHead) {
+    throw new Error("Operator inventory data is still syncing.");
+  }
+  if (indexed === null) {
+    if (checkpoint.blockNumber < chainHead) {
+      throw new Error("Operator inventory data is still syncing.");
     }
+    return null;
   }
-  for (let start = 1n; start <= GENESIS_SUPPLY; start += DISCOVERY_BATCH) {
-    const end = start + DISCOVERY_BATCH - 1n;
-    const ids = Array.from(
-      { length: Number((end < GENESIS_SUPPLY ? end : GENESIS_SUPPLY) - start + 1n) },
-      (_, index) => start + BigInt(index)
-    );
-    const results = await Promise.all(
-      ids.map((id) =>
-        publicClient.readContract({
-          address: deployment.contracts.vault,
-          abi: staticsGenesisVaultAbi,
-          functionName: "isVaultInventory",
-          args: [id],
-        })
-      )
-    );
-    const availableIndex = results.findIndex(Boolean);
-    if (availableIndex >= 0) return ids[availableIndex]!;
-  }
-  return null;
+  const available = await publicClient.readContract({
+    address: deployment.contracts.vault,
+    abi: staticsGenesisVaultAbi,
+    functionName: "isVaultInventory",
+    args: [indexed],
+  });
+  if (!available) throw new Error("The indexed Operator inventory changed. Try again shortly.");
+  return indexed;
 }
 
 export type GenesisDiscoverySnapshot = Readonly<{
@@ -115,75 +98,67 @@ export async function discoverWalletGenesisSnapshot(
   deployment: LaunchDeployment,
   owner: Address
 ): Promise<GenesisDiscoverySnapshot> {
-  let ids: bigint[] | null = null;
-  let indexed: readonly IndexedLaunchGenesis[] = [];
+  let recentIds: readonly bigint[] = [];
   let indexedBlock: bigint | null = null;
-  let chainHead: bigint | null = null;
-  let stale = false;
   const indexerUrl = configuredIndexerUrlForDeployment(deployment.descriptor.deploymentId);
-  if (indexerUrl) {
-    try {
-      const checkpoint = await loadIndexerCheckpoint(
-        deployment.descriptor.chainId,
-        deployment.descriptor.deploymentId,
-        indexerUrl
-      );
-      chainHead = await publicClient.getBlockNumber();
-      indexedBlock = checkpoint.blockNumber;
-      stale =
-        checkpoint.blockNumber > chainHead ||
-        chainHead - checkpoint.blockNumber > MAX_INDEXER_BLOCK_LAG;
-      if (stale) throw new Error("The Statics indexer is too far behind the selected chain.");
-      const [indexedItems, recentIds] = await Promise.all([
-        loadWalletLaunchGenesisItems(owner, deployment.descriptor.deploymentId, indexerUrl),
-        loadIncomingGenesisIds(
-          publicClient,
-          deployment,
-          owner,
-          checkpoint.blockNumber + 1n,
-          chainHead
-        ),
-      ]);
-      indexed = indexedItems;
-      ids = [...new Set([...indexedItems.map((item) => item.id), ...recentIds].map(String))].map(
-        BigInt
-      );
-    } catch {
-      // An unavailable, invalid, or stale indexer falls through to chain history.
-      if (!stale) {
-        // The onchain fallback is authoritative when the indexer failed for a
-        // reason other than freshness. Do not retain partial indexer metadata
-        // or report that authoritative result as stale.
-        indexed = [];
-        indexedBlock = null;
+  if (!indexerUrl) throw new Error("Operator ownership indexing is unavailable.");
+
+  const [indexedResult, checkpointResult, chainHeadResult] = await Promise.allSettled([
+    loadWalletLaunchGenesisItems(owner, deployment.descriptor.deploymentId, indexerUrl),
+    loadIndexerCheckpoint(
+      deployment.descriptor.chainId,
+      deployment.descriptor.deploymentId,
+      indexerUrl
+    ),
+    publicClient.getBlockNumber(),
+  ]);
+  if (indexedResult.status === "rejected") throw indexedResult.reason;
+  if (chainHeadResult.status === "rejected") throw chainHeadResult.reason;
+
+  const indexed = indexedResult.value;
+  const chainHead = chainHeadResult.value;
+  let stale = checkpointResult.status === "rejected";
+  if (checkpointResult.status === "fulfilled") {
+    const checkpoint = checkpointResult.value;
+    indexedBlock = checkpoint.blockNumber;
+    if (checkpoint.blockNumber > chainHead) {
+      stale = true;
+    } else {
+      const lag = chainHead - checkpoint.blockNumber;
+      stale = lag > 0n;
+      if (lag > 0n && lag <= MAX_GENESIS_RECONCILIATION_BLOCKS) {
+        try {
+          recentIds = await loadIncomingGenesisIds(
+            publicClient,
+            deployment,
+            owner,
+            checkpoint.blockNumber + 1n,
+            chainHead
+          );
+        } catch {
+          // Keep the last indexed snapshot visible. The stale marker tells the
+          // UI it may not include transfers that occurred after the checkpoint.
+          stale = true;
+        }
       }
     }
   }
-  if (ids === null) {
-    chainHead ??= await publicClient.getBlockNumber();
-    ids = await loadIncomingGenesisIds(
-      publicClient,
-      deployment,
-      owner,
-      deployment.deploymentStartBlock,
-      chainHead
-    );
-  }
+
+  const ids = [...new Set([...indexed.map((item) => item.id), ...recentIds].map(String))].map(
+    BigInt
+  );
   const current = await Promise.all(
     ids.map((id) =>
-      publicClient
-        .readContract({
-          address: deployment.contracts.genesis,
-          abi: staticsGenesisAbi,
-          functionName: "ownerOf",
-          args: [id],
-        })
-        .catch(() => null)
+      publicClient.readContract({
+        address: deployment.contracts.genesis,
+        abi: staticsGenesisAbi,
+        functionName: "ownerOf",
+        args: [id],
+      })
     )
   );
   const ownedIds = ids.filter(
-    (_, index) =>
-      current[index] !== null && String(current[index]).toLowerCase() === owner.toLowerCase()
+    (_, index) => String(current[index]).toLowerCase() === owner.toLowerCase()
   );
   const ownedSet = new Set(ownedIds.map(String));
   return {

--- a/ponder/README.md
+++ b/ponder/README.md
@@ -33,13 +33,13 @@ reserved `/health`, `/ready`, and `/status` endpoints. Vault ownership is the im
 the indexer does not materialize 5,555 identical rows. The application treats an unavailable or
 lagging indexer as degraded discovery only; transaction state is always re-read onchain. Operator
 wallet discovery reads `/status` as a checkpoint and reconciles no more than 50,000 subsequent
-blocks with one `eth_getLogs` request before checking current `ownerOf` state. Larger gaps retain the
-indexed snapshot as stale instead of replaying deployment history. The trade card accepts next
-inventory only from a checkpoint no more than 100 blocks behind the RPC head and withholds cached
-inventory while that authoritative read is refreshing.
+blocks in sequential 5,000-block `eth_getLogs` requests before checking current `ownerOf` state.
+Larger gaps retain the indexed snapshot as stale instead of replaying deployment history. The trade
+card rechecks every indexed inventory candidate onchain regardless of checkpoint lag, and accepts an
+indexed exhausted state only when the checkpoint is at the RPC head.
 
-Robinhood mainnet polls every two seconds. This keeps ordinary indexer lag inside the application's
-100-block freshness boundary while halving the fixed provider cost of Ponder's latest-block poll.
+Robinhood mainnet polls every two seconds. This keeps ordinary indexer lag within the application's
+bounded recent-reconciliation path while halving the fixed provider cost of Ponder's latest-block poll.
 The `/market/candles` route accepts `1`, `5`, `15`, `60`, `240`, and `1440` minute resolutions and
 an ordered Unix-second range of at most 31 days. It aggregates larger resolutions from reorg-safe
 one-minute rows and never scans historical RPC logs in response to an API request.
@@ -52,6 +52,6 @@ applications and API keys. They must also use separate Nginx rate-limit zones: b
 `/status`. Preserve an upstream `Retry-After` header through both proxy layers.
 
 Alert on sustained provider `429` or proxy `502` responses, an unhealthy `/ready` response, and a
-checkpoint that remains more than 100 blocks behind its configured chain. Logs and alerts may
-include status, chain ID, method names, batch size, and duration, but must not include RPC URLs,
-credentials, calldata, wallet addresses, or complete request bodies.
+checkpoint that remains outside the 50,000-block recent-reconciliation window or whose lag keeps
+growing. Logs and alerts may include status, chain ID, method names, batch size, and duration, but
+must not include RPC URLs, credentials, calldata, wallet addresses, or complete request bodies.

--- a/test/genesis/discovery.test.ts
+++ b/test/genesis/discovery.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { LaunchDeployment } from "@/lib/deployments/types";
 import {
+  MAX_GENESIS_RECONCILIATION_BLOCKS,
   discoverNextAvailableGenesisId,
   discoverWalletGenesisIds,
   discoverWalletGenesisSnapshot,
@@ -53,48 +54,133 @@ const deployment = {
   },
 } as const satisfies LaunchDeployment;
 
+function indexedResponses({
+  checkpoint = 10,
+  items = [],
+  next = "16",
+}: {
+  checkpoint?: number;
+  items?: readonly Record<string, unknown>[];
+  next?: string | null;
+} = {}) {
+  return vi.fn().mockImplementation(async (input: string | URL) => {
+    const url = String(input);
+    if (url.endsWith("/status")) {
+      return new Response(
+        JSON.stringify({ active: { id: 31_337, block: { number: checkpoint, timestamp: 100 } } })
+      );
+    }
+    if (url.endsWith("/genesis/next-available")) {
+      return new Response(JSON.stringify({ deploymentId, tokenId: next }));
+    }
+    if (url.includes(`/wallets/${owner}/genesis`)) {
+      return new Response(JSON.stringify({ deploymentId, items, nextCursor: null }));
+    }
+    throw new Error(`Unexpected indexer URL ${url}`);
+  });
+}
+
+function incomingTransfer(tokenId: bigint) {
+  return {
+    address: genesis,
+    data: "0x" as const,
+    topics: encodeEventTopics({
+      abi: [
+        {
+          type: "event",
+          name: "Transfer",
+          inputs: [
+            { indexed: true, name: "from", type: "address" },
+            { indexed: true, name: "to", type: "address" },
+            { indexed: true, name: "tokenId", type: "uint256" },
+          ],
+        },
+      ],
+      eventName: "Transfer",
+      args: { from: vault, to: owner, tokenId },
+    }),
+  };
+}
+
 describe("Genesis discovery", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 
-  it("finds the lowest available Operator directly from the Vault", async () => {
+  it("accepts an indexed inventory candidate at any lag after a current Vault check", async () => {
     vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
-    const readContract = vi.fn().mockImplementation(async ({ args }) => args[0] === 16n);
-    const publicClient = { readContract } as unknown as PublicClient;
+    vi.stubGlobal("fetch", indexedResponses({ checkpoint: 10 }));
+    const readContract = vi.fn().mockResolvedValue(true);
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(50_010n),
+      readContract,
+    } as unknown as PublicClient;
 
     await expect(discoverNextAvailableGenesisId(publicClient, deployment)).resolves.toBe(16n);
-    expect(readContract).toHaveBeenCalledTimes(64);
+    expect(readContract).toHaveBeenCalledTimes(1);
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "isVaultInventory", args: [16n] })
+    );
   });
 
-  it("does not treat a failed Vault read as unavailable inventory", async () => {
-    const readContract = vi.fn().mockImplementation(async ({ args }) => {
-      if (args[0] === 8n) throw new Error("RPC unavailable");
-      return args[0] === 16n;
-    });
-    const publicClient = { readContract } as unknown as PublicClient;
+  it("accepts indexed exhaustion only at the current chain head", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal("fetch", indexedResponses({ checkpoint: 10, next: null }));
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(10n),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+
+    await expect(discoverNextAvailableGenesisId(publicClient, deployment)).resolves.toBeNull();
+    expect(publicClient.readContract).not.toHaveBeenCalled();
+  });
+
+  it("reports syncing for stale indexed exhaustion without scanning Vault inventory", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal("fetch", indexedResponses({ checkpoint: 10, next: null }));
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(11n),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
 
     await expect(discoverNextAvailableGenesisId(publicClient, deployment)).rejects.toThrow(
-      "RPC unavailable"
+      "inventory data is still syncing"
     );
+    expect(publicClient.readContract).not.toHaveBeenCalled();
   });
 
-  it("does not replay history when an empty wallet snapshot is at chain head", async () => {
+  it("does not scan Vault inventory after an indexed candidate changes", async () => {
     vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({ active: { id: 31_337, block: { number: 10, timestamp: 100 } } })
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ deploymentId, items: [], nextCursor: null }))
-        )
+    vi.stubGlobal("fetch", indexedResponses());
+    const readContract = vi.fn().mockResolvedValue(false);
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(10n),
+      readContract,
+    } as unknown as PublicClient;
+
+    await expect(discoverNextAvailableGenesisId(publicClient, deployment)).rejects.toThrow(
+      "indexed Operator inventory changed"
     );
+    expect(readContract).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scan Vault inventory without an indexer", async () => {
+    const publicClient = {
+      getBlockNumber: vi.fn(),
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+
+    await expect(discoverNextAvailableGenesisId(publicClient, deployment)).rejects.toThrow(
+      "inventory indexing is unavailable"
+    );
+    expect(publicClient.getBlockNumber).not.toHaveBeenCalled();
+    expect(publicClient.readContract).not.toHaveBeenCalled();
+  });
+
+  it("does not request logs when an empty wallet snapshot is at chain head", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal("fetch", indexedResponses());
     const getLogs = vi.fn();
     const publicClient = {
       getBlockNumber: vi.fn().mockResolvedValue(10n),
@@ -102,126 +188,184 @@ describe("Genesis discovery", () => {
       readContract: vi.fn(),
     } as unknown as PublicClient;
 
-    await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).resolves.toEqual([]);
+    await expect(discoverWalletGenesisSnapshot(publicClient, deployment, owner)).resolves.toEqual({
+      ids: [],
+      indexed: [],
+      indexedBlock: 10n,
+      chainHead: 10n,
+      stale: false,
+    });
     expect(getLogs).not.toHaveBeenCalled();
   });
 
-  it("merges transfers after a healthy checkpoint before verifying ownership", async () => {
+  it("reconciles an 11,000-block lag in small provider-safe chunks", async () => {
     vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
     vi.stubGlobal(
       "fetch",
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({ active: { id: 31_337, block: { number: 10, timestamp: 100 } } })
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ deploymentId, items: [{ id: "7" }], nextCursor: null }))
-        )
+      indexedResponses({ checkpoint: 10, items: [{ id: "7", updatedAtBlock: "10" }] })
     );
-    const getLogs = vi.fn().mockResolvedValue([
-      {
-        address: genesis,
-        data: "0x",
-        topics: encodeEventTopics({
-          abi: [
-            {
-              type: "event",
-              name: "Transfer",
-              inputs: [
-                { indexed: true, name: "from", type: "address" },
-                { indexed: true, name: "to", type: "address" },
-                { indexed: true, name: "tokenId", type: "uint256" },
-              ],
-            },
-          ],
-          eventName: "Transfer",
-          args: { from: vault, to: owner, tokenId: 16n },
-        }),
-      },
-    ]);
+    const getLogs = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([incomingTransfer(16n)]);
     const readContract = vi.fn().mockResolvedValue(owner);
     const publicClient = {
-      getBlockNumber: vi.fn().mockResolvedValue(12n),
+      getBlockNumber: vi.fn().mockResolvedValue(11_010n),
       getLogs,
       readContract,
-    } as unknown as PublicClient;
-
-    await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).resolves.toEqual([
-      7n,
-      16n,
-    ]);
-    expect(readContract).toHaveBeenCalledTimes(2);
-    expect(getLogs).toHaveBeenCalledWith(expect.objectContaining({ fromBlock: 11n, toBlock: 12n }));
-  });
-
-  it("rejects a stale checkpoint and rebuilds wallet ownership from chain history", async () => {
-    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValue(
-          new Response(
-            JSON.stringify({ active: { id: 31_337, block: { number: 10, timestamp: 100 } } })
-          )
-        )
-    );
-    const getLogs = vi.fn().mockResolvedValue([]);
-    const publicClient = {
-      getBlockNumber: vi.fn().mockResolvedValue(111n),
-      getLogs,
-      readContract: vi.fn(),
-    } as unknown as PublicClient;
-
-    await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).resolves.toEqual([]);
-    expect(getLogs).toHaveBeenCalledWith(
-      expect.objectContaining({ fromBlock: deployment.deploymentStartBlock, toBlock: 111n })
-    );
-  });
-
-  it("does not mark an onchain fallback stale after an indexer failure", async () => {
-    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("indexer unavailable")));
-    const getLogs = vi.fn().mockResolvedValue([]);
-    const publicClient = {
-      getBlockNumber: vi.fn().mockResolvedValue(10n),
-      getLogs,
-      readContract: vi.fn(),
     } as unknown as PublicClient;
 
     await expect(
       discoverWalletGenesisSnapshot(publicClient, deployment, owner)
     ).resolves.toMatchObject({
-      ids: [],
-      indexed: [],
-      indexedBlock: null,
-      chainHead: 10n,
-      stale: false,
+      ids: [7n, 16n],
+      indexedBlock: 10n,
+      chainHead: 11_010n,
+      stale: true,
     });
-    expect(getLogs).toHaveBeenCalledWith(
-      expect.objectContaining({ fromBlock: deployment.deploymentStartBlock, toBlock: 10n })
+    expect(getLogs).toHaveBeenCalledTimes(3);
+    expect(getLogs).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fromBlock: 11n, toBlock: 5_010n })
+    );
+    expect(getLogs).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fromBlock: 5_011n, toBlock: 10_010n })
+    );
+    expect(getLogs).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ fromBlock: 10_011n, toBlock: 11_010n })
     );
   });
 
-  it("chunks the onchain ownership fallback for RPC providers with bounded log ranges", async () => {
+  it("allows exactly 50,000 blocks of bounded recent reconciliation", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal("fetch", indexedResponses({ checkpoint: 10 }));
     const getLogs = vi.fn().mockResolvedValue([]);
     const publicClient = {
-      getBlockNumber: vi.fn().mockResolvedValue(50_002n),
+      getBlockNumber: vi.fn().mockResolvedValue(10n + MAX_GENESIS_RECONCILIATION_BLOCKS),
       getLogs,
       readContract: vi.fn(),
     } as unknown as PublicClient;
 
     await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).resolves.toEqual([]);
+    expect(getLogs).toHaveBeenCalledTimes(10);
     expect(getLogs).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ fromBlock: 1n, toBlock: 50_000n })
+      expect.objectContaining({ fromBlock: 11n, toBlock: 5_010n })
     );
     expect(getLogs).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ fromBlock: 50_001n, toBlock: 50_002n })
+      10,
+      expect.objectContaining({ fromBlock: 45_011n, toBlock: 50_010n })
     );
+  });
+
+  it("uses stale indexed holdings without replay beyond the reconciliation bound", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal(
+      "fetch",
+      indexedResponses({ checkpoint: 10, items: [{ id: "7", updatedAtBlock: "10" }] })
+    );
+    const getLogs = vi.fn();
+    const readContract = vi.fn().mockResolvedValue(owner);
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(10n + MAX_GENESIS_RECONCILIATION_BLOCKS + 1n),
+      getLogs,
+      readContract,
+    } as unknown as PublicClient;
+
+    await expect(
+      discoverWalletGenesisSnapshot(publicClient, deployment, owner)
+    ).resolves.toMatchObject({
+      ids: [7n],
+      indexedBlock: 10n,
+      stale: true,
+    });
+    expect(getLogs).not.toHaveBeenCalled();
+    expect(readContract).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps indexed holdings visible when the checkpoint request fails", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (input: string | URL) => {
+        const url = String(input);
+        if (url.endsWith("/status")) throw new Error("indexer status unavailable");
+        if (url.includes(`/wallets/${owner}/genesis`)) {
+          return new Response(
+            JSON.stringify({
+              deploymentId,
+              items: [{ id: "7", updatedAtBlock: "10" }],
+              nextCursor: null,
+            })
+          );
+        }
+        throw new Error(`Unexpected indexer URL ${url}`);
+      })
+    );
+    const getLogs = vi.fn();
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(20n),
+      getLogs,
+      readContract: vi.fn().mockResolvedValue(owner),
+    } as unknown as PublicClient;
+
+    await expect(
+      discoverWalletGenesisSnapshot(publicClient, deployment, owner)
+    ).resolves.toMatchObject({ ids: [7n], indexedBlock: null, chainHead: 20n, stale: true });
+    expect(getLogs).not.toHaveBeenCalled();
+  });
+
+  it("keeps the indexed snapshot when recent log reconciliation fails", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal(
+      "fetch",
+      indexedResponses({ checkpoint: 10, items: [{ id: "7", updatedAtBlock: "10" }] })
+    );
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(12n),
+      getLogs: vi.fn().mockRejectedValue(new Error("RPC unavailable")),
+      readContract: vi.fn().mockResolvedValue(owner),
+    } as unknown as PublicClient;
+
+    await expect(
+      discoverWalletGenesisSnapshot(publicClient, deployment, owner)
+    ).resolves.toMatchObject({ ids: [7n], stale: true });
+  });
+
+  it("fails instead of presenting an empty wallet when ownership cannot be revalidated", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STATICS_LOCAL_INDEXER_URL", "https://indexer.example");
+    vi.stubGlobal(
+      "fetch",
+      indexedResponses({ checkpoint: 10, items: [{ id: "7", updatedAtBlock: "10" }] })
+    );
+    const getLogs = vi.fn();
+    const publicClient = {
+      getBlockNumber: vi.fn().mockResolvedValue(10n),
+      getLogs,
+      readContract: vi.fn().mockRejectedValue(new Error("RPC unavailable")),
+    } as unknown as PublicClient;
+
+    await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).rejects.toThrow(
+      "RPC unavailable"
+    );
+    expect(getLogs).not.toHaveBeenCalled();
+  });
+
+  it("requires an indexer instead of replaying from the deployment block", async () => {
+    const getLogs = vi.fn();
+    const publicClient = {
+      getBlockNumber: vi.fn(),
+      getLogs,
+      readContract: vi.fn(),
+    } as unknown as PublicClient;
+
+    await expect(discoverWalletGenesisIds(publicClient, deployment, owner)).rejects.toThrow(
+      "ownership indexing is unavailable"
+    );
+    expect(publicClient.getBlockNumber).not.toHaveBeenCalled();
+    expect(getLogs).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- remove the 100-block freshness cutoff that triggered deployment-history RPC replay
- keep stale indexed Operator holdings visible and reconcile only the next 50,000 blocks
- split reconciliation into sequential 5,000-block requests and keep current onchain ownership checks
- never scan all 5,555 IDs or replay from the deployment block when Ponder is behind

## Production incident

The Operators page rejected Ponder once it was more than 100 blocks behind, then issued 50,000-block `eth_getLogs` calls from deployment history. The production RPC timed out on those batched calls. This restores the liveness-safe indexed path while retaining current `ownerOf` / `isVaultInventory` verification.

## Validation

- `npx vitest run test/genesis/discovery.test.ts` — 13 passed
- related Genesis/indexer/component suite — 62 passed
- `npm run typecheck` — passed
- full Vitest suite — 688 passed
- production build — passed
- live same-origin RPC probe: two 5,000-block matching log ranges returned HTTP 200 in 6.0s
- broad Playwright suite: 43 passed, 5 skipped, 9 unrelated stale assertions failed consistently across all three viewports (unconfigured deployment and updated basket heading copy)
