### PR TITLE
fix(genesis): accept reconciled indexer lag

### DIFF
--- a/docs/adr/network-aware-genesis-launch-application.md
+++ b/docs/adr/network-aware-genesis-launch-application.md
@@ -94,11 +94,11 @@ The application does not scan all 5,555 IDs as a fallback.
 
 Wallet discovery starts from Ponder's ownership snapshot. When the checkpoint trails by no more than
 50,000 blocks, the application reconciles `Transfer` logs in sequential 5,000-block requests and then
-rechecks every resulting candidate with `ownerOf`. Any lag marks the snapshot stale. If the checkpoint
-is unavailable, is ahead of the RPC, or trails by more than the reconciliation bound, the indexed
-snapshot remains visible but is marked stale; the application never replays the collection's full
-history. A stale empty snapshot is presented as syncing rather than as proof that the wallet owns no
-Operators.
+rechecks every resulting candidate with `ownerOf`. A successful reconciliation makes that snapshot
+current at the observed RPC head. If the checkpoint is unavailable, is ahead of the RPC, trails by
+more than the reconciliation bound, or reconciliation fails, the indexed snapshot remains visible but
+is marked stale; the application never replays the collection's full history. A stale empty snapshot
+is presented as syncing rather than as proof that the wallet owns no Operators.
 
 ### Local fork
 

--- a/lib/genesis/discovery.ts
+++ b/lib/genesis/discovery.ts
@@ -125,7 +125,7 @@ export async function discoverWalletGenesisSnapshot(
       stale = true;
     } else {
       const lag = chainHead - checkpoint.blockNumber;
-      stale = lag > 0n;
+      stale = lag > MAX_GENESIS_RECONCILIATION_BLOCKS;
       if (lag > 0n && lag <= MAX_GENESIS_RECONCILIATION_BLOCKS) {
         try {
           recentIds = await loadIncomingGenesisIds(
@@ -135,6 +135,7 @@ export async function discoverWalletGenesisSnapshot(
             checkpoint.blockNumber + 1n,
             chainHead
           );
+          stale = false;
         } catch {
           // Keep the last indexed snapshot visible. The stale marker tells the
           // UI it may not include transfers that occurred after the checkpoint.

--- a/test/genesis/discovery.test.ts
+++ b/test/genesis/discovery.test.ts
@@ -222,7 +222,7 @@ describe("Genesis discovery", () => {
       ids: [7n, 16n],
       indexedBlock: 10n,
       chainHead: 11_010n,
-      stale: true,
+      stale: false,
     });
     expect(getLogs).toHaveBeenCalledTimes(3);
     expect(getLogs).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary
- stop marking Operator ownership stale solely because Ponder trails the RPC head
- treat successful bounded Transfer reconciliation as current
- preserve syncing state for unavailable/ahead checkpoints, excessive lag, or reconciliation failures

## Validation
- `npx vitest run test/genesis/discovery.test.ts` (13 passed)
- `npx prettier --check lib/genesis/discovery.ts test/genesis/discovery.test.ts docs/adr/network-aware-genesis-launch-application.md`
- `npx tsc --noEmit --incremental false`